### PR TITLE
fix: Lock → Locked icon (restores broken main build)

### DIFF
--- a/designs/sample-collection/pre-analytical-eligibility-gate.jsx
+++ b/designs/sample-collection/pre-analytical-eligibility-gate.jsx
@@ -48,7 +48,7 @@ import {
   Warning,
   Add,
   TrashCan,
-  Lock,
+  Locked,
   ArrowRight,
   Renew,
   Download,
@@ -489,7 +489,7 @@ function Screen1EligibilityAssessment() {
                             {severityTag(c.severity)}
                             {c.autoComputed && (
                               <>
-                                <Tag kind="gray" size="sm" renderIcon={Lock}>
+                                <Tag kind="gray" size="sm" renderIcon={Locked}>
                                   {t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}
                                 </Tag>
                                 {c.sourceData && (
@@ -1678,7 +1678,7 @@ function Screen6VectorVariant() {
                           {severityTag(c.severity)}
                           {c.autoComputed && (
                               <>
-                                <Tag kind="gray" size="sm" renderIcon={Lock}>{t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}</Tag>
+                                <Tag kind="gray" size="sm" renderIcon={Locked}>{t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}</Tag>
                                 {c.sourceData && (
                                   <Button kind="ghost" size="sm"
                                     onClick={() => toggleVectorSource(c.id)}


### PR DESCRIPTION
## Summary

`pre-analytical-eligibility-gate.jsx` (merged in #88) imported `Lock` from `@carbon/icons-react`, but the exported name is `Locked`. Tests pass in jsdom because it doesn't strictly check tree-shaking, but Rollup's production build fails.

**Main's deploy has been broken since #88 merged** ([run 24589932778](https://github.com/DIGI-UW/openelis-work/actions/runs/24589932778)) — the gallery has not updated.

This also unblocks #89 and #90 which inherit the same broken file.

## Test plan

- [x] `npm test` — 189/189 pass
- [x] `npm run build` — succeeds (was failing on main)
- [ ] CI green on this PR
- [ ] Gallery deploys after merge