### PR TITLE
feat: agent-accessible gallery — catalog, standalone preview/spec, screenshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,25 @@ INDEX.md           Cross-referenced design index
 
 When staging changes, always use `git add <specific files>` rather than `git add -A` or `git add .`. Past commits have accidentally deleted existing design files by staging unintended removals. After staging, run `git status` and verify no unexpected deletions appear.
 
+## Agent-accessible endpoints
+
+The gallery is a React SPA. For programmatic or non-JS access, use these static endpoints:
+
+| URL | Format | Contents |
+|-----|--------|----------|
+| `/catalog.json` | JSON | Structured index of all designs with URLs |
+| `/catalog.html` | HTML | Browsable plain-HTML catalog (no JS needed) |
+| `/llms.txt` | Markdown | LLM-optimized site index (llms.txt convention) |
+| `/llms-full.txt` | Markdown | All spec documents concatenated |
+| `/sitemap.xml` | XML | Standard sitemap for crawlers |
+| `/#/preview/{category}/{slug}` | SPA | Standalone mockup preview with screenshot |
+| `/#/spec/{category}/{slug}` | SPA | Standalone rendered spec document |
+| `/designs/{category}/{slug}.md` | Markdown | Raw spec file |
+| `/designs/{category}/{slug}.jsx` | JSX | Raw mockup source code |
+| `/designs/{category}/{slug}.html` | HTML | Standalone HTML mockup |
+
+All `/catalog.*`, `/llms*`, `/sitemap.xml`, and `/designs/**` URLs are static files — no JS execution needed. The `/#/preview/` and `/#/spec/` routes require the SPA but render without gallery chrome.
+
 ## Test suite
 
 Tests live in `mockup-viewer/src/App.test.jsx`. The suite includes:

--- a/mockup-viewer/index.html
+++ b/mockup-viewer/index.html
@@ -9,6 +9,10 @@
     <script src="https://cdn.tailwindcss.com"></script>
   </head>
   <body>
+    <noscript>
+      <meta http-equiv="refresh" content="0; url=catalog.html">
+      <p>This gallery requires JavaScript. <a href="catalog.html">View the static catalog</a>.</p>
+    </noscript>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/mockup-viewer/package-lock.json
+++ b/mockup-viewer/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@carbon/icons-react": "^11.77.1",
         "@carbon/react": "^1.104.1",
+        "html-to-image": "^1.11.13",
         "lucide-react": "^0.576.0",
         "marked": "^17.0.6",
         "react": "^18.2.0",
@@ -3441,6 +3442,12 @@
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
+    },
+    "node_modules/html-to-image": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/html-to-image/-/html-to-image-1.11.13.tgz",
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==",
+      "license": "MIT"
     },
     "node_modules/immer": {
       "version": "10.2.0",

--- a/mockup-viewer/package.json
+++ b/mockup-viewer/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@carbon/icons-react": "^11.77.1",
     "@carbon/react": "^1.104.1",
+    "html-to-image": "^1.11.13",
     "lucide-react": "^0.576.0",
     "marked": "^17.0.6",
     "react": "^18.2.0",

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -1066,6 +1066,33 @@ export function findMockupByHash(hash) {
   ) || null;
 }
 
+/**
+ * Parse the hash into a route object.
+ * Supports:
+ *   #/{category}/{slug}           → { mode: 'gallery', mockup }
+ *   #/preview/{category}/{slug}   → { mode: 'preview', mockup }
+ *   #/spec/{category}/{slug}      → { mode: 'spec', mockup }
+ */
+export function parseRoute(hash) {
+  const path = hash.replace(/^#\/?/, '');
+  if (!path) return { mode: 'gallery', mockup: null };
+  const parts = path.split('/');
+  if (parts[0] === 'preview' && parts.length >= 3) {
+    const cat = parts[1];
+    const slug = parts.slice(2).join('/');
+    const mockup = MOCKUP_REGISTRY.find(m => m.category === cat && toSlug(m.name) === slug) || null;
+    return { mode: 'preview', mockup };
+  }
+  if (parts[0] === 'spec' && parts.length >= 3) {
+    const cat = parts[1];
+    const slug = parts.slice(2).join('/');
+    const mockup = MOCKUP_REGISTRY.find(m => m.category === cat && toSlug(m.name) === slug) || null;
+    return { mode: 'spec', mockup };
+  }
+  const mockup = findMockupByHash(hash);
+  return { mode: 'gallery', mockup };
+}
+
 /** Build the hash string for a mockup */
 export function toHash(mockup) {
   return `#/${mockup.category}/${toSlug(mockup.name)}`;
@@ -1122,6 +1149,124 @@ function SpecViewer({ specPath }) {
       style={styles.specContent}
       dangerouslySetInnerHTML={{ __html: marked(content) }}
     />
+  );
+}
+
+// ─── Standalone Preview (full-screen mockup, no gallery chrome) ───
+
+function StandalonePreview({ mockup }) {
+  const previewRef = React.useRef(null);
+  const [capturing, setCapturing] = React.useState(false);
+
+  async function handleScreenshot() {
+    if (!previewRef.current) return;
+    setCapturing(true);
+    try {
+      const { toPng } = await import('html-to-image');
+      const dataUrl = await toPng(previewRef.current, { cacheBust: true, backgroundColor: '#ffffff' });
+      const link = document.createElement('a');
+      link.download = `${toSlug(mockup.name)}-screenshot.png`;
+      link.href = dataUrl;
+      link.click();
+    } catch (err) {
+      console.error('Screenshot failed:', err);
+      alert('Screenshot capture failed. Try using your browser\'s built-in screenshot tool.');
+    }
+    setCapturing(false);
+  }
+
+  const slug = toSlug(mockup.name);
+  const galleryUrl = `#/${mockup.category}/${slug}`;
+  const specUrl = mockup.specPath ? `#/spec/${mockup.category}/${slug}` : null;
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', background: '#fff' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.5rem 1rem', background: '#161616', color: '#f4f4f4', fontSize: '0.875rem', flexShrink: 0 }}>
+        <a href={galleryUrl} style={{ color: '#78a9ff', textDecoration: 'none' }}>← Gallery</a>
+        <span style={{ fontWeight: 600 }}>{mockup.name}</span>
+        <span style={{ color: '#6f6f6f' }}>{categoryLabels[mockup.category] || mockup.category}</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.75rem' }}>
+          {specUrl && <a href={specUrl} style={{ color: '#78a9ff', textDecoration: 'none' }}>View Spec</a>}
+          <button
+            onClick={handleScreenshot}
+            disabled={capturing}
+            style={{ background: '#0f62fe', color: '#fff', border: 'none', padding: '4px 12px', borderRadius: '4px', cursor: 'pointer', fontSize: '0.8rem' }}
+          >
+            {capturing ? 'Capturing...' : '📷 Screenshot'}
+          </button>
+        </div>
+      </div>
+      <div ref={previewRef} style={{ flex: 1, overflow: 'auto' }}>
+        {mockup.component ? (
+          <Suspense fallback={<div style={{ padding: '2rem', textAlign: 'center' }}>Loading mockup...</div>}>
+            <ErrorBoundary name={mockup.name}>
+              <mockup.component />
+            </ErrorBoundary>
+          </Suspense>
+        ) : mockup.htmlUrl ? (
+          <iframe
+            src={import.meta.env.BASE_URL + mockup.htmlUrl}
+            style={{ width: '100%', height: 'calc(100vh - 42px)', border: 'none' }}
+            title={mockup.name}
+          />
+        ) : mockup.figmaUrl ? (
+          <iframe
+            src={mockup.figmaUrl.replace('/make/', '/embed/') + '&embed-host=share'}
+            style={{ width: '100%', height: 'calc(100vh - 42px)', border: 'none' }}
+            title={mockup.name}
+          />
+        ) : (
+          <div style={{ padding: '2rem', textAlign: 'center', color: '#525252' }}>No preview available for this entry.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ─── Standalone Spec (full-page rendered markdown, no gallery chrome) ───
+
+function StandaloneSpec({ mockup }) {
+  const [content, setContent] = React.useState(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    if (!mockup.specPath) return;
+    fetch(import.meta.env.BASE_URL + mockup.specPath)
+      .then(r => r.ok ? r.text() : Promise.reject(`HTTP ${r.status}`))
+      .then(text => { setContent(text); setLoading(false); })
+      .catch(() => setLoading(false));
+  }, [mockup.specPath]);
+
+  const slug = toSlug(mockup.name);
+  const galleryUrl = `#/${mockup.category}/${slug}`;
+  const previewUrl = `#/preview/${mockup.category}/${slug}`;
+  const rawUrl = import.meta.env.BASE_URL + mockup.specPath;
+  const githubUrl = GITHUB_BASE + mockup.specPath;
+
+  return (
+    <div style={{ minHeight: '100vh', display: 'flex', flexDirection: 'column', background: '#fff' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '1rem', padding: '0.5rem 1rem', background: '#161616', color: '#f4f4f4', fontSize: '0.875rem', flexShrink: 0 }}>
+        <a href={galleryUrl} style={{ color: '#78a9ff', textDecoration: 'none' }}>← Gallery</a>
+        <span style={{ fontWeight: 600 }}>{mockup.name} — Spec</span>
+        <div style={{ marginLeft: 'auto', display: 'flex', gap: '0.75rem' }}>
+          <a href={previewUrl} style={{ color: '#78a9ff', textDecoration: 'none' }}>Preview</a>
+          <a href={rawUrl} download style={{ color: '#78a9ff', textDecoration: 'none' }}>Download MD</a>
+          <a href={githubUrl} target="_blank" rel="noopener" style={{ color: '#78a9ff', textDecoration: 'none' }}>GitHub</a>
+        </div>
+      </div>
+      <div style={{ flex: 1, maxWidth: '800px', margin: '0 auto', padding: '2rem 1rem' }}>
+        {loading ? (
+          <div style={{ textAlign: 'center', color: '#525252', padding: '2rem' }}>Loading spec...</div>
+        ) : content ? (
+          <div className="spec-content" style={styles.specContent} dangerouslySetInnerHTML={{ __html: marked(content) }} />
+        ) : (
+          <div style={{ textAlign: 'center', color: '#525252', padding: '2rem' }}>
+            <p>Could not load spec.</p>
+            <a href={githubUrl} target="_blank" rel="noopener" style={{ color: '#0f62fe' }}>View on GitHub →</a>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -1403,6 +1548,33 @@ export const themes = {
 };
 
 function App() {
+  // ─── Standalone route detection ───
+  const [routeMode, setRouteMode] = useState(() => parseRoute(window.location.hash).mode);
+  const [routeMockup, setRouteMockup] = useState(() => parseRoute(window.location.hash).mockup);
+
+  useEffect(() => {
+    function onHashChange() {
+      const route = parseRoute(window.location.hash);
+      setRouteMode(route.mode);
+      setRouteMockup(route.mockup);
+    }
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  // Render standalone modes immediately, bypassing the full gallery UI
+  if (routeMode === 'preview' && routeMockup) {
+    return <StandalonePreview mockup={routeMockup} />;
+  }
+  if (routeMode === 'spec' && routeMockup) {
+    return <StandaloneSpec mockup={routeMockup} />;
+  }
+
+  // ─── Gallery mode (original) ───
+  return <GalleryApp />;
+}
+
+function GalleryApp() {
   const [activeCategory, setActiveCategory] = useState('all');
   const [selectedMockup, setSelectedMockup] = useState(null);
   const [searchQuery, setSearchQuery] = useState('');

--- a/mockup-viewer/src/App.test.jsx
+++ b/mockup-viewer/src/App.test.jsx
@@ -6,6 +6,7 @@ import App, {
   toSlug,
   toHash,
   findMockupByHash,
+  parseRoute,
   formatDate,
   getEntryType,
   MOCKUP_REGISTRY,
@@ -837,6 +838,88 @@ Reason: Looks good, ready for implementation`;
   it('ignores invalid status values in backtick format', () => {
     expect(parseStatusFromComment('New status: `invalid`')).toBeNull();
     expect(parseStatusFromComment('New status: `pending`')).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Route parsing (standalone preview/spec routes)
+// ═══════════════════════════════════════════════════════════════
+
+describe('parseRoute', () => {
+  it('returns gallery mode for standard hash', () => {
+    const result = parseRoute('#/admin-config/data-dictionary');
+    expect(result.mode).toBe('gallery');
+    expect(result.mockup).not.toBeNull();
+    expect(result.mockup.name).toBe('Data Dictionary');
+  });
+
+  it('returns preview mode for #/preview/...', () => {
+    const result = parseRoute('#/preview/admin-config/data-dictionary');
+    expect(result.mode).toBe('preview');
+    expect(result.mockup).not.toBeNull();
+    expect(result.mockup.name).toBe('Data Dictionary');
+  });
+
+  it('returns spec mode for #/spec/...', () => {
+    const result = parseRoute('#/spec/admin-config/data-dictionary');
+    expect(result.mode).toBe('spec');
+    expect(result.mockup).not.toBeNull();
+    expect(result.mockup.name).toBe('Data Dictionary');
+  });
+
+  it('returns gallery mode with null mockup for empty hash', () => {
+    const result = parseRoute('');
+    expect(result.mode).toBe('gallery');
+    expect(result.mockup).toBeNull();
+  });
+
+  it('returns preview mode with null for unknown slug', () => {
+    const result = parseRoute('#/preview/admin-config/nonexistent');
+    expect(result.mode).toBe('preview');
+    expect(result.mockup).toBeNull();
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════
+// Catalog field validation (ensures build-time catalog has required data)
+// ═══════════════════════════════════════════════════════════════
+
+describe('Catalog field requirements', () => {
+  it('every registry entry has name, category, and description', () => {
+    for (const entry of MOCKUP_REGISTRY) {
+      expect(entry.name, `Entry missing name`).toBeTruthy();
+      expect(entry.category, `${entry.name} missing category`).toBeTruthy();
+      expect(entry.description, `${entry.name} missing description`).toBeTruthy();
+    }
+  });
+
+  it('no two entries produce the same category/slug permalink', () => {
+    const seen = new Set();
+    for (const entry of MOCKUP_REGISTRY) {
+      const key = `${entry.category}/${toSlug(entry.name)}`;
+      expect(seen.has(key), `Duplicate permalink: ${key}`).toBe(false);
+      seen.add(key);
+    }
+  });
+
+  it('all preview routes resolve to the correct mockup', () => {
+    for (const entry of MOCKUP_REGISTRY) {
+      const hash = `#/preview/${entry.category}/${toSlug(entry.name)}`;
+      const route = parseRoute(hash);
+      expect(route.mode).toBe('preview');
+      expect(route.mockup, `Preview route broken for ${entry.name}: ${hash}`).not.toBeNull();
+      expect(route.mockup.name).toBe(entry.name);
+    }
+  });
+
+  it('all spec routes resolve for entries with specPath', () => {
+    const specEntries = MOCKUP_REGISTRY.filter(m => m.specPath);
+    for (const entry of specEntries) {
+      const hash = `#/spec/${entry.category}/${toSlug(entry.name)}`;
+      const route = parseRoute(hash);
+      expect(route.mode).toBe('spec');
+      expect(route.mockup, `Spec route broken for ${entry.name}`).not.toBeNull();
+    }
   });
 });
 

--- a/mockup-viewer/vite.config.js
+++ b/mockup-viewer/vite.config.js
@@ -3,7 +3,10 @@ import react from '@vitejs/plugin-react';
 import path from 'path';
 import fs from 'fs';
 
-/** Copy designs/*.md (and .html) files into dist so they're fetchable at runtime */
+const BASE_URL = '/openelis-work/';
+const SITE_URL = 'https://digi-uw.github.io/openelis-work/';
+
+/** Copy designs/*.md, .html, and .jsx files into dist so they're fetchable at runtime */
 function copyDesignsPlugin() {
   return {
     name: 'copy-designs',
@@ -18,7 +21,7 @@ function copyDesignsPlugin() {
           const destPath = path.join(dest, entry.name);
           if (entry.isDirectory()) {
             copyRecursive(srcPath, destPath);
-          } else if (entry.name.endsWith('.md') || entry.name.endsWith('.html')) {
+          } else if (entry.name.endsWith('.md') || entry.name.endsWith('.html') || entry.name.endsWith('.jsx')) {
             fs.mkdirSync(dest, { recursive: true });
             fs.copyFileSync(srcPath, destPath);
           }
@@ -29,9 +32,249 @@ function copyDesignsPlugin() {
   };
 }
 
+/**
+ * Generate static catalog files at build time:
+ * - catalog.json  — structured machine-readable index
+ * - catalog.html  — plain HTML listing (no JS required)
+ * - llms.txt      — LLM-optimized site index
+ * - llms-full.txt — all spec content concatenated
+ * - sitemap.xml   — standard sitemap for crawlers
+ */
+function generateCatalogPlugin() {
+  return {
+    name: 'generate-catalog',
+    writeBundle(options) {
+      const appPath = path.resolve(__dirname, 'src/App.jsx');
+      const designsDir = path.resolve(__dirname, '../designs');
+      const distDir = options.dir;
+      const src = fs.readFileSync(appPath, 'utf-8');
+
+      // --- Extract MOCKUP_REGISTRY entries from App.jsx ---
+      const registryMatch = src.match(/export\s+const\s+MOCKUP_REGISTRY\s*=\s*\[([\s\S]*?)\n\];/);
+      if (!registryMatch) {
+        console.warn('[generate-catalog] Could not find MOCKUP_REGISTRY in App.jsx');
+        return;
+      }
+      const registryText = registryMatch[1];
+
+      // Extract category labels
+      const categoryLabelsMatch = src.match(/export\s+const\s+categoryLabels\s*=\s*\{([\s\S]*?)\n\};/);
+      let categoryLabels = {};
+      if (categoryLabelsMatch) {
+        try {
+          categoryLabels = new Function('return {' + categoryLabelsMatch[1] + '}')();
+        } catch (e) { /* fall back to category keys */ }
+      }
+
+      // Parse entries: split on `{` at object boundaries, extract fields via regex
+      const entries = [];
+      const entryBlocks = registryText.split(/\n\s*\{/).slice(1); // skip text before first {
+      for (const block of entryBlocks) {
+        const raw = '{' + block.split(/\n\s*\},?\s*$/m)[0] + '}';
+        const get = (key) => {
+          const m = raw.match(new RegExp(`${key}:\\s*'([^']*)'`)) || raw.match(new RegExp(`${key}:\\s*"([^"]*)"`));
+          return m ? m[1] : null;
+        };
+        const getNum = (key) => {
+          const m = raw.match(new RegExp(`${key}:\\s*(\\d+)`));
+          return m ? parseInt(m[1]) : null;
+        };
+        const getArr = (key) => {
+          const m = raw.match(new RegExp(`${key}:\\s*\\[([^\\]]*)\\]`));
+          if (!m) return [];
+          return m[1].match(/'([^']*)'/g)?.map(s => s.replace(/'/g, '')) || [];
+        };
+
+        const name = get('name');
+        if (!name) continue;
+
+        const category = get('category');
+        const hasComponent = /component:\s*React\.lazy/.test(raw);
+        const htmlUrl = get('htmlUrl');
+
+        let type = 'spec-only';
+        if (hasComponent) type = 'jsx';
+        else if (htmlUrl) type = 'html';
+        else if (/figmaUrl/.test(raw)) type = 'figma';
+
+        const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+
+        const entry = {
+          name,
+          slug,
+          category,
+          description: get('description') || '',
+          type,
+          added: get('added') || '2026-03-03',
+          status: get('status') || 'draft',
+          tags: getArr('tags'),
+          jira: getArr('jira'),
+          githubIssue: getNum('githubIssue'),
+          specPath: get('specPath'),
+        };
+
+        // Build URLs
+        entry.urls = {
+          gallery: `${SITE_URL}#/${category}/${slug}`,
+          preview: `${SITE_URL}#/preview/${category}/${slug}`,
+        };
+        if (entry.specPath) {
+          entry.urls.spec = `${SITE_URL}#/spec/${category}/${slug}`;
+          entry.urls.specRaw = `${SITE_URL}${entry.specPath}`;
+        }
+        if (type === 'jsx') {
+          const jsxPath = entry.specPath ? entry.specPath.replace('.md', '.jsx') : `designs/${category}/${slug}.jsx`;
+          entry.urls.jsxRaw = `${SITE_URL}${jsxPath}`;
+        }
+        if (htmlUrl) {
+          entry.urls.htmlRaw = `${SITE_URL}${htmlUrl}`;
+        }
+
+        entries.push(entry);
+      }
+
+      const categories = [...new Set(entries.map(e => e.category))].sort();
+
+      // --- catalog.json ---
+      const catalog = {
+        generated: new Date().toISOString(),
+        galleryUrl: SITE_URL,
+        totalDesigns: entries.length,
+        categories,
+        designs: entries,
+      };
+      fs.writeFileSync(path.join(distDir, 'catalog.json'), JSON.stringify(catalog, null, 2));
+
+      // --- catalog.html ---
+      const grouped = {};
+      for (const e of entries) {
+        if (!grouped[e.category]) grouped[e.category] = [];
+        grouped[e.category].push(e);
+      }
+      let html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>OpenELIS Design Gallery — Catalog</title>
+  <meta name="description" content="Searchable catalog of ${entries.length} design mockups and specifications for OpenELIS Global">
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 960px; margin: 0 auto; padding: 2rem 1rem; color: #161616; line-height: 1.5; }
+    h1 { border-bottom: 2px solid #0f62fe; padding-bottom: 0.5rem; }
+    h2 { color: #0f62fe; margin-top: 2rem; }
+    .design { margin-bottom: 1.5rem; padding: 1rem; border: 1px solid #e0e0e0; border-radius: 4px; }
+    .design h3 { margin: 0 0 0.25rem 0; }
+    .design p { margin: 0.25rem 0; color: #525252; }
+    .links a { margin-right: 1rem; color: #0f62fe; text-decoration: none; font-size: 0.875rem; }
+    .links a:hover { text-decoration: underline; }
+    .tags { font-size: 0.8rem; color: #6f6f6f; }
+    .tag { background: #f4f4f4; padding: 2px 6px; border-radius: 3px; margin-right: 4px; }
+    .meta { display: flex; gap: 1rem; flex-wrap: wrap; font-size: 0.875rem; color: #6f6f6f; margin-top: 0.5rem; }
+    nav { margin: 1rem 0; } nav a { margin-right: 0.75rem; }
+  </style>
+</head>
+<body>
+  <h1>OpenELIS Design Gallery — Catalog</h1>
+  <p>${entries.length} designs across ${categories.length} categories.
+    <a href="./">Interactive Gallery</a> |
+    <a href="catalog.json">JSON Catalog</a> |
+    <a href="llms.txt">LLM Index</a> |
+    <a href="sitemap.xml">Sitemap</a>
+  </p>
+  <nav>`;
+      for (const cat of categories) {
+        const label = categoryLabels[cat] || cat;
+        html += `<a href="#cat-${cat}">${label} (${grouped[cat].length})</a> `;
+      }
+      html += '</nav>\n';
+
+      for (const cat of categories) {
+        const label = categoryLabels[cat] || cat;
+        html += `\n  <h2 id="cat-${cat}">${label} (${grouped[cat].length})</h2>\n`;
+        for (const e of grouped[cat]) {
+          html += `  <div class="design">
+    <h3><a href="${e.urls.gallery}">${e.name}</a></h3>
+    <p>${e.description}</p>
+    <div class="links">
+      <a href="${e.urls.preview}">Preview</a>`;
+          if (e.urls.spec) html += `\n      <a href="${e.urls.spec}">Spec</a>`;
+          if (e.urls.specRaw) html += `\n      <a href="${e.urls.specRaw}">Raw Spec (MD)</a>`;
+          if (e.urls.jsxRaw) html += `\n      <a href="${e.urls.jsxRaw}">Source (JSX)</a>`;
+          if (e.urls.htmlRaw) html += `\n      <a href="${e.urls.htmlRaw}">HTML Mockup</a>`;
+          if (e.jira.length) {
+            for (const j of e.jira) html += `\n      <a href="https://uwdigi.atlassian.net/browse/${j}">${j}</a>`;
+          }
+          if (e.githubIssue) html += `\n      <a href="https://github.com/DIGI-UW/openelis-work/issues/${e.githubIssue}">#${e.githubIssue}</a>`;
+          html += `\n    </div>`;
+          if (e.tags.length) {
+            html += `\n    <div class="tags">${e.tags.map(t => `<span class="tag">${t}</span>`).join(' ')}</div>`;
+          }
+          html += `\n  </div>\n`;
+        }
+      }
+      html += '</body>\n</html>\n';
+      fs.writeFileSync(path.join(distDir, 'catalog.html'), html);
+
+      // --- llms.txt ---
+      let llms = `# OpenELIS Design Gallery\n\n`;
+      llms += `> Design mockups and functional requirement specs for OpenELIS Global, an open-source laboratory information management system. ${entries.length} designs across ${categories.length} categories.\n\n`;
+      llms += `## Catalog\n`;
+      llms += `- [JSON Catalog](${SITE_URL}catalog.json): Machine-readable index of all designs\n`;
+      llms += `- [HTML Catalog](${SITE_URL}catalog.html): Browsable plain-HTML catalog\n`;
+      llms += `- [Full Spec Content](${SITE_URL}llms-full.txt): All spec documents concatenated\n\n`;
+
+      for (const cat of categories) {
+        const label = categoryLabels[cat] || cat;
+        llms += `## ${label}\n`;
+        for (const e of grouped[cat]) {
+          const specUrl = e.urls.specRaw || e.urls.gallery;
+          llms += `- [${e.name}](${specUrl}): ${e.description}\n`;
+        }
+        llms += '\n';
+      }
+      fs.writeFileSync(path.join(distDir, 'llms.txt'), llms);
+
+      // --- llms-full.txt ---
+      let fullText = `# OpenELIS Design Gallery — Full Spec Content\n\n`;
+      fullText += `Generated: ${new Date().toISOString()}\n`;
+      fullText += `Total designs: ${entries.length}\n\n`;
+      fullText += `---\n\n`;
+
+      for (const e of entries) {
+        if (!e.specPath) continue;
+        const specFile = path.resolve(__dirname, '..', e.specPath);
+        if (!fs.existsSync(specFile)) continue;
+        const content = fs.readFileSync(specFile, 'utf-8');
+        fullText += `# ${e.name} (${e.category})\n`;
+        fullText += `Gallery: ${e.urls.gallery}\n`;
+        if (e.jira.length) fullText += `Jira: ${e.jira.join(', ')}\n`;
+        fullText += `\n${content}\n\n---\n\n`;
+      }
+      fs.writeFileSync(path.join(distDir, 'llms-full.txt'), fullText);
+
+      // --- sitemap.xml ---
+      let sitemap = `<?xml version="1.0" encoding="UTF-8"?>\n`;
+      sitemap += `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n`;
+      sitemap += `  <url><loc>${SITE_URL}</loc></url>\n`;
+      sitemap += `  <url><loc>${SITE_URL}catalog.html</loc></url>\n`;
+      sitemap += `  <url><loc>${SITE_URL}catalog.json</loc></url>\n`;
+      sitemap += `  <url><loc>${SITE_URL}llms.txt</loc></url>\n`;
+      for (const e of entries) {
+        if (e.urls.specRaw) sitemap += `  <url><loc>${e.urls.specRaw}</loc></url>\n`;
+        if (e.urls.jsxRaw) sitemap += `  <url><loc>${e.urls.jsxRaw}</loc></url>\n`;
+        if (e.urls.htmlRaw) sitemap += `  <url><loc>${e.urls.htmlRaw}</loc></url>\n`;
+      }
+      sitemap += `</urlset>\n`;
+      fs.writeFileSync(path.join(distDir, 'sitemap.xml'), sitemap);
+
+      console.log(`[generate-catalog] Generated catalog.json (${entries.length} designs), catalog.html, llms.txt, llms-full.txt, sitemap.xml`);
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), copyDesignsPlugin()],
-  base: '/openelis-work/',
+  plugins: [react(), copyDesignsPlugin(), generateCatalogPlugin()],
+  base: BASE_URL,
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
## Summary

Makes the design gallery accessible to AI agents, web crawlers, and automated tools — not just browser users.

### Build-time catalog generation (Vite plugin)
- **`/catalog.json`** — structured index of all 82 designs with full URL maps (gallery, preview, spec, raw file URLs)
- **`/catalog.html`** — plain semantic HTML listing, no JS required, grouped by category with links
- **`/llms.txt`** — LLM-optimized site index following the [llms.txt convention](https://llmstxt.org/)
- **`/llms-full.txt`** — all spec documents concatenated for single-fetch context loading
- **`/sitemap.xml`** — standard sitemap with 159 URLs

### Standalone routes (zero gallery chrome)
- **`#/preview/{category}/{slug}`** — full-screen mockup with screenshot capture button
- **`#/spec/{category}/{slug}`** — full-page rendered spec with download/GitHub links
- Screenshot via `html-to-image` (`toPng` → PNG download)

### Raw artifact serving
- JSX source files now copied to dist alongside MD and HTML
- Every design accessible at `/designs/{category}/{slug}.{jsx,md,html}`
- `<noscript>` fallback redirects non-JS agents to `catalog.html`

### AGENTS.md
Updated with full endpoint table for programmatic access.

## Test plan
- [x] 185/185 tests pass (9 new: route parsing, catalog fields, permalink uniqueness, route resolution)
- [x] `npm run build` generates all 5 catalog files
- [x] `catalog.json` has 82 designs across 15 categories
- [ ] Verify CI passes on this PR
- [ ] After merge, curl `catalog.json`, `catalog.html`, `llms.txt` on live site
- [ ] Open `#/preview/admin-config/data-dictionary` — renders full-screen mockup with screenshot button
- [ ] Open `#/spec/admin-config/data-dictionary` — renders full-page spec

## Future work (not in this PR)
- MCP server via Cloudflare Worker (catalog.json is the data layer)
- Build-time screenshot thumbnails via Playwright
- Pre-rendered static HTML per route

🤖 Generated with [Claude Code](https://claude.com/claude-code)