### PR TITLE
feat(s-ref): Sample Collection v2.1 Referral Addendum — order entry screens update

### DIFF
--- a/designs/sample-collection/sample-collection-referral-addendum.html
+++ b/designs/sample-collection/sample-collection-referral-addendum.html
@@ -1,645 +1,437 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Label &amp; Store — Refer Out Addendum — OpenELIS Preview</title>
-  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <meta charset="utf-8" />
+  <title>OpenELIS — Label &amp; Store + Refer Out (Sample-level) Preview</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <style>
-    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
-    .preview-banner {
-      background: #0f62fe; color: #fff;
-      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    /* --------------------------------------------------------------------
+       Minimal Carbon-flavored preview styles — mirrors @carbon/react looks
+       enough to read the mockup without pulling the full CSS bundle.
+    -------------------------------------------------------------------- */
+    :root {
+      --bg:       #ffffff;
+      --bg-alt:  #f4f4f4;
+      --bg-ui:   #e0e0e0;
+      --ink:     #161616;
+      --ink-muted: #525252;
+      --blue-60:  #0f62fe;
+      --purple-60:#8a3ffc;
+      --cyan-70:  #00539a;
+      --red-60:   #da1e28;
+      --teal-60:  #009d9a;
+      --gray-60:  #525252;
+      --gray-20:  #e0e0e0;
+      --success-bg: #defbe6;
+      --info-bg: #edf5ff;
+      --warn-bg: #fff8e1;
     }
-    .preview-content { padding: 1rem 2rem; max-width: 1440px; margin: 0 auto; }
-    .section { background: #fff; border: 1px solid #e0e0e0; margin-bottom: 1rem; }
-    .section-heading {
+    * { box-sizing: border-box; }
+    body {
+      font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: var(--bg-alt);
+      color: var(--ink);
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    .page { max-width: 1400px; margin: 0 auto; padding: 2rem; background: var(--bg); }
+    h1, h2, h3, h4, h5 { font-weight: 400; margin-top: 0; }
+    h2 { font-size: 1.75rem; margin-bottom: 0.5rem; }
+    h3 { font-size: 1.25rem; margin-bottom: 0.75rem; }
+    h5 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .muted { color: var(--ink-muted); font-size: 0.875rem; }
+
+    .tile { background: var(--bg); border: 1px solid var(--gray-20); padding: 1rem 1.25rem; margin-bottom: 1rem; }
+
+    .ctx-card { display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center; }
+    .ctx-card > div { min-width: 90px; }
+    .ctx-card strong { font-size: 0.75rem; color: var(--ink-muted); display: block; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.02em; }
+
+    .tag {
+      display: inline-block;
+      padding: 0.15rem 0.6rem;
+      border-radius: 10px;
+      font-size: 0.75rem;
+      margin-right: 0.3rem;
+      margin-bottom: 0.25rem;
+      white-space: nowrap;
+    }
+    .tag.gray   { background: var(--gray-20); color: var(--ink); }
+    .tag.purple { background: #e8daff; color: #491d8b; }
+    .tag.blue   { background: #d0e2ff; color: #002d9c; }
+    .tag.cyan   { background: #bae6ff; color: #003a6d; }
+    .tag.teal   { background: #9ef0f0; color: #003a3a; }
+    .tag.red    { background: #ffd7d9; color: #750e13; }
+
+    .btn {
+      background: var(--blue-60);
+      color: white;
+      border: 1px solid var(--blue-60);
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.875rem;
+    }
+    .btn.secondary { background: white; color: var(--blue-60); }
+    .btn.tertiary  { background: white; color: var(--ink); border-color: var(--ink); }
+    .btn.ghost     { background: transparent; color: var(--blue-60); border: none; padding: 0.25rem 0.5rem; }
+    .btn.disabled, .btn:disabled { background: var(--gray-20); color: var(--ink-muted); border-color: var(--gray-20); cursor: not-allowed; }
+
+    table { width: 100%; border-collapse: collapse; background: var(--bg); }
+    th, td { text-align: left; padding: 0.75rem; border-bottom: 1px solid var(--gray-20); font-size: 0.875rem; vertical-align: top; }
+    th { background: var(--bg-alt); font-weight: 600; }
+
+    .notif {
+      border-left: 3px solid var(--blue-60);
       padding: 0.75rem 1rem;
-      border-bottom: 1px solid #e0e0e0;
-      background: #fafafa;
+      margin-bottom: 1rem;
+      background: var(--info-bg);
     }
-    .section-heading h3 { margin: 0; font-weight: 600; font-size: 14px; }
-    .section-heading p { margin: 0.25rem 0 0; color: #525252; font-size: 12px; }
-    .toolbar {
-      display: flex; align-items: center; justify-content: space-between;
-      padding: 0.5rem 1rem; border-bottom: 1px solid #e0e0e0; background: #fafafa;
+    .notif.success { border-color: #24a148; background: var(--success-bg); }
+    .notif.warn    { border-color: #f1c21b; background: var(--warn-bg); }
+    .notif.info    { border-color: var(--blue-60); background: var(--info-bg); }
+    .notif strong  { display: block; margin-bottom: 0.25rem; }
+    .notif span    { font-size: 0.8125rem; color: var(--ink-muted); }
+
+    .expand {
+      background: var(--bg-alt);
+      border-left: 4px solid var(--purple-60);
+      padding: 1rem 1.5rem;
     }
-    .cds--data-table td, .cds--data-table th { padding: 0.75rem 1rem; vertical-align: middle; }
-    .stepper {
-      display: flex; gap: 0; margin-bottom: 1rem; background: #fff;
-      padding: 1rem 1.5rem; border: 1px solid #e0e0e0;
+
+    .labels-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 1rem;
+      margin-bottom: 1rem;
     }
-    .step { flex: 1; display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0; position: relative; }
-    .step-circle {
-      width: 20px; height: 20px; border-radius: 50%; border: 2px solid #8d8d8d;
-      display: inline-flex; align-items: center; justify-content: center;
-      font-size: 11px; color: #525252; flex-shrink: 0;
+    .labels-grid label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--ink-muted);
+      margin-bottom: 0.25rem;
     }
-    .step.complete .step-circle { background: #198038; border-color: #198038; color: #fff; }
-    .step.current .step-circle { background: #0f62fe; border-color: #0f62fe; color: #fff; }
-    .step.disabled { opacity: 0.5; }
-    .step-label { font-size: 13px; }
-    .step.current .step-label { font-weight: 600; }
-    .ctx-card {
-      background: #fff; border: 1px solid #e0e0e0; padding: 1rem 1.5rem;
-      display: grid; grid-template-columns: auto 2fr 1fr 1.5fr; gap: 1.5rem; margin-bottom: 1rem;
+    .num-input {
+      display: flex;
+      border: 1px solid var(--gray-20);
+      width: 120px;
     }
-    .ctx-item-label { font-size: 11px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px; }
-    .ctx-item-value { font-size: 14px; font-weight: 500; margin-top: 2px; }
-    .ctx-item-value.big { font-size: 20px; font-weight: 600; }
-    .ctx-item-sub { font-size: 11px; color: #525252; }
-    .inline-form {
-      background: #f4f4f4; padding: 1rem; border-left: 3px solid #8a3ffc;
+    .num-input button { border: none; background: var(--bg-alt); padding: 0 0.5rem; cursor: pointer; }
+    .num-input input  { border: none; padding: 0.5rem; width: 60px; text-align: center; font-family: inherit; }
+
+    .toolbar-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.5rem;
     }
-    .inline-form h5 { margin: 0 0 0.75rem; font-size: 13px; font-weight: 600; }
-    .form-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 0.75rem; margin-bottom: 0.75rem; }
-    .form-grid.single { grid-template-columns: 1fr; }
-    .form-actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
-    .inline-field label { font-size: 11px; color: #525252; display: block; margin-bottom: 4px; font-weight: 500; }
-    .inline-field input, .inline-field textarea, .inline-field select {
-      width: 100%; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
-      background: #fff; font-family: inherit; font-size: 13px;
+    .accordion-header {
+      background: var(--bg-alt);
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--gray-20);
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-weight: 600;
     }
-    .breadcrumb { font-size: 12px; color: #525252; margin-bottom: 0.75rem; }
-    .breadcrumb a { color: #0f62fe; text-decoration: none; }
-    .breadcrumb .current { color: #161616; }
-    .modal-backdrop {
-      position: fixed; inset: 0; background: rgba(22,22,22,0.5);
-      display: flex; align-items: center; justify-content: center; z-index: 10;
+    .accordion-body { padding: 1rem; border: 1px solid var(--gray-20); border-top: none; }
+
+    .footer-nav { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--gray-20); }
+
+    select, input[type="text"], textarea {
+      width: 100%;
+      padding: 0.5rem;
+      font-family: inherit;
+      font-size: 0.875rem;
+      border: 1px solid var(--gray-20);
+      background: var(--bg);
+      margin-bottom: 0.5rem;
     }
-    .modal {
-      background: #fff; width: 560px; max-width: 90vw; max-height: 90vh; overflow: auto;
-      display: flex; flex-direction: column;
+    label.field-label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--ink-muted);
+      margin-bottom: 0.25rem;
     }
-    .modal-header {
-      padding: 1rem 1.5rem 0.5rem; font-size: 18px; font-weight: 400;
-    }
-    .modal-body { padding: 1rem 1.5rem; }
-    .modal-footer { padding: 1rem 1.5rem; display: flex; justify-content: flex-end; gap: 0; border-top: 1px solid #e0e0e0; }
-    .modal-footer .cds--btn { flex: 1; max-width: 50%; justify-content: flex-start; padding: 0.875rem 1rem; }
-    .notif-preview { margin: 0.75rem 0; }
-    .referred-details { font-size: 11px; color: #525252; margin-top: 4px; font-style: italic; }
-    .dashboard-preview { margin-top: 2rem; padding: 1.5rem; background: #fff; border: 1px solid #e0e0e0; }
-    .dashboard-preview h3 { margin-top: 0; }
-    .filter-row { display: flex; gap: 0.75rem; align-items: flex-end; margin-bottom: 1rem; padding: 1rem; background: #fafafa; }
-    .filter-row label { font-size: 11px; color: #525252; display: block; margin-bottom: 4px; }
-    .filter-row .cds--select { min-width: 180px; }
-    .badge-pill {
-      display: inline-flex; align-items: center; gap: 0.5rem;
-      background: #e8daff; color: #491d8b; padding: 4px 12px; border-radius: 12px;
-      font-size: 12px; font-weight: 500;
-    }
-    .badge-pill-count {
-      background: #491d8b; color: #fff; padding: 1px 8px; border-radius: 10px; font-size: 11px;
-    }
+    .section-title { margin: 2rem 0 0.75rem; padding-top: 1rem; border-top: 1px solid var(--gray-20); }
+    .section-title small { font-weight: 400; color: var(--ink-muted); }
+    .chip-cell .tag { margin-bottom: 0.25rem; }
   </style>
 </head>
-<body class="cds--white">
-  <div class="preview-banner">
-    Visual Preview &nbsp;|&nbsp; Label &amp; Store — Refer Out Addendum &nbsp;|&nbsp; OpenELIS Sample Collection Redesign v2.1 &nbsp;|&nbsp; Not a live application
+<body>
+
+<div class="page">
+
+  <h2>Step 3 — Label &amp; Store</h2>
+  <p class="muted">
+    Print labels, assign storage, and refer samples to external labs.
+    Referrals are assigned per physical sample — every test on a referred sample travels with the specimen.
+  </p>
+
+  <!-- ======================================================================
+       Order context card — with Referred chip (REF-8)
+  ======================================================================= -->
+  <div class="tile ctx-card">
+    <div><strong>Lab #</strong>2026-00412</div>
+    <div><strong>Patient</strong>Siti Rahayu</div>
+    <div><strong>Patient ID</strong>P-88103</div>
+    <div><strong>Facility</strong>Puskesmas Kebayoran</div>
+    <div><strong>Priority</strong><span class="tag teal">Routine</span></div>
+    <div><strong>Samples</strong>2</div>
+    <div><strong>Referred</strong><span class="tag purple">Referred (1 of 2 samples)</span></div>
   </div>
-  <div class="preview-content" id="root"></div>
-  <script type="text/babel">
-    const { useState, useMemo, useCallback, Fragment } = React;
 
-    // ---------------------------------------------------------------
-    // Mock data
-    // ---------------------------------------------------------------
-    const REFERRING_LABS = [
-      { id: 'lab-01', text: 'Balai Besar Teknik Kesehatan Lingkungan (BBTKL) Jakarta', fhirEnabled: true },
-      { id: 'lab-02', text: 'Laboratorium Kesehatan Daerah — Yogyakarta', fhirEnabled: true },
-      { id: 'lab-03', text: 'Eijkman Institute — Molecular Reference Lab', fhirEnabled: false },
-      { id: 'lab-04', text: 'National Reference Laboratory — Antananarivo', fhirEnabled: true },
-    ];
+  <!-- ======================================================================
+       Print Labels section (LBL-2) — collapsed accordion style
+  ======================================================================= -->
+  <div class="accordion-header">
+    Print Labels (LBL-2) — travels with every sample, including referred ones
+    <span>▼</span>
+  </div>
+  <div class="accordion-body">
+    <p class="muted" style="margin-top:0;margin-bottom:1rem;">
+      Labels travel with specimens — including referred ones. Keep label quantity ≥ 1 for any sample being shipped externally.
+    </p>
+    <div class="labels-grid">
+      <div>
+        <label>Order Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="1" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Sample Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="2" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Slide Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="0" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Block Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="0" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Freezer Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="1" /><button>+</button></div>
+      </div>
+    </div>
+    <button class="btn secondary">🖨 Print All Labels</button>
+  </div>
 
-    const INITIAL_ROWS = [
-      { id: 'r1', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412',
-        storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Viral Load (PCR)', referralState: 'inhouse' },
-      { id: 'r2', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412',
-        storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Drug Resistance Genotyping', referralState: 'inhouse' },
-      { id: 'r3', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412',
-        storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis B DNA Quantitative', referralState: 'inhouse' },
-      { id: 'r4', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412',
-        storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis C RNA Quantitative', referralState: 'inhouse' },
-    ];
+  <!-- ======================================================================
+       Toolbar — bulk refer out + counts
+  ======================================================================= -->
+  <div class="toolbar-row" style="margin-top:1.5rem;">
+    <div class="muted">1 in-house sample • 1 referred</div>
+    <button class="btn tertiary">Bulk Refer Out ↗</button>
+  </div>
 
-    // Dashboard mock data (for lower preview panel)
-    const DASHBOARD_ORDERS = [
-      { lab: '2026-00408', patient: 'Budi Hartono', facility: 'Puskesmas Kramat Jati', priority: 'Routine',
-        status: 'Awaiting QA', referredTag: null, step: 4 },
-      { lab: '2026-00410', patient: 'Fitri Ananda', facility: 'RS Cipto Mangunkusumo', priority: 'Urgent',
-        status: 'Labeling', referredTag: 'Referred (1 of 3)', step: 3 },
-      { lab: '2026-00412', patient: 'Sari Wulandari', facility: 'RS Hasan Sadikin Bandung', priority: 'Routine',
-        status: 'Labeling', referredTag: 'Referred (2 of 4)', step: 3 },
-      { lab: '2026-00413', patient: 'Arya Pratama', facility: 'Klinik Harapan', priority: 'Routine',
-        status: 'Referred Out', referredTag: 'Referred (all)', step: 4, fullyReferred: true },
-      { lab: '2026-00414', patient: 'Nadia Safitri', facility: 'RS Pondok Indah', priority: 'Routine',
-        status: 'Completed', referredTag: null, step: 4 },
-    ];
+  <!-- ======================================================================
+       Samples table — sample-centric rows (LBL-5)
+  ======================================================================= -->
+  <table>
+    <thead>
+      <tr>
+        <th style="width:2rem;"></th>
+        <th>Sample ID</th>
+        <th>Type / Qty</th>
+        <th>Tests on this sample</th>
+        <th>Storage Location</th>
+        <th>Labels</th>
+        <th>Refer Out</th>
+        <th style="width:3rem;"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Row 1: In-house sample with inline refer-out form expanded -->
+      <tr>
+        <td><button class="btn ghost">▲</button></td>
+        <td><strong>S.2026-00412.1</strong><br /><span class="muted">Collected 2026-04-22 09:14</span></td>
+        <td>Whole Blood (EDTA)<br /><span class="muted">4 mL</span></td>
+        <td class="chip-cell">
+          <span class="tag cyan">HIV Viral Load</span>
+          <span class="tag cyan">CD4 Count</span>
+        </td>
+        <td><button class="btn ghost">F-02 / S-3 / B-14 / A4</button></td>
+        <td><button class="btn ghost">🖨 Print (2)</button></td>
+        <td><span class="tag gray">In-house</span></td>
+        <td><button class="btn ghost">⋯</button></td>
+      </tr>
 
-    // ---------------------------------------------------------------
-    // Helpers
-    // ---------------------------------------------------------------
-    function StatusTag({ state, labName, onRetry }) {
-      if (state === 'inhouse') return <span className="cds--tag cds--tag--gray">In-house</span>;
-      if (state === 'referred') return (
-        <span className="cds--tag cds--tag--purple" title={labName}>Referred — {truncate(labName, 32)}</span>
-      );
-      if (state === 'sent') return <span className="cds--tag cds--tag--blue">Awaiting External Results</span>;
-      if (state === 'failed') return (
-        <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-          <span className="cds--tag cds--tag--red">Send Failed</span>
-          <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={onRetry}>Retry Send</button>
-        </span>
-      );
-      return null;
-    }
-
-    function truncate(s, n) { return s && s.length > n ? s.slice(0, n - 1) + '…' : s; }
-
-    function deriveOrderStatus(rows) {
-      const active = rows.filter(r => !r.voided);
-      const referredCount = active.filter(r => r.referralState !== 'inhouse').length;
-      const total = active.length;
-      if (total === 0) return 'LABELING';
-      if (referredCount === total) return 'REFERRED_OUT';
-      return 'LABELING';
-    }
-
-    function HeaderStatusBadge({ orderStatus, rows }) {
-      if (orderStatus === 'REFERRED_OUT') return <span className="cds--tag cds--tag--purple">Referred Out</span>;
-      const referredCount = rows.filter(r => r.referralState !== 'inhouse').length;
-      const total = rows.length;
-      if (referredCount > 0) return (
-        <Fragment>
-          <span className="cds--tag cds--tag--blue">Labeling</span>
-          <span className="cds--tag cds--tag--purple" style={{ marginLeft: '0.25rem' }}>
-            Referred ({referredCount} of {total})
-          </span>
-        </Fragment>
-      );
-      return <span className="cds--tag cds--tag--blue">Labeling</span>;
-    }
-
-    // ---------------------------------------------------------------
-    // Inline per-row refer form
-    // ---------------------------------------------------------------
-    function InlineReferForm({ row, onSave, onCancel, xoaEnabled }) {
-      const [referringLabId, setReferringLabId] = useState('');
-      const [reason, setReason] = useState('');
-      const [expectedReturn, setExpectedReturn] = useState('');
-      const [notifyCustomer, setNotifyCustomer] = useState(true);
-      const [error, setError] = useState(null);
-
-      const save = () => {
-        if (!referringLabId) {
-          setError('Select a referring lab before saving.');
-          return;
-        }
-        const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-        onSave({ rowId: row.id, lab, reason, expectedReturn, notifyCustomer });
-      };
-
-      return (
-        <div className="inline-form">
-          <h5>Refer Out — {row.test}</h5>
-          {error && (
-            <div className="cds--inline-notification cds--inline-notification--error" style={{ marginBottom: '0.75rem' }}>
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">{error}</div>
-                </div>
-              </div>
+      <!-- Inline expansion row (LBL-6) -->
+      <tr>
+        <td colspan="8" style="padding:0;">
+          <div class="expand">
+            <h5>Refer Sample to External Lab</h5>
+            <div class="notif info" style="margin-bottom:1rem;">
+              <strong>Sample-level referral</strong>
+              <span>This will refer Whole Blood (EDTA) (S.2026-00412.1) and all 2 tests on it: HIV Viral Load, CD4 Count.</span>
             </div>
-          )}
-          <div className="form-grid">
-            <div className="inline-field">
-              <label>Referring Lab *</label>
-              <select value={referringLabId} onChange={(e) => setReferringLabId(e.target.value)}>
-                <option value="">Select a referring lab…</option>
-                {REFERRING_LABS.map(lab => (
-                  <option key={lab.id} value={lab.id}>
-                    {lab.text}{lab.fhirEnabled ? '' : ' (paper/manifest only)'}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="inline-field">
-              <label>Expected Return Date</label>
-              <input type="date" value={expectedReturn} onChange={(e) => setExpectedReturn(e.target.value)} />
-            </div>
-          </div>
-          <div className="form-grid single">
-            <div className="inline-field">
-              <label>Reason (optional, max 500)</label>
-              <textarea rows="2" maxLength="500" value={reason} onChange={(e) => setReason(e.target.value)} />
-            </div>
-          </div>
-          {xoaEnabled && (
-            <div className="inline-field" style={{ marginBottom: '0.5rem' }}>
-              <label style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-                <input type="checkbox" checked={notifyCustomer} onChange={(e) => setNotifyCustomer(e.target.checked)} />
-                Notify customer of referral
-              </label>
-            </div>
-          )}
-          <div className="form-actions">
-            <button className="cds--btn cds--btn--primary cds--btn--sm" onClick={save}>Save Referral</button>
-            <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={onCancel}>Cancel</button>
-          </div>
-        </div>
-      );
-    }
-
-    // ---------------------------------------------------------------
-    // Bulk modal
-    // ---------------------------------------------------------------
-    function BulkReferModal({ open, onClose, onConfirm, pendingRows, xoaEnabled }) {
-      const [referringLabId, setReferringLabId] = useState('');
-      const [reason, setReason] = useState('');
-      const [expectedReturn, setExpectedReturn] = useState('');
-      const [notifyCustomer, setNotifyCustomer] = useState(true);
-
-      if (!open) return null;
-
-      const sampleCount = new Set(pendingRows.map(r => r.sampleId)).size;
-      const testCount = pendingRows.length;
-      const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-
-      const reset = () => { setReferringLabId(''); setReason(''); setExpectedReturn(''); setNotifyCustomer(true); };
-      const closeAndReset = () => { reset(); onClose(); };
-      const handleConfirm = () => {
-        if (!referringLabId || testCount === 0) return;
-        onConfirm({ lab, reason, expectedReturn, notifyCustomer });
-        reset();
-      };
-
-      return (
-        <div className="modal-backdrop" onClick={closeAndReset}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">Refer All Tests to External Lab</div>
-            <div className="modal-body">
-              {testCount === 0 ? (
-                <div className="cds--inline-notification cds--inline-notification--info">
-                  <div className="cds--inline-notification__details">
-                    <div className="cds--inline-notification__text-wrapper">
-                      <div className="cds--inline-notification__title">
-                        No in-house tests to refer. All tests on this order are already referred.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <Fragment>
-                  <div className="form-grid single" style={{ marginBottom: '1rem' }}>
-                    <div className="inline-field">
-                      <label>Referring Lab *</label>
-                      <select value={referringLabId} onChange={(e) => setReferringLabId(e.target.value)}>
-                        <option value="">Select a referring lab…</option>
-                        {REFERRING_LABS.map(lab => (
-                          <option key={lab.id} value={lab.id}>
-                            {lab.text}{lab.fhirEnabled ? '' : ' (paper/manifest only)'}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-                  <div className="form-grid">
-                    <div className="inline-field">
-                      <label>Expected Return Date</label>
-                      <input type="date" value={expectedReturn} onChange={(e) => setExpectedReturn(e.target.value)} />
-                    </div>
-                    <div className="inline-field">
-                      <label>Reason (optional)</label>
-                      <input type="text" maxLength="500" value={reason} onChange={(e) => setReason(e.target.value)} />
-                    </div>
-                  </div>
-                  {xoaEnabled && (
-                    <div className="inline-field" style={{ marginBottom: '0.75rem' }}>
-                      <label style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-                        <input type="checkbox" checked={notifyCustomer} onChange={(e) => setNotifyCustomer(e.target.checked)} />
-                        Notify customer of referral
-                      </label>
-                    </div>
-                  )}
-                  <div className="cds--inline-notification cds--inline-notification--warning">
-                    <div className="cds--inline-notification__details">
-                      <div className="cds--inline-notification__text-wrapper">
-                        <div className="cds--inline-notification__title">
-                          This will refer {testCount} test{testCount === 1 ? '' : 's'} on {sampleCount} sample{sampleCount === 1 ? '' : 's'}{lab ? ` to ${lab.text}` : ''}.
-                        </div>
-                        <div className="cds--inline-notification__subtitle">
-                          {lab && !lab.fhirEnabled ? 'This lab is paper/manifest only — no FHIR transmission will occur.'
-                           : lab ? 'FHIR ServiceRequest will be transmitted to the receiving lab.'
-                           : 'Select a referring lab to see transmission details.'}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Fragment>
-              )}
-            </div>
-            <div className="modal-footer">
-              <button className="cds--btn cds--btn--secondary" onClick={closeAndReset}>Cancel</button>
-              <button className="cds--btn cds--btn--primary" disabled={!referringLabId || testCount === 0} onClick={handleConfirm}>
-                Refer All
-              </button>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // ---------------------------------------------------------------
-    // Main app
-    // ---------------------------------------------------------------
-    function App() {
-      const [rows, setRows] = useState(INITIAL_ROWS);
-      const [expandedRowId, setExpandedRowId] = useState(null);
-      const [bulkOpen, setBulkOpen] = useState(false);
-      const [notification, setNotification] = useState(null);
-      const [dashboardFilter, setDashboardFilter] = useState('any');
-
-      const xoaEnabled = true;
-      const allowBulkReferOut = true;
-      const orderStatus = useMemo(() => deriveOrderStatus(rows), [rows]);
-      const pendingInhouseRows = useMemo(() => rows.filter(r => r.referralState === 'inhouse'), [rows]);
-
-      const toggleExpand = (rowId) => setExpandedRowId(prev => prev === rowId ? null : rowId);
-
-      const savePerRowReferral = ({ rowId, lab, reason, expectedReturn, notifyCustomer }) => {
-        setRows(prev => prev.map(r =>
-          r.id === rowId
-            ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-                reason, expectedReturn, notifyCustomer }
-            : r
-        ));
-        setExpandedRowId(null);
-        setNotification({ kind: 'success', title: `Referred 1 test to ${lab.text}.` });
-        setTimeout(() => setNotification(null), 5000);
-      };
-
-      const confirmBulk = ({ lab, reason, expectedReturn, notifyCustomer }) => {
-        const pendingIds = pendingInhouseRows.map(r => r.id);
-        setRows(prev => prev.map(r =>
-          pendingIds.includes(r.id)
-            ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-                reason, expectedReturn, notifyCustomer }
-            : r
-        ));
-        setBulkOpen(false);
-        setNotification({ kind: 'success', title: `Referred ${pendingIds.length} tests to ${lab.text}.` });
-        setTimeout(() => setNotification(null), 5000);
-      };
-
-      const undoReferral = (rowId) => {
-        setRows(prev => prev.map(r => r.id === rowId ? {
-          ...r, referralState: 'inhouse', referringLab: null, fhirEnabled: null,
-          reason: null, expectedReturn: null, notifyCustomer: null
-        } : r));
-        setNotification({ kind: 'info', title: 'Referral undone. Test returned to in-house queue.' });
-        setTimeout(() => setNotification(null), 4000);
-      };
-
-      // Dashboard filter
-      const filteredDashboard = DASHBOARD_ORDERS.filter(o => {
-        if (dashboardFilter === 'any') return true;
-        if (dashboardFilter === 'hasReferred') return o.referredTag !== null;
-        if (dashboardFilter === 'fullyReferred') return o.fullyReferred;
-        return true;
-      });
-
-      return (
-        <Fragment>
-          {/* Step 3 Label & Store */}
-          <div className="breadcrumb">
-            <a href="#">Add Order</a> / <a href="#">Order 2026-00412</a> / <span className="current">Label &amp; Store</span>
-          </div>
-
-          <div className="stepper">
-            <div className="step complete"><span className="step-circle">✓</span><span className="step-label">Enter Order</span></div>
-            <div className="step complete"><span className="step-circle">✓</span><span className="step-label">Collect Sample</span></div>
-            <div className="step current"><span className="step-circle">3</span><span className="step-label">Label &amp; Store</span></div>
-            <div className={'step ' + (orderStatus === 'REFERRED_OUT' ? 'disabled' : '')}>
-              <span className="step-circle">4</span>
-              <span className="step-label">
-                QA Review {orderStatus === 'REFERRED_OUT' && <em style={{ fontSize: '11px', color: '#525252' }}>(skipped — fully referred)</em>}
-              </span>
-            </div>
-          </div>
-
-          {/* Order Context Card */}
-          <div className="ctx-card">
-            <div>
-              <div className="ctx-item-label">Lab Number</div>
-              <div className="ctx-item-value big">2026-00412</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Patient</div>
-              <div className="ctx-item-value">Ibu Sari Wulandari</div>
-              <div className="ctx-item-sub">F · 34 · NIK 3174012345678901</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Tests</div>
-              <div className="ctx-item-value">{rows.length} tests · {new Set(rows.map(r => r.sampleId)).size} samples</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Status</div>
-              <div style={{ marginTop: '0.25rem', display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                <HeaderStatusBadge orderStatus={orderStatus} rows={rows} />
-              </div>
-            </div>
-          </div>
-
-          {notification && (
-            <div className={'cds--inline-notification cds--inline-notification--' + notification.kind + ' notif-preview'}>
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">{notification.title}</div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {orderStatus === 'REFERRED_OUT' && (
-            <div className="cds--inline-notification cds--inline-notification--info notif-preview">
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">Order fully referred out</div>
-                  <div className="cds--inline-notification__subtitle">
-                    All tests are referred to an external lab. Step 4 QA Review is skipped — the order will complete when external results return via referral result entry.
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Samples & Tests table */}
-          <div className="section">
-            <div className="section-heading">
-              <h3>Samples &amp; Tests</h3>
-              <p>Assign storage location, print labels, and refer individual tests or the whole order to an external lab.</p>
-            </div>
-            <div className="toolbar">
-              <button
-                className="cds--btn cds--btn--secondary cds--btn--sm"
-                disabled={!allowBulkReferOut || pendingInhouseRows.length === 0}
-                onClick={() => setBulkOpen(true)}
-              >
-                Bulk Refer Out{pendingInhouseRows.length > 0 ? ` (${pendingInhouseRows.length})` : ''}
-              </button>
-              <button className="cds--btn cds--btn--primary cds--btn--sm">Save &amp; Next</button>
-            </div>
-            <div className="cds--data-table-container">
-              <table className="cds--data-table">
-                <thead>
-                  <tr>
-                    <th>Sample</th><th>Type</th><th>Storage</th><th>Test</th><th>Refer Out</th><th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map(row => {
-                    const isExpanded = expandedRowId === row.id;
-                    return (
-                      <Fragment key={row.id}>
-                        <tr>
-                          <td><code style={{ fontSize: '12px' }}>{row.sampleId}</code></td>
-                          <td>{row.sampleType}</td>
-                          <td><span style={{ fontSize: '11px', color: '#525252' }}>{row.storage}</span></td>
-                          <td>{row.test}</td>
-                          <td>
-                            <StatusTag state={row.referralState} labName={row.referringLab} />
-                            {row.referralState === 'referred' && row.referringLab && (
-                              <div className="referred-details">
-                                {row.fhirEnabled ? 'FHIR transmission queued' : 'Paper/manifest referral'}
-                                {row.expectedReturn ? ' · return by ' + row.expectedReturn : ''}
-                              </div>
-                            )}
-                          </td>
-                          <td style={{ textAlign: 'right' }}>
-                            {row.referralState === 'inhouse' ? (
-                              <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={() => toggleExpand(row.id)}>
-                                {isExpanded ? 'Close' : 'Refer Out'}
-                              </button>
-                            ) : (
-                              <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={() => undoReferral(row.id)}>
-                                Undo Referral
-                              </button>
-                            )}
-                          </td>
-                        </tr>
-                        {isExpanded && (
-                          <tr>
-                            <td colSpan="6" style={{ padding: 0 }}>
-                              <InlineReferForm row={row} xoaEnabled={xoaEnabled}
-                                onCancel={() => setExpandedRowId(null)}
-                                onSave={savePerRowReferral} />
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          {/* Dashboard filter preview */}
-          <div className="dashboard-preview">
-            <h3 style={{ fontWeight: 600, fontSize: '16px' }}>Order Dashboard — Referred Out filter</h3>
-            <p style={{ color: '#525252', fontSize: '13px', marginTop: 0 }}>
-              New filter on the Order Entry dashboard. Try changing it to see which orders qualify.
-            </p>
-            <div className="filter-row">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
               <div>
-                <label>Status</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" disabled>
-                    <option>All</option>
-                  </select>
-                </div>
+                <label class="field-label">Referring Lab (required)</label>
+                <select>
+                  <option>Select a referring lab…</option>
+                  <option selected>BBTKL Jakarta (FHIR) • TAT 5 days</option>
+                  <option>Eijkman Institute (FHIR) • TAT 3 days</option>
+                  <option>Prodia Reference Lab • TAT 7 days</option>
+                  <option>SILNAS Bandung (FHIR) • TAT 4 days</option>
+                </select>
               </div>
               <div>
-                <label>Priority</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" disabled>
-                    <option>Any</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label style={{ fontWeight: 600, color: '#8a3ffc' }}>Referred Out (new)</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" value={dashboardFilter} onChange={(e) => setDashboardFilter(e.target.value)}>
-                    <option value="any">Any</option>
-                    <option value="hasReferred">Has Referred Tests</option>
-                    <option value="fullyReferred">Fully Referred Out</option>
-                  </select>
-                </div>
-              </div>
-              <div style={{ marginLeft: 'auto' }}>
-                <span className="badge-pill">
-                  Awaiting External Results <span className="badge-pill-count">3</span>
-                </span>
+                <label class="field-label">Expected Return Date (optional)</label>
+                <input type="text" placeholder="yyyy-mm-dd" value="2026-04-28" />
               </div>
             </div>
-            <div className="cds--data-table-container">
-              <table className="cds--data-table">
-                <thead>
-                  <tr>
-                    <th>Lab Number</th><th>Patient</th><th>Facility</th><th>Priority</th>
-                    <th>Status</th><th>Step</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredDashboard.map(o => (
-                    <tr key={o.lab}>
-                      <td><code style={{ fontSize: '12px' }}>{o.lab}</code></td>
-                      <td>{o.patient}</td>
-                      <td style={{ fontSize: '12px' }}>{o.facility}</td>
-                      <td>{o.priority}</td>
-                      <td>
-                        <span className={'cds--tag cds--tag--' + (o.status === 'Referred Out' ? 'purple'
-                          : o.status === 'Completed' ? 'green' : o.status === 'Awaiting QA' ? 'warm-gray' : 'blue')}>
-                          {o.status}
-                        </span>
-                        {o.referredTag && o.status !== 'Referred Out' && (
-                          <span className="cds--tag cds--tag--purple" style={{ marginLeft: '0.25rem' }}>
-                            {o.referredTag}
-                          </span>
-                        )}
-                      </td>
-                      <td style={{ fontSize: '12px', color: '#525252' }}>
-                        Step {o.step}{o.fullyReferred ? ' (skipped)' : ''}
-                      </td>
-                    </tr>
-                  ))}
-                  {filteredDashboard.length === 0 && (
-                    <tr><td colSpan="6" style={{ textAlign: 'center', color: '#525252', padding: '2rem' }}>
-                      No orders match this filter.
-                    </td></tr>
-                  )}
-                </tbody>
-              </table>
+            <label class="field-label" style="margin-top:0.5rem;">Reason (optional)</label>
+            <textarea rows="2" placeholder="e.g., Local VL platform offline until Monday.">Local VL platform offline; sending full panel upstream.</textarea>
+            <label><input type="checkbox" checked /> Notify customer of referral (X-01 REFERRAL_OUT event)</label>
+            <div style="margin-top:1rem;">
+              <button class="btn">Save Referral ↗</button>
+              <button class="btn ghost">Cancel</button>
             </div>
           </div>
+        </td>
+      </tr>
 
-          <BulkReferModal
-            open={bulkOpen}
-            onClose={() => setBulkOpen(false)}
-            onConfirm={confirmBulk}
-            pendingRows={pendingInhouseRows}
-            xoaEnabled={xoaEnabled}
-          />
-        </Fragment>
-      );
-    }
+      <!-- Row 2: Referred sample -->
+      <tr>
+        <td><button class="btn ghost">▼</button></td>
+        <td><strong>S.2026-00412.2</strong><br /><span class="muted">Collected 2026-04-22 09:18</span></td>
+        <td>Plasma<br /><span class="muted">2 mL</span></td>
+        <td class="chip-cell">
+          <span class="tag purple">Hepatitis B DNA PCR</span>
+          <span class="tag purple">HCV Antibody</span>
+        </td>
+        <td><button class="btn ghost">F-04 / S-1 / B-07 / C2</button></td>
+        <td><button class="btn ghost">🖨 Print (1)</button></td>
+        <td><span class="tag purple">Referred — Eijkman Institute</span></td>
+        <td><button class="btn ghost">⋯</button></td>
+      </tr>
+    </tbody>
+  </table>
 
-    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
-  </script>
+  <!-- Info banner for mixed partial-referral state -->
+  <div class="notif info" style="margin-top:1rem;">
+    <strong>Partial referral in progress.</strong>
+    <span>This order has 1 in-house sample (HIV Viral Load, CD4 Count) and 1 referred sample. Order will continue through QA Review for the in-house sample. (REF-5, BR-REF-3)</span>
+  </div>
+
+  <div class="footer-nav">
+    <button class="btn secondary">← Back to Step 2 (Collect Sample)</button>
+    <button class="btn">Save &amp; Next → Step 4 (QA Review)</button>
+  </div>
+
+  <!-- ======================================================================
+       Fully-referred example (all samples)
+  ======================================================================= -->
+  <h3 class="section-title">Fully-referred example <small>(same screen, different order state)</small></h3>
+  <div class="notif info">
+    <strong>All samples referred — QA will be skipped (REF-2, REF-3).</strong>
+    <span>Order auto-transitions to REFERRED_OUT on save. The QA Review queue will not show this order. When external results return, the order auto-approves (REF-4).</span>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Sample ID</th>
+        <th>Type</th>
+        <th>Tests</th>
+        <th>Storage</th>
+        <th>Refer Out</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>S.2026-00415.1</strong></td>
+        <td>Plasma — 3 mL</td>
+        <td class="chip-cell">
+          <span class="tag purple">HIV Viral Load</span>
+          <span class="tag purple">CD4 Count</span>
+          <span class="tag purple">Hepatitis B DNA PCR</span>
+        </td>
+        <td>F-02 / S-1 / B-03 / B7</td>
+        <td><span class="tag blue">Sent to External — BBTKL Jakarta</span></td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="footer-nav">
+    <button class="btn secondary">← Back to Step 2</button>
+    <button class="btn">Close Order (Referred Out) ✓</button>
+  </div>
+
+  <!-- ======================================================================
+       Dashboard filter preview (DSH-10, DSH-11)
+  ======================================================================= -->
+  <h3 class="section-title">Order Dashboard — Referred Out filter <small>(DSH-10, DSH-11)</small></h3>
+  <div style="display:flex;gap:1rem;align-items:end;margin-bottom:1rem;">
+    <div style="max-width:260px;flex:1;">
+      <label class="field-label">Referred Out</label>
+      <select>
+        <option>Any</option>
+        <option>Has Referred Samples</option>
+        <option>Fully Referred Out</option>
+      </select>
+    </div>
+    <div class="muted">Combines with existing filters via AND.</div>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Lab #</th>
+        <th>Patient / Subject</th>
+        <th>Facility</th>
+        <th>Status</th>
+        <th>Referred Samples</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-00412</td>
+        <td>Siti Rahayu</td>
+        <td>Puskesmas Kebayoran</td>
+        <td><span class="tag blue">Labeling</span><span class="tag purple">Referred (1 of 2 samples)</span></td>
+        <td>1 of 2</td>
+      </tr>
+      <tr>
+        <td>2026-00413</td>
+        <td>Budi Santoso</td>
+        <td>RS Cipto</td>
+        <td><span class="tag purple">Referred Out</span><span class="tag purple">Referred (all samples)</span></td>
+        <td>2 of 2</td>
+      </tr>
+      <tr>
+        <td>2026-00414</td>
+        <td>ENV-KBY-0412-01</td>
+        <td>Kebayoran River</td>
+        <td><span class="tag blue">QA Review</span></td>
+        <td>0 of 3</td>
+      </tr>
+      <tr>
+        <td>2026-00415</td>
+        <td>Ayu Lestari</td>
+        <td>Klinik Harapan</td>
+        <td><span class="tag purple">Referred Out</span><span class="tag purple">Referred (all samples)</span></td>
+        <td>1 of 1</td>
+      </tr>
+      <tr>
+        <td>2026-00416</td>
+        <td>Dewi Sartika</td>
+        <td>Puskesmas Setiabudi</td>
+        <td><span class="tag blue">Labeling</span><span class="tag purple">Referred (1 of 3 samples)</span></td>
+        <td>1 of 3</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="muted" style="margin-top:2rem;font-size:0.75rem;">
+    OpenELIS Sample Collection Redesign — Referral Out addendum preview v2.1 (2026-04-23).
+    FRS: sample-collection-referral-addendum-frs-v2.1.md.
+    Mockup source: sample-collection-referral-addendum-mockup.jsx (Carbon React).
+  </p>
+
+</div>
+
 </body>
 </html>

--- a/designs/sample-collection/sample-collection-referral-addendum.jsx
+++ b/designs/sample-collection/sample-collection-referral-addendum.jsx
@@ -1,481 +1,725 @@
-import React, { useState, useMemo, useCallback } from 'react';
+/**
+ * OpenELIS Sample Collection Redesign — Addendum Mockup
+ * Step 3 (Label & Store) with Refer Out integrated alongside Print Labels and Storage Assignment
+ *
+ * Design model: SAMPLE-LEVEL referral.
+ *   - One row per physical sample (not per test).
+ *   - Tests on each sample shown as Carbon Tags within the row.
+ *   - Referring a sample carries every test on it to the same external lab.
+ *   - Per-test referral inside a single sample is blocked by design (BR-REF-7).
+ *
+ * Source FRS: sample-collection-referral-addendum-frs-v2.1.md
+ *   LBL-5…LBL-14, REF-1…REF-8, DSH-10…DSH-13, BR-REF-1…BR-REF-7
+ *
+ * Uses @carbon/react (Carbon v11) and @carbon/icons-react.
+ * Constitution principle 3: inline row expansion for non-destructive actions; modal only for bulk.
+ */
+
+import React, { useMemo, useState } from 'react';
 import {
-  Grid, Column, Stack,
-  DataTable, TableContainer, Table, TableHead, TableRow, TableHeader,
-  TableBody, TableCell, TableToolbar, TableToolbarContent,
-  TextInput, TextArea, ComboBox, DatePicker, DatePickerInput, Checkbox,
-  Button, OverflowMenu, OverflowMenuItem,
-  InlineNotification, Tag, Modal, Tile,
-  ProgressIndicator, ProgressStep,
-  Breadcrumb, BreadcrumbItem,
+  Accordion,
+  AccordionItem,
+  Button,
+  Checkbox,
+  ComboBox,
+  DataTable,
+  DatePicker,
+  DatePickerInput,
+  Dropdown,
+  InlineNotification,
+  Modal,
+  NumberInput,
+  OverflowMenu,
+  OverflowMenuItem,
+  Tag,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+  TableToolbar,
+  TableToolbarContent,
+  TextArea,
+  TextInput,
+  Tile,
+  Tooltip,
 } from '@carbon/react';
-import { Renew, ArrowRight, CheckmarkFilled, WarningAlt, Close } from '@carbon/icons-react';
-
-// i18n helper — real impl wires to localization provider
-const t = (key, fallback) => fallback || key;
+import {
+  Add,
+  ChevronDown,
+  ChevronUp,
+  Printer,
+  Send,
+  ArrowRight,
+  Undo,
+  Warning,
+} from '@carbon/icons-react';
 
 // ---------------------------------------------------------------------------
-// Mock data
+// Mock data — Indonesian VL / ENV context
 // ---------------------------------------------------------------------------
+
 const REFERRING_LABS = [
-  { id: 'lab-01', text: 'Balai Besar Teknik Kesehatan Lingkungan (BBTKL) Jakarta', fhirEnabled: true },
-  { id: 'lab-02', text: 'Laboratorium Kesehatan Daerah — Yogyakarta', fhirEnabled: true },
-  { id: 'lab-03', text: 'Eijkman Institute — Molecular Reference Lab', fhirEnabled: false },
-  { id: 'lab-04', text: 'National Reference Laboratory — Antananarivo', fhirEnabled: true },
+  { id: 'lab-bbtkl-jkt', name: 'BBTKL Jakarta', fhirEnabled: true,  tat: '5 days' },
+  { id: 'lab-eijkman',   name: 'Eijkman Institute', fhirEnabled: true,  tat: '3 days' },
+  { id: 'lab-prodia',    name: 'Prodia Reference Lab', fhirEnabled: false, tat: '7 days' },
+  { id: 'lab-silnas',    name: 'SILNAS Bandung', fhirEnabled: true,  tat: '4 days' },
 ];
 
-const INITIAL_ROWS = [
-  { id: 'r1', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412', storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Viral Load (PCR)', referralState: 'inhouse' },
-  { id: 'r2', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412', storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Drug Resistance Genotyping', referralState: 'inhouse' },
-  { id: 'r3', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412', storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis B DNA Quantitative', referralState: 'inhouse' },
-  { id: 'r4', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412', storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis C RNA Quantitative', referralState: 'inhouse' },
+const ORDER = {
+  labNumber: '2026-00412',
+  patientName: 'Siti Rahayu',
+  patientId: 'P-88103',
+  facility: 'Puskesmas Kebayoran',
+  priority: 'Routine',
+  collectedAt: '2026-04-22 09:14',
+};
+
+// One row per physical sample. Tests carried as chip list.
+const INITIAL_SAMPLES = [
+  {
+    id: 'S.2026-00412.1',
+    type: 'Whole Blood (EDTA)',
+    quantity: '4 mL',
+    collectedAt: '2026-04-22 09:14',
+    tests: [
+      { code: 'VL',       name: 'HIV Viral Load' },
+      { code: 'CD4',      name: 'CD4 Count' },
+    ],
+    storage: { freezer: 'F-02', shelf: 'S-3', box: 'B-14', position: 'A4' },
+    labelsToPrint: 2,
+    referral: null,
+  },
+  {
+    id: 'S.2026-00412.2',
+    type: 'Plasma',
+    quantity: '2 mL',
+    collectedAt: '2026-04-22 09:18',
+    tests: [
+      { code: 'HBVDNA',   name: 'Hepatitis B DNA PCR' },
+      { code: 'HCV_AB',   name: 'HCV Antibody' },
+    ],
+    storage: { freezer: 'F-04', shelf: 'S-1', box: 'B-07', position: 'C2' },
+    labelsToPrint: 1,
+    referral: null,
+  },
 ];
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-function statusTag(state, labName, onRetry) {
-  if (state === 'inhouse') return <Tag type="gray">{t('label.sampleCollection.referOut.inhouse', 'In-house')}</Tag>;
-  if (state === 'referred') return <Tag type="purple">{t('label.sampleCollection.referOut.referredTo', 'Referred — ') + labName}</Tag>;
-  if (state === 'sent') return <Tag type="blue">{t('label.sampleCollection.referOut.awaitingExternal', 'Awaiting External Results')}</Tag>;
-  if (state === 'failed') {
-    return (
-      <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.5rem' }}>
-        <Tag type="red">{t('label.sampleCollection.referOut.sendFailed', 'Send Failed — Retry')}</Tag>
-        <Button kind="ghost" size="sm" renderIcon={Renew} onClick={onRetry}>
-          {t('label.sampleCollection.referOut.action.retry', 'Retry Send')}
-        </Button>
-      </span>
-    );
-  }
-  return null;
-}
 
-function deriveOrderStatus(rows) {
-  const active = rows.filter(r => !r.voided);
-  const referredCount = active.filter(r => r.referralState !== 'inhouse').length;
-  const total = active.length;
-  if (total === 0) return 'LABELING';
-  if (referredCount === total) return 'REFERRED_OUT';
-  return 'LABELING';
-}
+const statusTag = (referral) => {
+  if (!referral) return <Tag type="gray">In-house</Tag>;
+  if (referral.state === 'REFERRED')  return <Tag type="purple">Referred — {referral.labName}</Tag>;
+  if (referral.state === 'SENT')      return <Tag type="blue">Sent to External — {referral.labName}</Tag>;
+  if (referral.state === 'AWAITING')  return <Tag type="blue">Awaiting External Results — {referral.labName}</Tag>;
+  if (referral.state === 'SEND_FAIL') return <Tag type="red">Send Failed — Retry</Tag>;
+  return <Tag type="gray">In-house</Tag>;
+};
 
-function headerStatusBadge(orderStatus, rows) {
-  if (orderStatus === 'REFERRED_OUT') {
-    return <Tag type="purple" size="md">{t('label.sampleCollection.referOut.status.fullyReferred', 'Referred Out')}</Tag>;
-  }
-  const referredCount = rows.filter(r => r.referralState !== 'inhouse').length;
-  const total = rows.length;
-  if (referredCount > 0) {
-    return (
-      <Tag type="purple" size="md">
-        {t('label.sampleCollection.referOut.contextCard.referredPartial',
-           `Referred (${referredCount} of ${total})`)}
-      </Tag>
-    );
-  }
-  return <Tag type="blue" size="md">Labeling</Tag>;
-}
+const countReferredSamples = (samples) =>
+  samples.filter(s => s.referral && s.referral.state !== 'VOIDED').length;
+
+const countInHouseSamples = (samples) =>
+  samples.filter(s => !s.referral || s.referral.state === 'VOIDED').length;
+
+const flattenInHouseTests = (samples) =>
+  samples
+    .filter(s => !s.referral || s.referral.state === 'VOIDED')
+    .flatMap(s => s.tests);
 
 // ---------------------------------------------------------------------------
-// Per-row referral form (inline expansion)
+// Per-sample inline refer-out form (LBL-6)
 // ---------------------------------------------------------------------------
-function InlineReferForm({ row, onSave, onCancel, xoaEnabled }) {
-  const [referringLabId, setReferringLabId] = useState(null);
+
+function InlineReferSampleForm({ sample, onCancel, onSave }) {
+  const [labId, setLabId]   = useState(null);
   const [reason, setReason] = useState('');
-  const [expectedReturn, setExpectedReturn] = useState(null);
-  const [notifyCustomer, setNotifyCustomer] = useState(true);
-  const [error, setError] = useState(null);
-
-  const save = () => {
-    if (!referringLabId) {
-      setError(t('error.referOut.noReferringLab', 'Select a referring lab before saving.'));
-      return;
-    }
-    const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-    onSave({ rowId: row.id, lab, reason, expectedReturn, notifyCustomer });
-  };
+  const [expected, setExpected] = useState('');
+  const [notify, setNotify] = useState(true);
+  const labObj = REFERRING_LABS.find(l => l.id === labId) || null;
 
   return (
-    <Tile style={{ padding: '1rem', backgroundColor: 'var(--cds-layer-02)' }}>
-      <Stack gap={5}>
-        <h5 style={{ margin: 0 }}>
-          {t('label.sampleCollection.referOut.action.refer', 'Refer Out')} — {row.test}
-        </h5>
-        {error && (
-          <InlineNotification
-            kind="error"
-            lowContrast
-            title={error}
-            hideCloseButton
+    <div style={{ padding: '1rem 1.5rem', background: '#f4f4f4', borderLeft: '4px solid #8a3ffc' }}>
+      <h5 style={{ marginBottom: '0.75rem' }}>
+        Refer Sample to External Lab
+      </h5>
+
+      <InlineNotification
+        kind="info"
+        lowContrast
+        hideCloseButton
+        title="Sample-level referral"
+        subtitle={`This will refer ${sample.type} (${sample.id}) and all ${sample.tests.length} tests on it: ${sample.tests.map(t => t.name).join(', ')}.`}
+        style={{ marginBottom: '1rem', maxWidth: '100%' }}
+      />
+
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' }}>
+        <ComboBox
+          id={`refer-lab-${sample.id}`}
+          titleText="Referring Lab (required)"
+          placeholder="Search external labs…"
+          items={REFERRING_LABS}
+          itemToString={(item) => (item ? item.name : '')}
+          onChange={({ selectedItem }) => setLabId(selectedItem ? selectedItem.id : null)}
+        />
+        <DatePicker datePickerType="single" onChange={(d) => setExpected(d?.[0]?.toISOString?.() || '')}>
+          <DatePickerInput
+            id={`refer-expected-${sample.id}`}
+            labelText="Expected Return Date (optional)"
+            placeholder="yyyy-mm-dd"
           />
-        )}
-        <Grid narrow>
-          <Column sm={4} md={4} lg={8}>
-            <ComboBox
-              id={`referring-lab-${row.id}`}
-              titleText={t('label.sampleCollection.referOut.form.referringLab', 'Referring Lab') + ' *'}
-              placeholder="Search referring labs…"
-              items={REFERRING_LABS}
-              itemToString={(item) => (item ? item.text : '')}
-              selectedItem={REFERRING_LABS.find(l => l.id === referringLabId) || null}
-              onChange={({ selectedItem }) => setReferringLabId(selectedItem ? selectedItem.id : null)}
-            />
-          </Column>
-          <Column sm={4} md={4} lg={4}>
-            <DatePicker datePickerType="single" onChange={(d) => setExpectedReturn(d[0])}>
-              <DatePickerInput
-                id={`expected-return-${row.id}`}
-                labelText={t('label.sampleCollection.referOut.form.expectedReturn', 'Expected Return Date')}
-                placeholder="mm/dd/yyyy"
-              />
-            </DatePicker>
-          </Column>
-          <Column sm={4} md={8} lg={8}>
-            <TextArea
-              id={`reason-${row.id}`}
-              labelText={t('label.sampleCollection.referOut.form.reason', 'Reason (optional)')}
-              rows={2}
-              maxCount={500}
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-            />
-          </Column>
-          {xoaEnabled && (
-            <Column sm={4} md={8} lg={8}>
-              <Checkbox
-                id={`notify-${row.id}`}
-                labelText={t('label.sampleCollection.referOut.form.notifyCustomer', 'Notify customer of referral')}
-                checked={notifyCustomer}
-                onChange={(_, { checked }) => setNotifyCustomer(checked)}
-              />
-            </Column>
-          )}
-        </Grid>
-        <Stack orientation="horizontal" gap={3}>
-          <Button kind="primary" size="sm" onClick={save}>
-            {t('button.save', 'Save Referral')}
-          </Button>
-          <Button kind="ghost" size="sm" onClick={onCancel}>
-            {t('button.cancel', 'Cancel')}
-          </Button>
-        </Stack>
-      </Stack>
-    </Tile>
+        </DatePicker>
+      </div>
+
+      <TextArea
+        id={`refer-reason-${sample.id}`}
+        labelText="Reason (optional)"
+        maxLength={500}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        style={{ marginTop: '1rem' }}
+      />
+
+      <Checkbox
+        id={`refer-notify-${sample.id}`}
+        labelText="Notify customer of referral (X-01 REFERRAL_OUT event)"
+        checked={notify}
+        onChange={(_, { checked }) => setNotify(checked)}
+        style={{ marginTop: '0.75rem' }}
+      />
+
+      <div style={{ marginTop: '1rem', display: 'flex', gap: '0.5rem' }}>
+        <Button
+          kind="primary"
+          renderIcon={Send}
+          disabled={!labId}
+          onClick={() => onSave({
+            labId,
+            labName: labObj?.name,
+            reason,
+            expected,
+            notify,
+            fhirEnabled: !!labObj?.fhirEnabled,
+          })}
+        >
+          Save Referral
+        </Button>
+        <Button kind="ghost" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Bulk Refer Out modal
+// Bulk refer-out modal (LBL-7)
 // ---------------------------------------------------------------------------
-function BulkReferModal({ open, onClose, onConfirm, pendingRows, xoaEnabled }) {
-  const [referringLabId, setReferringLabId] = useState(null);
+
+function BulkReferModal({ open, samples, onClose, onConfirm }) {
+  const [labId, setLabId] = useState(null);
   const [reason, setReason] = useState('');
-  const [expectedReturn, setExpectedReturn] = useState(null);
-  const [notifyCustomer, setNotifyCustomer] = useState(true);
+  const [expected, setExpected] = useState('');
+  const [notify, setNotify] = useState(true);
 
-  const sampleCount = useMemo(() => new Set(pendingRows.map(r => r.sampleId)).size, [pendingRows]);
-  const testCount = pendingRows.length;
-  const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-
-  const reset = () => {
-    setReferringLabId(null);
-    setReason('');
-    setExpectedReturn(null);
-    setNotifyCustomer(true);
-  };
-
-  const handleConfirm = () => {
-    if (!referringLabId) return;
-    onConfirm({ lab, reason, expectedReturn, notifyCustomer });
-    reset();
-  };
+  const inHouseSamples = samples.filter(s => !s.referral || s.referral.state === 'VOIDED');
+  const labObj = REFERRING_LABS.find(l => l.id === labId) || null;
+  const sampleCount = inHouseSamples.length;
+  const testCount   = inHouseSamples.reduce((sum, s) => sum + s.tests.length, 0);
+  const sampleListText = inHouseSamples.map(s => `${s.type} (${s.id})`).join(', ');
 
   return (
     <Modal
       open={open}
-      onRequestClose={() => { reset(); onClose(); }}
-      modalHeading={t('label.sampleCollection.referOut.bulk.modalTitle', 'Refer All Tests to External Lab')}
-      primaryButtonText={t('button.confirmReferral', 'Refer All')}
-      secondaryButtonText={t('button.cancel', 'Cancel')}
-      onRequestSubmit={handleConfirm}
-      primaryButtonDisabled={!referringLabId || testCount === 0}
-      size="md"
+      modalHeading="Refer All In-House Samples to External Lab"
+      primaryButtonText="Refer All"
+      secondaryButtonText="Cancel"
+      primaryButtonDisabled={!labId || sampleCount === 0}
+      onRequestClose={onClose}
+      onRequestSubmit={() => onConfirm({
+        labId,
+        labName: labObj?.name,
+        reason,
+        expected,
+        notify,
+        fhirEnabled: !!labObj?.fhirEnabled,
+      })}
     >
-      {testCount === 0 ? (
-        <InlineNotification
-          kind="info"
-          lowContrast
-          title={t('error.referOut.bulkNoTests',
-            'No in-house tests to refer. All tests on this order are already referred.')}
-          hideCloseButton
-        />
-      ) : (
-        <Stack gap={5}>
-          <ComboBox
-            id="bulk-referring-lab"
-            titleText={t('label.sampleCollection.referOut.form.referringLab', 'Referring Lab') + ' *'}
-            placeholder="Search referring labs…"
-            items={REFERRING_LABS}
-            itemToString={(item) => (item ? item.text : '')}
-            selectedItem={lab || null}
-            onChange={({ selectedItem }) => setReferringLabId(selectedItem ? selectedItem.id : null)}
-          />
-          <DatePicker datePickerType="single" onChange={(d) => setExpectedReturn(d[0])}>
-            <DatePickerInput
-              id="bulk-expected-return"
-              labelText={t('label.sampleCollection.referOut.form.expectedReturn', 'Expected Return Date')}
-              placeholder="mm/dd/yyyy"
-            />
-          </DatePicker>
-          <TextArea
-            id="bulk-reason"
-            labelText={t('label.sampleCollection.referOut.form.reason', 'Reason (optional)')}
-            rows={3}
-            maxCount={500}
-            value={reason}
-            onChange={(e) => setReason(e.target.value)}
-          />
-          {xoaEnabled && (
-            <Checkbox
-              id="bulk-notify"
-              labelText={t('label.sampleCollection.referOut.form.notifyCustomer', 'Notify customer of referral')}
-              checked={notifyCustomer}
-              onChange={(_, { checked }) => setNotifyCustomer(checked)}
-            />
-          )}
-          <InlineNotification
-            kind="warning"
-            lowContrast
-            title={t('label.sampleCollection.referOut.bulk.preview',
-              `This will refer ${testCount} test${testCount === 1 ? '' : 's'} on ${sampleCount} sample${sampleCount === 1 ? '' : 's'}${lab ? ` to ${lab.text}` : ''}.`)}
-            subtitle={lab && !lab.fhirEnabled
-              ? 'This lab is paper/manifest only — no FHIR transmission will occur.'
-              : lab
-              ? 'FHIR ServiceRequest will be transmitted to the receiving lab.'
-              : 'Select a referring lab to see transmission details.'}
-            hideCloseButton
-          />
-        </Stack>
-      )}
+      <InlineNotification
+        kind={sampleCount === 0 ? 'warning' : 'info'}
+        lowContrast
+        hideCloseButton
+        title={sampleCount === 0 ? 'Nothing to refer' : `${sampleCount} samples / ${testCount} tests`}
+        subtitle={sampleCount === 0
+          ? 'All samples on this order are already referred.'
+          : `This will refer ${sampleListText} and every test on them to the selected lab. Every physical specimen moves to the external site.`}
+        style={{ marginBottom: '1rem' }}
+      />
+
+      <ComboBox
+        id="bulk-refer-lab"
+        titleText="Referring Lab (required)"
+        placeholder="Search external labs…"
+        items={REFERRING_LABS}
+        itemToString={(item) => (item ? `${item.name}${item.fhirEnabled ? ' (FHIR)' : ''} • TAT ${item.tat}` : '')}
+        onChange={({ selectedItem }) => setLabId(selectedItem ? selectedItem.id : null)}
+      />
+
+      <DatePicker datePickerType="single" onChange={(d) => setExpected(d?.[0]?.toISOString?.() || '')} style={{ marginTop: '1rem' }}>
+        <DatePickerInput id="bulk-refer-expected" labelText="Expected Return Date (optional)" placeholder="yyyy-mm-dd" />
+      </DatePicker>
+
+      <TextArea
+        id="bulk-refer-reason"
+        labelText="Reason (optional)"
+        maxLength={500}
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        style={{ marginTop: '1rem' }}
+      />
+
+      <Checkbox
+        id="bulk-refer-notify"
+        labelText="Notify customer of referral (one REFERRAL_OUT event per sample)"
+        checked={notify}
+        onChange={(_, { checked }) => setNotify(checked)}
+        style={{ marginTop: '0.75rem' }}
+      />
     </Modal>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Main Step 3 — Label & Store with Refer Out
+// Step 3 — Samples table (sample-centric rows, inline storage + refer out)
 // ---------------------------------------------------------------------------
-export default function LabelStoreWithReferOut() {
-  const [rows, setRows] = useState(INITIAL_ROWS);
-  const [expandedRowId, setExpandedRowId] = useState(null);
-  const [bulkOpen, setBulkOpen] = useState(false);
-  const [notification, setNotification] = useState(null);
 
-  // In real app this comes from lab-unit config + global X-01 trigger state
-  const xoaEnabled = true;
-  const allowBulkReferOut = true;
-
-  const orderStatus = useMemo(() => deriveOrderStatus(rows), [rows]);
-  const pendingInhouseRows = useMemo(() => rows.filter(r => r.referralState === 'inhouse'), [rows]);
-
-  const toggleExpand = (rowId) => setExpandedRowId(prev => prev === rowId ? null : rowId);
-
-  const savePerRowReferral = useCallback(({ rowId, lab, reason, expectedReturn, notifyCustomer }) => {
-    setRows(prev => prev.map(r =>
-      r.id === rowId
-        ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-            reason, expectedReturn, notifyCustomer }
-        : r
-    ));
-    setExpandedRowId(null);
-    setNotification({ kind: 'success',
-      title: t('label.sampleCollection.referOut.notification.success', `Referred 1 test to ${lab.text}.`) });
-    setTimeout(() => setNotification(null), 5000);
-  }, []);
-
-  const confirmBulk = useCallback(({ lab, reason, expectedReturn, notifyCustomer }) => {
-    const pendingIds = rows.filter(r => r.referralState === 'inhouse').map(r => r.id);
-    setRows(prev => prev.map(r =>
-      pendingIds.includes(r.id)
-        ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-            reason, expectedReturn, notifyCustomer }
-        : r
-    ));
-    setBulkOpen(false);
-    setNotification({ kind: 'success',
-      title: t('label.sampleCollection.referOut.notification.success',
-        `Referred ${pendingIds.length} tests to ${lab.text}.`) });
-    setTimeout(() => setNotification(null), 5000);
-  }, [rows]);
-
-  const undoReferral = (rowId) => {
-    setRows(prev => prev.map(r => r.id === rowId ? {
-      ...r, referralState: 'inhouse', referringLab: null, fhirEnabled: null,
-      reason: null, expectedReturn: null, notifyCustomer: null
-    } : r));
-    setNotification({ kind: 'info', title: 'Referral undone. Test returned to in-house queue.' });
-    setTimeout(() => setNotification(null), 4000);
-  };
-
-  const retryFhirSend = (rowId) => {
-    setRows(prev => prev.map(r => r.id === rowId ? { ...r, referralState: 'sent' } : r));
-  };
-
-  const headers = [
-    { key: 'sampleId', header: 'Sample' },
-    { key: 'sampleType', header: 'Type' },
-    { key: 'storage', header: 'Storage' },
-    { key: 'test', header: 'Test' },
-    { key: 'referOut', header: 'Refer Out' },
-    { key: 'actions', header: '' },
-  ];
+function SamplesTable({ samples, onReferSample, onUndoReferral, onEditStorage, onPrintLabel }) {
+  const [expandedId, setExpandedId] = useState(null);
 
   return (
-    <div style={{ padding: 'var(--cds-spacing-06)', maxWidth: '1440px', margin: '0 auto' }}>
-      <Stack gap={6}>
-        {/* Breadcrumb */}
-        <Breadcrumb noTrailingSlash>
-          <BreadcrumbItem href="#">Add Order</BreadcrumbItem>
-          <BreadcrumbItem href="#">Order 2026-00412</BreadcrumbItem>
-          <BreadcrumbItem isCurrentPage>Label & Store</BreadcrumbItem>
-        </Breadcrumb>
+    <TableContainer
+      title="Samples"
+      description="One row per physical sample. Tests on each sample travel together."
+    >
+      <Table size="md" useZebraStyles>
+        <TableHead>
+          <TableRow>
+            <TableHeader />
+            <TableHeader>Sample ID</TableHeader>
+            <TableHeader>Type / Qty</TableHeader>
+            <TableHeader>Tests on this sample</TableHeader>
+            <TableHeader>Storage Location</TableHeader>
+            <TableHeader>Labels</TableHeader>
+            <TableHeader>Refer Out</TableHeader>
+            <TableHeader />
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {samples.map((s) => {
+            const isReferred = !!s.referral && s.referral.state !== 'VOIDED';
+            const canUndo    = isReferred && s.referral.state === 'REFERRED';
+            const storageStr = `${s.storage.freezer} / ${s.storage.shelf} / ${s.storage.box} / ${s.storage.position}`;
 
-        {/* Progress stepper */}
-        <ProgressIndicator currentIndex={2}>
-          <ProgressStep complete label="Enter Order" />
-          <ProgressStep complete label="Collect Sample" />
-          <ProgressStep current label="Label & Store" />
-          <ProgressStep label={orderStatus === 'REFERRED_OUT' ? 'QA Review (skipped — fully referred)' : 'QA Review'}
-            disabled={orderStatus === 'REFERRED_OUT'} />
-        </ProgressIndicator>
+            return (
+              <React.Fragment key={s.id}>
+                <TableRow>
+                  <TableCell>
+                    <Button
+                      kind="ghost"
+                      size="sm"
+                      hasIconOnly
+                      iconDescription={expandedId === s.id ? 'Collapse' : 'Expand'}
+                      renderIcon={expandedId === s.id ? ChevronUp : ChevronDown}
+                      onClick={() => setExpandedId(expandedId === s.id ? null : s.id)}
+                    />
+                  </TableCell>
+                  <TableCell>
+                    <strong>{s.id}</strong>
+                    <br />
+                    <span style={{ fontSize: '0.75rem', color: '#525252' }}>
+                      Collected {s.collectedAt}
+                    </span>
+                  </TableCell>
+                  <TableCell>
+                    {s.type}
+                    <br />
+                    <span style={{ fontSize: '0.75rem', color: '#525252' }}>{s.quantity}</span>
+                  </TableCell>
+                  <TableCell>
+                    {s.tests.map((t) => (
+                      <Tag key={t.code} type={isReferred ? 'purple' : 'cyan'} size="sm">
+                        {t.name}
+                      </Tag>
+                    ))}
+                  </TableCell>
+                  <TableCell>
+                    <Button kind="ghost" size="sm" onClick={() => onEditStorage(s.id)}>
+                      {storageStr}
+                    </Button>
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      kind="ghost"
+                      size="sm"
+                      renderIcon={Printer}
+                      onClick={() => onPrintLabel(s.id)}
+                    >
+                      Print ({s.labelsToPrint})
+                    </Button>
+                  </TableCell>
+                  <TableCell>{statusTag(s.referral)}</TableCell>
+                  <TableCell>
+                    <OverflowMenu flipped aria-label={`Actions for ${s.id}`}>
+                      {!isReferred && (
+                        <OverflowMenuItem
+                          itemText="Refer Out Sample…"
+                          onClick={() => setExpandedId(s.id)}
+                        />
+                      )}
+                      {canUndo && (
+                        <OverflowMenuItem
+                          itemText="Undo Referral"
+                          isDelete
+                          onClick={() => onUndoReferral(s.id)}
+                        />
+                      )}
+                      <OverflowMenuItem
+                        itemText="Edit Storage Location"
+                        onClick={() => onEditStorage(s.id)}
+                      />
+                      <OverflowMenuItem
+                        itemText="Reprint Label"
+                        onClick={() => onPrintLabel(s.id)}
+                      />
+                    </OverflowMenu>
+                  </TableCell>
+                </TableRow>
 
-        {/* Order Context Card */}
-        <Tile style={{ padding: 'var(--cds-spacing-05)' }}>
-          <Grid narrow>
-            <Column sm={4} md={2} lg={3}>
-              <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>Lab Number</div>
-              <div style={{ fontSize: '1.25rem', fontWeight: 600 }}>2026-00412</div>
-            </Column>
-            <Column sm={4} md={3} lg={4}>
-              <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>Patient</div>
-              <div style={{ fontWeight: 500 }}>Ibu Sari Wulandari</div>
-              <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>F · 34 · NIK 3174012345678901</div>
-            </Column>
-            <Column sm={4} md={2} lg={3}>
-              <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>Tests</div>
-              <div>{rows.length} tests on {new Set(rows.map(r => r.sampleId)).size} samples</div>
-            </Column>
-            <Column sm={4} md={3} lg={6}>
-              <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>Status</div>
-              <Stack orientation="horizontal" gap={2} style={{ marginTop: '0.25rem' }}>
-                {headerStatusBadge(orderStatus, rows)}
-              </Stack>
-            </Column>
-          </Grid>
-        </Tile>
+                {expandedId === s.id && !isReferred && (
+                  <TableRow>
+                    <TableCell colSpan={8} style={{ padding: 0 }}>
+                      <InlineReferSampleForm
+                        sample={s}
+                        onCancel={() => setExpandedId(null)}
+                        onSave={(payload) => {
+                          onReferSample(s.id, payload);
+                          setExpandedId(null);
+                        }}
+                      />
+                    </TableCell>
+                  </TableRow>
+                )}
 
-        {notification && (
-          <InlineNotification
-            kind={notification.kind}
-            lowContrast
-            title={notification.title}
-            onClose={() => setNotification(null)}
-          />
-        )}
+                {expandedId === s.id && isReferred && (
+                  <TableRow>
+                    <TableCell colSpan={8} style={{ background: '#f4f4f4', padding: '0.75rem 1.5rem' }}>
+                      <strong>Referral details:</strong>{' '}
+                      Referred to <em>{s.referral.labName}</em>
+                      {s.referral.expected ? ` — expected back ${new Date(s.referral.expected).toISOString().slice(0, 10)}` : ''}
+                      {s.referral.reason ? ` — reason: "${s.referral.reason}"` : ''}.
+                      <br />
+                      <span style={{ fontSize: '0.75rem', color: '#525252' }}>
+                        {s.tests.length} test{s.tests.length === 1 ? '' : 's'} ({s.tests.map(t => t.name).join(', ')}) carried with this specimen.
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
 
-        {orderStatus === 'REFERRED_OUT' && (
-          <InlineNotification
-            kind="info"
-            lowContrast
-            hideCloseButton
-            title="Order fully referred out"
-            subtitle="All tests on this order are referred to an external lab. Step 4 QA Review is skipped — the order will complete when external results return via referral result entry."
-          />
-        )}
+// ---------------------------------------------------------------------------
+// Print Labels section (LBL-2 — preserved)
+// ---------------------------------------------------------------------------
 
-        {/* Samples & Tests table */}
-        <TableContainer
-          title="Samples & Tests"
-          description="Assign storage location, print labels, and refer individual tests or the whole order to an external lab."
-        >
-          <TableToolbar>
-            <TableToolbarContent>
-              <Button kind="secondary"
-                renderIcon={ArrowRight}
-                disabled={!allowBulkReferOut || pendingInhouseRows.length === 0}
-                onClick={() => setBulkOpen(true)}>
-                {t('label.sampleCollection.referOut.bulk.button', 'Bulk Refer Out')}
-                {pendingInhouseRows.length > 0 && ` (${pendingInhouseRows.length})`}
-              </Button>
-              <Button kind="primary">Save & Next</Button>
-            </TableToolbarContent>
-          </TableToolbar>
-          <Table>
-            <TableHead>
-              <TableRow>
-                {headers.map(h => <TableHeader key={h.key}>{h.header}</TableHeader>)}
-              </TableRow>
-            </TableHead>
-            <TableBody>
-              {rows.map(row => {
-                const isExpanded = expandedRowId === row.id;
-                return (
-                  <React.Fragment key={row.id}>
-                    <TableRow>
-                      <TableCell><code>{row.sampleId}</code></TableCell>
-                      <TableCell>{row.sampleType}</TableCell>
-                      <TableCell><span style={{ fontSize: '0.75rem' }}>{row.storage}</span></TableCell>
-                      <TableCell>{row.test}</TableCell>
-                      <TableCell>
-                        {statusTag(row.referralState, row.referringLab, () => retryFhirSend(row.id))}
-                      </TableCell>
-                      <TableCell>
-                        <OverflowMenu size="sm" flipped aria-label={`Actions for ${row.test}`}>
-                          {row.referralState === 'inhouse' && (
-                            <OverflowMenuItem
-                              itemText={t('label.sampleCollection.referOut.action.refer', 'Refer Out')}
-                              onClick={() => toggleExpand(row.id)}
-                            />
-                          )}
-                          {row.referralState === 'referred' && (
-                            <OverflowMenuItem
-                              itemText={t('label.sampleCollection.referOut.action.undo', 'Undo Referral')}
-                              hasDivider
-                              onClick={() => undoReferral(row.id)}
-                            />
-                          )}
-                          <OverflowMenuItem itemText="Edit Storage" />
-                          <OverflowMenuItem itemText="Print Label" />
-                        </OverflowMenu>
-                      </TableCell>
-                    </TableRow>
-                    {isExpanded && (
-                      <TableRow>
-                        <TableCell colSpan={headers.length} style={{ padding: 0 }}>
-                          <InlineReferForm
-                            row={row}
-                            xoaEnabled={xoaEnabled}
-                            onCancel={() => setExpandedRowId(null)}
-                            onSave={savePerRowReferral}
-                          />
-                        </TableCell>
-                      </TableRow>
-                    )}
-                  </React.Fragment>
-                );
-              })}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Stack>
+function PrintLabelsSection({ samples, onPrintBatch }) {
+  const [orderQty, setOrderQty]     = useState(1);
+  const [sampleQty, setSampleQty]   = useState(1);
+  const [slideQty, setSlideQty]     = useState(0);
+  const [blockQty, setBlockQty]     = useState(0);
+  const [freezerQty, setFreezerQty] = useState(0);
+
+  return (
+    <Tile style={{ marginBottom: '1rem' }}>
+      <Accordion>
+        <AccordionItem title="Print Labels (LBL-2)">
+          <p style={{ fontSize: '0.875rem', color: '#525252', marginBottom: '1rem' }}>
+            Labels travel with specimens — including referred ones. Keep label quantity ≥ 1 for any sample being shipped externally.
+          </p>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: '1rem' }}>
+            <NumberInput id="lbl-order"   label="Order Label"   min={0} max={20} value={orderQty}   onChange={(_, { value }) => setOrderQty(value)} />
+            <NumberInput id="lbl-sample"  label="Sample Label"  min={0} max={20} value={sampleQty}  onChange={(_, { value }) => setSampleQty(value)} />
+            <NumberInput id="lbl-slide"   label="Slide Label"   min={0} max={20} value={slideQty}   onChange={(_, { value }) => setSlideQty(value)} />
+            <NumberInput id="lbl-block"   label="Block Label"   min={0} max={20} value={blockQty}   onChange={(_, { value }) => setBlockQty(value)} />
+            <NumberInput id="lbl-freezer" label="Freezer Label" min={0} max={20} value={freezerQty} onChange={(_, { value }) => setFreezerQty(value)} />
+          </div>
+          <Button
+            kind="secondary"
+            renderIcon={Printer}
+            onClick={() => onPrintBatch({ orderQty, sampleQty, slideQty, blockQty, freezerQty })}
+            style={{ marginTop: '1rem' }}
+          >
+            Print All Labels
+          </Button>
+        </AccordionItem>
+      </Accordion>
+    </Tile>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Context card with Referred chip (REF-8)
+// ---------------------------------------------------------------------------
+
+function OrderContextCard({ order, samples }) {
+  const referredCount = countReferredSamples(samples);
+  const totalCount = samples.length;
+  let referredChip = null;
+  if (referredCount > 0) {
+    referredChip = (
+      <Tag type="purple">
+        Referred {referredCount === totalCount ? '(all samples)' : `(${referredCount} of ${totalCount} samples)`}
+      </Tag>
+    );
+  }
+
+  return (
+    <Tile style={{ marginBottom: '1rem' }}>
+      <div style={{ display: 'flex', gap: '1.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+        <div><strong>Lab #</strong><br />{order.labNumber}</div>
+        <div><strong>Patient</strong><br />{order.patientName}</div>
+        <div><strong>Patient ID</strong><br />{order.patientId}</div>
+        <div><strong>Facility</strong><br />{order.facility}</div>
+        <div><strong>Priority</strong><br /><Tag type="teal">{order.priority}</Tag></div>
+        <div><strong>Samples</strong><br />{totalCount}</div>
+        {referredChip && <div>{referredChip}</div>}
+      </div>
+    </Tile>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Top-level Step 3 screen
+// ---------------------------------------------------------------------------
+
+export default function LabelStoreWithReferOut() {
+  const [samples, setSamples] = useState(INITIAL_SAMPLES);
+  const [bulkOpen, setBulkOpen] = useState(false);
+  const [toast, setToast] = useState(null);
+
+  const referredCount = countReferredSamples(samples);
+  const totalCount = samples.length;
+  const inHouseCount = countInHouseSamples(samples);
+  const allReferred = referredCount === totalCount && totalCount > 0;
+
+  const referSample = (sampleId, payload) => {
+    setSamples(prev => prev.map(s => s.id === sampleId
+      ? { ...s, referral: { ...payload, state: payload.fhirEnabled ? 'SENT' : 'REFERRED' } }
+      : s
+    ));
+    setToast({
+      kind: 'success',
+      title: `Referred 1 sample (${samples.find(s => s.id === sampleId)?.tests.length} tests) to ${payload.labName}.`,
+      subtitle: 'X-01 REFERRAL_OUT event fired. Label and storage remain editable for logistics.',
+    });
+  };
+
+  const undoReferral = (sampleId) => {
+    setSamples(prev => prev.map(s => s.id === sampleId
+      ? { ...s, referral: null }
+      : s
+    ));
+    setToast({
+      kind: 'info',
+      title: 'Referral undone.',
+      subtitle: 'Sample restored to in-house pipeline.',
+    });
+  };
+
+  const bulkRefer = (payload) => {
+    setSamples(prev => prev.map(s => (!s.referral || s.referral.state === 'VOIDED')
+      ? { ...s, referral: { ...payload, state: payload.fhirEnabled ? 'SENT' : 'REFERRED' } }
+      : s
+    ));
+    setBulkOpen(false);
+    const refSampleCount = samples.filter(s => !s.referral).length;
+    const refTestCount   = flattenInHouseTests(samples).length;
+    setToast({
+      kind: 'success',
+      title: `Referred ${refSampleCount} samples (${refTestCount} tests) to ${payload.labName}.`,
+      subtitle: 'One REFERRAL_OUT event fired per sample.',
+    });
+  };
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '1400px', margin: '0 auto' }}>
+      <h2>Step 3 — Label &amp; Store</h2>
+      <p style={{ marginBottom: '1rem', color: '#525252' }}>
+        Print labels, assign storage, and refer samples to external labs.
+        Referrals are assigned per-sample — every test on a referred sample travels with the specimen.
+      </p>
+
+      <OrderContextCard order={ORDER} samples={samples} />
+
+      {toast && (
+        <InlineNotification
+          kind={toast.kind}
+          lowContrast
+          title={toast.title}
+          subtitle={toast.subtitle}
+          onCloseButtonClick={() => setToast(null)}
+          style={{ marginBottom: '1rem' }}
+        />
+      )}
+
+      {allReferred && (
+        <InlineNotification
+          kind="info"
+          lowContrast
+          hideCloseButton
+          title="All samples referred — QA will be skipped (REF-2, REF-3)."
+          subtitle="Order auto-transitions to REFERRED_OUT on save. The QA Review queue will not show this order."
+          style={{ marginBottom: '1rem' }}
+        />
+      )}
+
+      <PrintLabelsSection
+        samples={samples}
+        onPrintBatch={(cfg) => setToast({
+          kind: 'success',
+          title: 'Labels sent to printer.',
+          subtitle: `${cfg.orderQty} order, ${cfg.sampleQty} sample, ${cfg.slideQty} slide, ${cfg.blockQty} block, ${cfg.freezerQty} freezer`,
+        })}
+      />
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
+        <div style={{ fontSize: '0.875rem', color: '#525252' }}>
+          {inHouseCount} in-house sample{inHouseCount === 1 ? '' : 's'} • {referredCount} referred
+        </div>
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <Tooltip label={inHouseCount === 0 ? 'No in-house samples to refer.' : 'Refer all remaining in-house samples to one external lab.'}>
+            <Button
+              kind="tertiary"
+              renderIcon={Send}
+              disabled={inHouseCount === 0}
+              onClick={() => setBulkOpen(true)}
+            >
+              Bulk Refer Out
+            </Button>
+          </Tooltip>
+        </div>
+      </div>
+
+      <SamplesTable
+        samples={samples}
+        onReferSample={referSample}
+        onUndoReferral={undoReferral}
+        onEditStorage={(sampleId) => setToast({
+          kind: 'info',
+          title: `Edit Storage for ${sampleId}`,
+          subtitle: 'Inline storage assignment panel (LBL-3) opens here. Stays editable even after referral (BR-REF-4).',
+        })}
+        onPrintLabel={(sampleId) => setToast({
+          kind: 'success',
+          title: `Reprinted label for ${sampleId}`,
+          subtitle: 'Reprint allowed for referred samples (BR-REF-4).',
+        })}
+      />
 
       <BulkReferModal
         open={bulkOpen}
+        samples={samples}
         onClose={() => setBulkOpen(false)}
-        onConfirm={confirmBulk}
-        pendingRows={pendingInhouseRows}
-        xoaEnabled={xoaEnabled}
+        onConfirm={bulkRefer}
       />
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '2rem' }}>
+        <Button kind="secondary">← Back to Step 2 (Collect Sample)</Button>
+        <Button kind="primary" renderIcon={ArrowRight}>
+          {allReferred ? 'Close Order (Referred Out)' : 'Save & Next → Step 4 (QA Review)'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Secondary mockup — Dashboard filter row (DSH-10, DSH-11)
+// ---------------------------------------------------------------------------
+
+export function OrderDashboardPreview() {
+  const [referFilter, setReferFilter] = useState('any');
+
+  const MOCK_ORDERS = [
+    { lab: '2026-00412', patient: 'Siti Rahayu',     facility: 'Puskesmas Kebayoran', status: 'Labeling',     referred: 'partial', samples: '1 of 2' },
+    { lab: '2026-00413', patient: 'Budi Santoso',    facility: 'RS Cipto',            status: 'Referred Out', referred: 'full',    samples: '2 of 2' },
+    { lab: '2026-00414', patient: 'ENV-KBY-0412-01', facility: 'Kebayoran River',     status: 'QA Review',    referred: 'none',    samples: '0 of 3' },
+    { lab: '2026-00415', patient: 'Ayu Lestari',     facility: 'Klinik Harapan',      status: 'Referred Out', referred: 'full',    samples: '1 of 1' },
+    { lab: '2026-00416', patient: 'Dewi Sartika',    facility: 'Puskesmas Setiabudi', status: 'Labeling',     referred: 'partial', samples: '1 of 3' },
+  ];
+
+  const filtered = MOCK_ORDERS.filter(o => {
+    if (referFilter === 'any')  return true;
+    if (referFilter === 'has')  return o.referred !== 'none';
+    if (referFilter === 'full') return o.referred === 'full';
+    return true;
+  });
+
+  return (
+    <div style={{ padding: '2rem', maxWidth: '1200px', margin: '0 auto' }}>
+      <h3>Order Dashboard — Referred Out Filter (DSH-10, DSH-11)</h3>
+
+      <Dropdown
+        id="dsh-refer-filter"
+        titleText="Referred Out"
+        label="Any"
+        items={[
+          { id: 'any',  text: 'Any' },
+          { id: 'has',  text: 'Has Referred Samples' },
+          { id: 'full', text: 'Fully Referred Out' },
+        ]}
+        itemToString={(item) => (item ? item.text : '')}
+        onChange={({ selectedItem }) => setReferFilter(selectedItem?.id || 'any')}
+        style={{ maxWidth: '260px', marginBottom: '1rem' }}
+      />
+
+      <TableContainer>
+        <Table size="md">
+          <TableHead>
+            <TableRow>
+              <TableHeader>Lab #</TableHeader>
+              <TableHeader>Patient / Subject</TableHeader>
+              <TableHeader>Facility</TableHeader>
+              <TableHeader>Status</TableHeader>
+              <TableHeader>Referred Samples</TableHeader>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {filtered.map(o => (
+              <TableRow key={o.lab}>
+                <TableCell>{o.lab}</TableCell>
+                <TableCell>{o.patient}</TableCell>
+                <TableCell>{o.facility}</TableCell>
+                <TableCell>
+                  <Tag type={o.status === 'Referred Out' ? 'purple' : 'blue'}>{o.status}</Tag>
+                  {o.referred === 'partial' && <Tag type="purple" size="sm">Referred ({o.samples})</Tag>}
+                  {o.referred === 'full' && <Tag type="purple" size="sm">Referred (all samples)</Tag>}
+                </TableCell>
+                <TableCell>{o.samples}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
     </div>
   );
 }

--- a/designs/sample-collection/sample-collection-referral-addendum.md
+++ b/designs/sample-collection/sample-collection-referral-addendum.md
@@ -15,7 +15,7 @@
 
 ## Change Log
 
-- **v2.1 (2026-04-23, this addendum):** Adds Refer Out capability to Step 3 (Label & Store). Adds partial/full referral handling rules. Adds `REFERRED_OUT` order status. Adds dashboard filters for referred-out orders. Preserves existing Refer Out module mechanics and X-01 notification trigger.
+- **v2.1 (2026-04-23, this addendum):** Adds Refer Out capability to Step 3 (Label & Store). Refer Out operates at the **sample level** — a physical specimen cannot be both kept and referred, so referring any test on a sample refers the whole sample and every test assigned to it. Partial referral is achieved by having multiple samples on an order, some referred and some in-house. Adds `REFERRED_OUT` order status (fires when all samples are referred). Adds dashboard filters for referred-out orders. Referral UI is integrated alongside the existing LBL-2 Print Labels and LBL-3 Storage Assignment sections so Step 3 reads as one unified step. Preserves existing Refer Out module mechanics and X-01 notification trigger.
 - **v2.0 (2026-04-16, parent):** Merged S-03 (Environmental Order Entry) into main redesign FRS. See parent FRS change log.
 
 ---
@@ -24,23 +24,36 @@
 
 The Sample Collection Redesign v2.0 decomposes the monolithic `AddOrder.js` form into four independently routable steps (Enter Order → Collect Sample → Label & Store → QA Review). In the original monolith the "Refer Out" workflow was embedded alongside result reporting; the v2.0 redesign inadvertently dropped it because the four-step decomposition was organized around the sample lifecycle, not the test lifecycle.
 
-This addendum restores the existing OpenELIS **Refer Out** workflow into Step 3 (Label & Store). Referrals are assigned *after* samples have been collected and labeled — that is the point at which the tech knows which physical specimen is going where. The existing Refer Out module (referring lab config, `ReferralItem` entity, referred result entry, FHIR outbound referral) is reused without modification; this addendum only specifies the **UI placement**, the **order status transitions** that fire when tests are referred, and the **dashboard filters** that surface referred-out orders.
+This addendum restores the existing OpenELIS **Refer Out** workflow into Step 3 (Label & Store). Referrals are assigned *after* samples have been collected and labeled — that is the point at which the tech knows which physical specimen is going where. The existing Refer Out module (referring lab config, `ReferralItem` entity, referred result entry, FHIR outbound referral) is reused without modification; this addendum only specifies the **UI placement**, the **order status transitions** that fire when samples are referred, and the **dashboard filters** that surface referred-out orders.
 
 This addendum also does not re-specify the notification pipeline — **X-01 Referral-Out Notification** (v1.0) handles that, triggered by `ReferralItem.save()`. When the tech saves a referral per this spec, X-01 fires its notification.
 
-### 1.1 What this addendum adds
+### 1.1 Unit of referral — SAMPLE, not test
+
+A referral operates on a **physical sample** (one tube/specimen/container). Once a sample is referred out, **every test assigned to that sample** goes with it — they share one physical object and cannot be in two laboratories at once.
+
+This has three practical consequences:
+
+1. **Partial referral = partial samples, not partial tests.** An order with partial referral is an order whose *samples* split across locations: some samples stay in-house (with all their tests), some go to an external lab (with all their tests). You cannot refer a subset of tests on a single sample and keep the rest in-house.
+2. **If a tech needs to run some tests in-house and refer others for the same patient, they must collect multiple samples at Step 2** (e.g., two aliquots of blood). Each sample can then be routed independently.
+3. **All-samples-referred → order is REFERRED_OUT.** Not all-tests — the count that matters is the count of active, non-voided samples.
+
+This design intentionally diverges from how the original `ReferralItem` entity is structured in the legacy OpenELIS (which stores one referral per test). The UI enforces sample-level choices, but the backend still persists one `ReferralItem` per test for compatibility with existing referred-result-entry and reporting screens. See §4 Data Model.
+
+### 1.2 What this addendum adds
 
 | Area | New capability |
 |------|----------------|
-| Step 3 UI | Inline Refer Out column on the Samples & Tests table; per-test and per-sample Refer Out assignment |
-| Step 3 bulk action | "Refer all to Lab X" action referring every remaining test on the order to one external lab |
-| Order status | New `REFERRED_OUT` terminal status when **all** tests on an order are referred |
+| Step 3 UI | Sample-centric table with a Refer Out column per sample; referral is a sample-level action — all tests on that sample inherit the referral |
+| Step 3 integration | Refer Out UI rendered alongside the existing LBL-2 Print Labels and LBL-3 Storage Assignment sections — one unified step, not a separate screen |
+| Step 3 bulk action | "Refer all in-house samples to Lab X" action |
+| Order status | New `REFERRED_OUT` terminal status when **all active samples** on an order are referred |
 | QA bypass rule | Fully-referred orders skip Step 4 QA and close on the in-house side |
-| Partial referral | Order continues through Step 4 QA normally; referred tests split off into the existing referral track |
-| Order Dashboard | Two new filters — "Has Referred Tests" (partial + full) and "Fully Referred Out" |
-| Order Context Card | Adds a "Referred" chip with count when ≥1 test is referred |
+| Partial referral | Order continues through Step 4 QA normally; only in-house samples' tests count toward completeness |
+| Order Dashboard | Two new filters — "Has Referred Samples" (partial + full) and "Fully Referred Out" |
+| Order Context Card | Adds a "Referred" chip with sample count when ≥1 sample is referred |
 
-### 1.2 What this addendum does NOT change
+### 1.3 What this addendum does NOT change
 
 - **Existing Refer Out module mechanics** — unchanged. This addendum reuses: the referring lab admin config, the `ReferralItem` entity, the FHIR ServiceRequest outbound referral pathway, and the referred-result-entry screen.
 - **X-01 Notification pipeline** — unchanged. Saving a referral in Step 3 fires `REFERRAL_OUT` event as specified in X-01 v1.0 FR-01.
@@ -54,11 +67,12 @@ This addendum also does not re-specify the notification pipeline — **X-01 Refe
 
 Appended to parent FRS §5.
 
-- **US-26** — As a lab technician, after labeling a sample, I want to mark one or more of its tests for referral to an external lab so that the physical specimen and its referral are recorded together in a single step.
-- **US-27** — As a lab technician, I want to refer every test on an order to a single external lab with one action so I don't have to click through each test when the whole order is being sent out.
-- **US-28** — As a QA officer, I don't want to see orders where every test has been referred externally in my QA queue — those orders have no in-house testing to validate.
-- **US-29** — As a lab manager, I want to see which orders have tests out at external labs so I can follow up with those labs if results are late.
-- **US-30** — As a lab manager, I want to distinguish "some tests referred" from "all tests referred" on the dashboard so I can see which orders are still partially in-house.
+- **US-26** — As a lab technician, after labeling a sample, I want to refer that physical specimen to an external lab (carrying all its tests with it) so the specimen and its referral are recorded together in a single step.
+- **US-27** — As a lab technician, when the entire order is being sent out, I want to refer every in-house sample on the order to a single external lab with one action so I don't have to click through each sample.
+- **US-28** — As a lab technician, when I need to run some tests in-house and refer others for the same patient, I want to collect the specimen as multiple samples (e.g., two aliquots) during Step 2 so each sample can be routed independently at Step 3.
+- **US-29** — As a QA officer, I don't want orders where every sample has been referred externally to appear in my QA queue — there is no in-house testing to validate.
+- **US-30** — As a lab manager, I want to see which orders have samples out at external labs so I can follow up with those labs if results are late.
+- **US-31** — As a lab manager, I want to distinguish "some samples referred" from "all samples referred" on the dashboard so I can see which orders are still partially in-house.
 
 ---
 
@@ -66,19 +80,20 @@ Appended to parent FRS §5.
 
 ### 3.1 Label & Store (Step 3) — Refer Out UI
 
-Appended to parent FRS §6.4 (LBL-1 through LBL-4).
+Appended to parent FRS §6.4 (LBL-1 through LBL-4). Refer Out is rendered **within the existing Step 3 layout**, alongside the LBL-2 Print Labels section and the LBL-3 Storage Assignment — not as a separate screen or tab. The Samples List (LBL-1) gains a Refer Out column.
 
 | ID | Priority | Requirement | Testability |
 |----|----------|-------------|-------------|
-| **LBL-5** | **P0** | The Samples & Tests table on Step 3 MUST include a **Refer Out** column (after Storage Location). Each row (one row per test within a sample) displays the referral state as a Carbon Tag: "In-house" (kind=`gray`, default), "Referred — [Lab Name]" (kind=`purple`), or "Awaiting External Results" (kind=`blue`, set once the referral is saved and the external lab has acknowledged receipt). | Tag renders per row. State updates on referral save. |
-| **LBL-6** | **P0** | Each table row MUST provide a **Refer Out** action (overflow menu or inline button, per Carbon). Selecting it expands an inline form below the row with: ReferringLab `ComboBox` (required, options from existing referring-lab admin config), Reason `TextArea` (optional, free text, max 500 chars), Expected Return Date `DatePicker` (optional), and Notify Customer `Checkbox` (default checked if X-01 trigger is enabled; hidden otherwise). Save and Cancel buttons on the expansion. | Row expands. All fields render. Lab dropdown populated. Save persists a `ReferralItem`. Cancel collapses without save. Modal is NOT used. |
-| **LBL-7** | **P0** | A **Bulk Refer Out** button MUST appear above the table, left-aligned. Clicking opens a Carbon `Modal` with: ReferringLab `ComboBox` (required), Reason `TextArea` (optional), Expected Return Date `DatePicker` (optional), Notify Customer `Checkbox`, and a preview list showing "This will refer N tests on M samples to [Lab Name]." Confirming creates one `ReferralItem` per remaining in-house test, all pointing at the chosen lab. Modal is justified here because the action changes order-level status (see LBL-10) and is non-reversible without per-test undo. | Modal opens. Preview count reflects unreferred tests. Confirm creates N referrals in one transaction. Cancel closes without change. |
-| **LBL-8** | **P0** | A test that has ALREADY been referred MUST NOT be included in the Bulk Refer Out count. The bulk action refers only remaining in-house tests. | Bulk modal count excludes already-referred tests. Re-opening bulk modal after a prior referral shows updated count. |
-| **LBL-9** | **P0** | After a referral is saved (per-row LBL-6 or bulk LBL-7), the affected table rows MUST update the Refer Out column Tag to "Referred — [Lab Name]" without a page reload. An `InlineNotification` (kind=`success`) MUST appear at the top of the Step 3 panel confirming "Referred N tests to [Lab Name]." and MUST auto-dismiss after 5 seconds. | Rows update in place. Success notification appears and dismisses. |
-| **LBL-10** | **P0** | Saving a referral MUST fire the existing X-01 `REFERRAL_OUT` event (X-01 FR-01) per referral record. If X-01 trigger is disabled globally and no lab-unit override enables it, no notification is sent — this is normal X-01 behavior. | `REFERRAL_OUT` event fires on save. X-01 FR-02 per-referral behavior honored. |
-| **LBL-11** | **P0** | A referral MAY be **undone** before the external lab acknowledges receipt. The row overflow menu includes an "Undo Referral" action when state is "Referred — [Lab Name]" and the referral has not yet moved to "Awaiting External Results". Undo voids the `ReferralItem` and emits no additional X-01 event (the original `REFERRAL_OUT` event is not recalled — this is consistent with existing behavior and X-01 is not in scope to modify). | Undo action present only in "Referred" state. Undo reverts Tag to "In-house". |
-| **LBL-12** | P1 | When FHIR outbound referral is configured for the selected referring lab, the system MUST transmit a FHIR `ServiceRequest` to the receiving lab as part of the referral save (existing outbound pathway — no new API). Transmission state is reflected in the row Tag: "Referred" = saved locally, "Sent to External" = FHIR transmission succeeded, "Awaiting External Results" = external lab acknowledged via `Task` response. If FHIR transmission fails, row shows kind=`red` Tag with "Send Failed — Retry" action. | FHIR ServiceRequest sent for FHIR-enabled referring lab. Failure state visible and retryable. |
-| **LBL-13** | P1 | For non-FHIR referring labs (paper/manifest only), the row Tag transitions are: "In-house" → "Referred — [Lab Name]" → (stays in this state; manual return when results are entered via existing referral-result-entry screen). No Send Failed state. | Paper-only labs do not attempt FHIR send. |
+| **LBL-5** | **P0** | The Step 3 Samples List (parent LBL-1) MUST be rendered as a sample-centric table (one row per physical sample) with columns: Sample ID, Sample Type, Tests (list of test name chips), Storage Location (from LBL-3, editable inline), Label Actions (from LBL-2, inline Print button), **Refer Out** (new). The Refer Out column displays a Carbon Tag per sample: "In-house" (kind=`gray`, default), "Referred — [Lab Name]" (kind=`purple`), "Sent to External" (kind=`blue` — FHIR transmission acknowledged), or "Awaiting External Results" (kind=`blue` — external lab has received and accepted). | Table renders one row per sample. All columns visible. Tag state updates on referral save. |
+| **LBL-6** | **P0** | Each sample row MUST provide a **Refer Out Sample** action (overflow menu or inline button). Selecting it expands an inline form below the row with: ReferringLab `ComboBox` (required, options from existing referring-lab admin config), Reason `TextArea` (optional, free text, max 500 chars), Expected Return Date `DatePicker` (optional), Notify Customer `Checkbox` (default checked if X-01 trigger is enabled; hidden otherwise), and a read-only preview listing the tests that will go with this sample: "This will refer {{sampleType}} ({{sampleId}}) and all {{testCount}} tests on it to {{labName}}: {{testList}}." Save and Cancel buttons on the expansion. | Row expands. All fields render. Preview lists all tests on the sample. Save persists one `ReferralItem` per test on the sample (see §4). Cancel collapses without save. Modal is NOT used for the per-sample case. |
+| **LBL-7** | **P0** | A **Bulk Refer Out** button MUST appear in the Samples table toolbar. Clicking opens a Carbon `Modal` with: ReferringLab `ComboBox` (required), Reason `TextArea` (optional), Expected Return Date `DatePicker` (optional), Notify Customer `Checkbox`, and a preview list showing "This will refer {{sampleCount}} samples ({{testCount}} tests total) to {{labName}}: {{sampleList}}." Confirming refers every **in-house** sample on the order to the chosen lab; every test on each referred sample is carried over. Modal is justified because the action changes order-level status (see REF-2) and touches multiple samples at once. | Modal opens. Preview counts reflect unreferred samples and their tests. Confirm refers N samples and all tests on them in one transaction. Cancel closes without change. |
+| **LBL-8** | **P0** | A sample that has ALREADY been referred MUST NOT be included in the Bulk Refer Out preview or action. The bulk action operates on remaining in-house samples only. If zero in-house samples remain, the Bulk Refer Out button is disabled with tooltip "No in-house samples to refer." | Bulk modal excludes referred samples. Button disabled when count = 0. |
+| **LBL-9** | **P0** | After a referral is saved (per-sample LBL-6 or bulk LBL-7), the affected sample rows MUST update the Refer Out column Tag to "Referred — [Lab Name]" without a page reload. An `InlineNotification` (kind=`success`) MUST appear at the top of the Step 3 panel confirming "Referred {{sampleCount}} samples ({{testCount}} tests) to [Lab Name]." and MUST auto-dismiss after 5 seconds. | Rows update in place. Success notification appears and dismisses. |
+| **LBL-10** | **P0** | Saving a referral MUST fire the existing X-01 `REFERRAL_OUT` event (X-01 FR-01) **once per sample** referred — because X-01 FR-02 specifies one event per referral record and the UI groups a sample's tests into one logical referral per sample per receiving lab. If the data model stores one `ReferralItem` per test (see §4), the backend MUST coalesce same-sample/same-receiving-lab referrals into a single X-01 event. | `REFERRAL_OUT` fires once per (sample × receiving lab) combination, not per test. |
+| **LBL-11** | **P0** | A sample referral MAY be **undone** before the external lab acknowledges receipt. The row overflow menu includes an "Undo Referral" action when state is "Referred — [Lab Name]" and the referral has not yet moved to "Awaiting External Results". Undo voids every `ReferralItem` on that sample and emits no additional X-01 event. All tests on the sample return to the in-house pipeline. | Undo action present only in "Referred" state. Undo reverts sample Tag to "In-house" and restores all tests to in-house. |
+| **LBL-12** | P1 | When FHIR outbound referral is configured for the selected referring lab, the system MUST transmit one FHIR `ServiceRequest` per sample (grouping all tests on the sample as `ServiceRequest.basedOn` entries) to the receiving lab **immediately** as part of the referral save transaction. No "Send now vs batch" choice is offered on the refer-out form. Transmission state is reflected in the sample row Tag: "Referred" = saved locally (brief, typically <1 s), "Sent to External" = FHIR transmission succeeded, "Awaiting External Results" = external lab acknowledged via FHIR `Task` response. If FHIR transmission fails, row shows kind=`red` Tag with "Send Failed — Retry" action; the local referral record is preserved so retry does not re-create `ReferralItem` rows. | One FHIR ServiceRequest sent per referred sample, synchronously with save. Failure state visible and retryable without duplicating referrals. |
+| **LBL-13** | P1 | For non-FHIR referring labs (paper/manifest only), the sample row Tag transitions are: "In-house" → "Referred — [Lab Name]" → (stays; manual return when results are entered via existing referral-result-entry screen). No Send Failed state. | Paper-only labs do not attempt FHIR send. |
+| **LBL-14** | **P0** | The existing LBL-2 Print Labels section and LBL-3 Storage Assignment MUST remain the primary Step 3 sections and sit alongside the sample table. Referral actions do NOT replace labeling or storage — a referred sample still needs a printed label (it travels with the specimen to the external lab) and a storage location (it is stored locally until pickup). After referral, the Storage Location field for that sample MAY remain editable (BR-REF-4) so the tech can move the physical specimen between fridges before pickup. | Print Labels section visible. Storage Assignment visible. Both remain functional for referred samples. |
 
 ### 3.2 Order Status Transitions — Auto-Complete on Full Referral
 
@@ -86,13 +101,14 @@ Appended to parent FRS §6.5 (QA-1 through QA-6) and §4.3 OrderContext.
 
 | ID | Priority | Requirement | Testability |
 |----|----------|-------------|-------------|
-| **REF-1** | **P0** | The `orderStatus` enum (parent FRS §4.3) MUST add a new value: `REFERRED_OUT`. Semantics: every test on the order has an active (non-voided) referral. The order has no in-house testing to perform or validate. | Enum value present. Schema migration included. |
-| **REF-2** | **P0** | When a referral save (LBL-6 or LBL-7) results in **all** active tests on the order having active referrals, the order `orderStatus` MUST transition from `LABELING` (or `QA_REVIEW` if already there) directly to `REFERRED_OUT`. Step 4 QA Review is bypassed — the QA officer does not see the order in their queue. | All-referred save transitions status. Order disappears from QA queue. Audit trail records transition. |
+| **REF-1** | **P0** | The `orderStatus` enum (parent FRS §4.3) MUST add a new value: `REFERRED_OUT`. Semantics: every active (non-voided) sample on the order has an active referral. The order has no in-house testing to perform or validate. | Enum value present. Schema migration included. |
+| **REF-2** | **P0** | When a referral save (LBL-6 or LBL-7) results in **all** active samples on the order being referred, the order `orderStatus` MUST transition from `LABELING` (or `QA_REVIEW` if already there) directly to `REFERRED_OUT`. Step 4 QA Review is bypassed — the QA officer does not see the order in their queue. The count that matters is the sample count, not the test count. | All-samples-referred save transitions status. Order disappears from QA queue. Audit trail records transition. |
 | **REF-3** | **P0** | A `REFERRED_OUT` order is considered **closed on the in-house side** but remains **open on the referral side** until external results return via the existing referral-result-entry screen. The order does not appear in the QA queue, does not block dashboards, and does not require any further lab action until external results return. | Order not in QA queue. Order visible in "Fully Referred Out" dashboard filter. |
-| **REF-4** | **P0** | When external results return for a `REFERRED_OUT` order (via existing referral-result-entry screen), the existing behavior is preserved — results are attached to the order, the `ReferralItem` is marked complete, and the order can be reported. No new status is introduced for "results returned" at this time — the existing `APPROVED` state (set when all results are validated, including external) applies. | External result entry on `REFERRED_OUT` order works as before. Final validated order is `APPROVED`. |
-| **REF-5** | **P0** | For a **partially** referred order (at least one test still in-house), the order continues through `LABELING` → `QA_REVIEW` → `APPROVED` normally. Referred tests are excluded from Step 4 QA completeness checks — QA-1 (parent FRS §6.5) MUST treat referred tests as "not applicable" and not red/yellow. | QA completeness excludes referred tests. Mixed order transitions through QA normally. |
-| **REF-6** | **P0** | Undoing a referral (LBL-11) that caused an order to enter `REFERRED_OUT` state MUST revert the order to `LABELING` (or the last pre-`REFERRED_OUT` status, read from the audit trail). The order re-enters the appropriate queue. | Undo on last-referred test reverts status. Audit trail captures revert. |
-| **REF-7** | P1 | If a `REFERRED_OUT` order has ALL its referrals voided (via LBL-11 on each), it reverts to the previous status (typically `LABELING`) and requires manual re-entry into QA. | Revert-all behavior correct. |
+| **REF-4** | **P0** | When external results return for a **fully** `REFERRED_OUT` order (via existing referral-result-entry screen), the system MUST auto-transition the order to `APPROVED` once all `ReferralItem` rows are marked complete with results. The external lab's entry acts as the validating action — no in-house validator review is required. Audit trail records `APPROVED_BY = EXTERNAL:{{referringLabId}}` and `validated_at` = external result entry timestamp. Rationale: a `REFERRED_OUT` order has no in-house testing to validate; the external lab is the authoritative source. | External result entry on a `REFERRED_OUT` order transitions status to `APPROVED` automatically. Audit trail shows external validator identity. |
+| **REF-4a** | **P0** | For **partially** referred orders (some samples in-house, some referred), the order MUST still require explicit in-house validator action before reaching `APPROVED` (unchanged in-house behavior). External results attach as read-only and feed into the validator's review, but the in-house validator remains the approver of record. | Partial-referral order requires validator action to reach APPROVED. External results visible in validator view. |
+| **REF-5** | **P0** | For a **partially** referred order (at least one sample still in-house), the order continues through `LABELING` → `QA_REVIEW` → `APPROVED` normally. Tests on referred samples are excluded from Step 4 QA completeness checks — QA-1 (parent FRS §6.5) MUST treat tests on referred samples as "not applicable" (not red/yellow). | QA completeness excludes referred-sample tests. Mixed order transitions through QA normally. |
+| **REF-6** | **P0** | Undoing a sample referral (LBL-11) that caused an order to enter `REFERRED_OUT` state MUST revert the order to `LABELING` (or the last pre-`REFERRED_OUT` status, read from the audit trail). The order re-enters the appropriate queue. | Undo on last-referred sample reverts status. Audit trail captures revert. |
+| **REF-7** | P1 | If a `REFERRED_OUT` order has ALL its sample referrals voided (via LBL-11 on each), it reverts to the previous status (typically `LABELING`) and requires manual re-entry into QA. | Revert-all behavior correct. |
 
 ### 3.3 Order Context Card — Referred Chip
 
@@ -100,7 +116,7 @@ Appended to parent FRS §4.3 (Context card rendering).
 
 | ID | Priority | Requirement | Testability |
 |----|----------|-------------|-------------|
-| **REF-8** | **P0** | When an order has ≥1 active referral, the Order Context Card (NAV-5) MUST display a "Referred" Tag (kind=`purple`) with count, e.g. "Referred (2 of 4)." For fully-referred orders the text reads "Referred (all)." Clicking the Tag anchors the page to the Step 3 referrals section. | Chip displays with count. Clicking scrolls/anchors. Fully-referred label differs. |
+| **REF-8** | **P0** | When an order has ≥1 referred sample, the Order Context Card (NAV-5) MUST display a "Referred" Tag (kind=`purple`) with sample count, e.g. "Referred (2 of 4 samples)." For fully-referred orders the text reads "Referred (all samples)." Clicking the Tag anchors the page to the Step 3 sample table and scrolls the first referred row into view. | Chip displays with sample count. Clicking scrolls/anchors. Fully-referred label differs. |
 
 ### 3.4 Order Dashboard — Filters
 
@@ -108,21 +124,33 @@ Appended to parent FRS §6.9 (DSH-1 through DSH-9).
 
 | ID | Priority | Requirement | Testability |
 |----|----------|-------------|-------------|
-| **DSH-10** | **P0** | Dashboard Filters (DSH-7) MUST add a new filter: **Referred Out** with options: "Any" (default), "Has Referred Tests" (orders where ≥1 test is referred — includes both partial and full), "Fully Referred Out" (orders where all tests are referred — `orderStatus = REFERRED_OUT`). Filter combines with existing filters via AND. | Filter present. All three options work. Combines with other filters correctly. |
-| **DSH-11** | **P0** | Dashboard table rows for orders matching "Has Referred Tests" or "Fully Referred Out" MUST show a Referred Tag (kind=`purple`) in the Status column alongside the primary status. Example row status: "Labeling • Referred (2 of 4)" or "Referred Out (all)". | Status column renders both statuses. |
-| **DSH-12** | P1 | Clicking a "Fully Referred Out" row MUST route to Step 3 (Label & Store) with the referrals section anchored — not Step 4 QA, since there is no QA to perform. For partial referrals, clicking routes to the current step per existing DSH behavior. | Fully-referred click routes to Step 3. Partial click routes to current step. |
-| **DSH-13** | P2 | A dashboard badge MAY show the total count of "Awaiting External Results" across all orders — a single number visible at the top of the dashboard for quick follow-up triage. | Badge renders with correct count. Clicking filters to those orders. |
+| **DSH-10** | **P0** | Dashboard Filters (DSH-7) MUST add a new filter: **Referred Out** with options: "Any" (default), "Has Referred Samples" (orders where ≥1 sample is referred — includes both partial and full), "Fully Referred Out" (orders where all active samples are referred — `orderStatus = REFERRED_OUT`). Filter combines with existing filters via AND. | Filter present. All three options work. Combines with other filters correctly. |
+| **DSH-11** | **P0** | Dashboard table rows for orders matching "Has Referred Samples" or "Fully Referred Out" MUST show a Referred Tag (kind=`purple`) in the Status column alongside the primary status. Example row status: "Labeling" + "Referred (2 of 4 samples)" or "Referred Out" + "Referred (all samples)". | Status column renders both statuses. |
+| **DSH-12** | P1 | Clicking a "Fully Referred Out" row MUST route to Step 3 (Label & Store) with the sample table anchored — not Step 4 QA, since there is no QA to perform. For partial referrals, clicking routes to the current step per existing DSH behavior. | Fully-referred click routes to Step 3. Partial click routes to current step. |
+| **DSH-13** | **Deferred** | A top-of-dashboard "Awaiting External Results" badge is **out of scope for v2.1**. The DSH-10 filter (Has Referred Samples / Fully Referred Out) is sufficient follow-up triage for now. A dedicated Referred-Out dashboard is planned as a separate initiative; external-results tracking (TAT, stale threshold, pending badge) will be re-specified there. | Not implemented in v2.1. |
 
 ### 3.5 Lab Unit Configuration
 
 | ID | Priority | Requirement | Testability |
 |----|----------|-------------|-------------|
 | **REF-9** | P1 | Refer Out at Label & Store MUST be available under all three workflow modes (Clinical, Environmental, Both). No per-mode gating. | Refer Out visible in all three modes. |
-| **REF-10** | P2 | A lab unit SHOULD support a configuration flag `allowBulkReferOut` (default true) that hides the Bulk Refer Out button (LBL-7) when false. Useful for labs that want to force per-test review before referral. | Flag hides button when false. Per-row Refer Out still works. |
+| ~~REF-10~~ | ~~Dropped~~ | *Dropped from v2.1 scope.* Bulk Refer Out (LBL-7) is always enabled for every lab unit. No `allowBulkReferOut` admin flag. If a future deployment needs per-sample-only workflow, file a follow-up. | — |
 
 ---
 
 ## 4. Data Model
+
+The existing legacy `ReferralItem` entity in OpenELIS stores one referral row per test (analysis). This addendum preserves that schema — the backend creates one `ReferralItem` per test on the sample when a sample is referred. Conceptually the referral is sample-level; physically the table stores test-level rows so that existing referred-result-entry and reporting screens (which iterate `ReferralItem` by test/analysis) continue to work without change.
+
+**Sample-level grouping is derived, not stored:**
+
+| Derivation | Rule |
+|-----------|------|
+| "Sample is referred" | `EXISTS(SELECT 1 FROM referral_item ri JOIN analysis a ON ri.analysis_id = a.id WHERE a.sample_id = :sampleId AND ri.voided = false)` |
+| "All tests on sample referred" | For the UI, an invariant holds: **every** test on a referred sample is also referred. Per-test partial referral within a sample is blocked at the UI and API layer. |
+| "Fully referred out order" | All active (non-voided) samples on the order have all their tests referred. Materialized as `orderStatus = REFERRED_OUT`. |
+
+**Backend invariant (enforced at service layer, not DB constraint for performance):** when a new `ReferralItem` is created for any test on a sample, the service MUST create `ReferralItem` rows for every other test on that same sample to the same receiving lab in the same transaction. When a `ReferralItem` is voided, all sibling `ReferralItem` rows for the same sample MUST be voided in the same transaction. This keeps the data model consistent with the sample-level UI constraint.
 
 No new tables — reuses the existing `ReferralItem` entity. One new enum value:
 
@@ -154,10 +182,10 @@ No new columns on `sample_order`, `analysis`, or `referral_item`. The order-leve
 
 | Column | Derivation |
 |--------|-----------|
-| `has_referred_tests` | `EXISTS(SELECT 1 FROM referral_item WHERE order_id = sample_order.id AND voided = false)` |
+| `has_referred_samples` | `EXISTS(SELECT 1 FROM sample s JOIN analysis a ON a.sample_id = s.id JOIN referral_item ri ON ri.analysis_id = a.id WHERE s.sample_order_id = sample_order.id AND ri.voided = false)` |
 | `fully_referred` | `orderStatus = 'REFERRED_OUT'` |
-| `referred_count` | `COUNT(referral_item WHERE order_id = sample_order.id AND voided = false)` |
-| `total_test_count` | `COUNT(analysis WHERE order_id = sample_order.id AND cancelled = false)` |
+| `referred_sample_count` | `COUNT(DISTINCT s.id)` where sample s has at least one active (non-voided) `ReferralItem` |
+| `total_sample_count` | `COUNT(DISTINCT s.id)` where sample s is not cancelled |
 
 ---
 
@@ -167,10 +195,10 @@ No new endpoints. Extensions only:
 
 | Endpoint | Change |
 |----------|--------|
-| `POST /rest/referral` | Existing endpoint — no change to request/response. On save, emits X-01 `REFERRAL_OUT` event (existing). |
-| `POST /rest/order/{id}/referral/bulk` | **New** — accepts `{ referringLabId, reason, expectedReturnDate, notifyCustomer }`. Server creates one `ReferralItem` per remaining in-house test on the order in a single transaction. Returns `{ createdReferrals: [...], newOrderStatus: 'LABELING' \| 'REFERRED_OUT' }`. |
-| `PUT /rest/order/{id}/referral/{referralId}/undo` | **New** — voids a `ReferralItem` and recomputes order status. Returns `{ newOrderStatus }`. Idempotent. |
-| `GET /rest/order/search` | Existing dashboard search endpoint — add query params `hasReferred=bool` and `fullyReferred=bool` for DSH-10. |
+| `POST /rest/sample/{sampleId}/referral` | **New** (or extension of existing `/rest/referral`) — accepts `{ referringLabId, reason, expectedReturnDate, notifyCustomer }`. Server creates one `ReferralItem` per test on the sample, all pointing at the same receiving lab, in a single transaction. Returns `{ sampleId, createdReferralIds: [...], newOrderStatus: 'LABELING' \| 'REFERRED_OUT' }`. Emits one X-01 `REFERRAL_OUT` event (LBL-10 coalescing). |
+| `POST /rest/order/{id}/referral/bulk` | **New** — accepts `{ referringLabId, reason, expectedReturnDate, notifyCustomer }`. Server calls the per-sample referral logic for every remaining in-house sample on the order in a single transaction. Returns `{ referredSampleIds: [...], createdReferralCount: N, newOrderStatus: 'LABELING' \| 'REFERRED_OUT' }`. Emits one X-01 event per sample. |
+| `PUT /rest/sample/{sampleId}/referral/undo` | **New** — voids every `ReferralItem` on the sample and recomputes order status. Returns `{ newOrderStatus }`. Idempotent. |
+| `GET /rest/order/search` | Existing dashboard search endpoint — add query params `hasReferredSamples=bool` and `fullyReferred=bool` for DSH-10. |
 
 ---
 
@@ -180,12 +208,13 @@ Appended to parent FRS §9.
 
 | ID | Rule |
 |----|------|
-| **BR-REF-1** | An order's `orderStatus` transitions to `REFERRED_OUT` the moment the save that results in all active tests having active referrals completes — not on a scheduled job. Atomic with the save. |
-| **BR-REF-2** | Voiding a referral MUST re-evaluate order status synchronously. If the last referral is voided, revert to the pre-`REFERRED_OUT` status from the audit log. If no audit log entry exists (edge case), revert to `LABELING`. |
-| **BR-REF-3** | Referred tests are excluded from Step 4 QA completeness checks (parent FRS QA-1). They show in the QA panel as a separate "Referred (external)" group for informational context, not as incomplete. |
-| **BR-REF-4** | A `REFERRED_OUT` order MUST still allow edit of storage location (LBL-3) in case the physical specimen is moved between refrigerators before external pickup. All other Step 3 fields are read-only once referred. |
+| **BR-REF-1** | An order's `orderStatus` transitions to `REFERRED_OUT` the moment the save that results in all active samples being referred completes — not on a scheduled job. Atomic with the save. |
+| **BR-REF-2** | Voiding a sample referral MUST re-evaluate order status synchronously. If the last referred sample is voided, revert to the pre-`REFERRED_OUT` status from the audit log. If no audit log entry exists (edge case), revert to `LABELING`. |
+| **BR-REF-3** | Tests on referred samples are excluded from Step 4 QA completeness checks (parent FRS QA-1). They show in the QA panel as a "Referred (external)" group per sample for informational context, not as incomplete. |
+| **BR-REF-4** | A `REFERRED_OUT` order MUST still allow edit of storage location (LBL-3) and reprint of labels (LBL-2) for each sample in case the physical specimen is moved between refrigerators before external pickup or the label is damaged. All other sample-level Step 3 fields are read-only once referred. |
 | **BR-REF-5** | A `REFERRED_OUT` order is treated as "closed" for in-house workload reports (TAT, productivity). It is treated as "open" for referral-pending-results reports. |
-| **BR-REF-6** | Adding a new test to an order that is currently `REFERRED_OUT` (via Edit Order workflow, parent FRS §6.8) MUST revert the order to `LABELING` — the new test is in-house by default and requires the normal pipeline. |
+| **BR-REF-6** | Adding a new sample to an order that is currently `REFERRED_OUT` (via Edit Order workflow, parent FRS §6.8) MUST revert the order to `LABELING` — the new sample is in-house by default and requires the normal pipeline. |
+| **BR-REF-7** | Per-test referral within a single sample MUST NOT be supported at the UI or API layer. If a tech needs mixed routing (some tests in-house, some external) for one patient, they must collect multiple samples at Step 2 first. The sample-collection step's "+ New Sample" action is the mechanism for this. |
 
 ---
 
@@ -204,24 +233,26 @@ Appended to parent FRS §10.
 | `label.sampleCollection.referOut.action.undo` | Undo Referral |
 | `label.sampleCollection.referOut.action.retry` | Retry Send |
 | `label.sampleCollection.referOut.bulk.button` | Bulk Refer Out |
-| `label.sampleCollection.referOut.bulk.modalTitle` | Refer All Tests to External Lab |
-| `label.sampleCollection.referOut.bulk.preview` | This will refer {{testCount}} tests on {{sampleCount}} samples to {{labName}}. |
+| `label.sampleCollection.referOut.bulk.modalTitle` | Refer All In-House Samples to External Lab |
+| `label.sampleCollection.referOut.bulk.preview` | This will refer {{sampleCount}} samples ({{testCount}} tests total) to {{labName}}. |
+| `label.sampleCollection.referOut.perSample.preview` | This will refer {{sampleType}} ({{sampleId}}) and all {{testCount}} tests on it to {{labName}}. |
 | `label.sampleCollection.referOut.form.referringLab` | Referring Lab |
 | `label.sampleCollection.referOut.form.reason` | Reason (optional) |
 | `label.sampleCollection.referOut.form.expectedReturn` | Expected Return Date |
 | `label.sampleCollection.referOut.form.notifyCustomer` | Notify customer of referral |
-| `label.sampleCollection.referOut.notification.success` | Referred {{count}} tests to {{labName}}. |
+| `label.sampleCollection.referOut.notification.success` | Referred {{sampleCount}} samples ({{testCount}} tests) to {{labName}}. |
 | `label.sampleCollection.referOut.notification.fhirFailure` | FHIR transmission failed. Referral saved locally — retry send. |
-| `label.sampleCollection.referOut.contextCard.referredPartial` | Referred ({{referredCount}} of {{totalCount}}) |
-| `label.sampleCollection.referOut.contextCard.referredAll` | Referred (all) |
+| `label.sampleCollection.referOut.contextCard.referredPartial` | Referred ({{referredCount}} of {{totalCount}} samples) |
+| `label.sampleCollection.referOut.contextCard.referredAll` | Referred (all samples) |
 | `label.sampleCollection.referOut.status.fullyReferred` | Referred Out |
 | `label.dashboard.filter.referredOut` | Referred Out |
 | `label.dashboard.filter.referredOut.any` | Any |
-| `label.dashboard.filter.referredOut.hasReferred` | Has Referred Tests |
+| `label.dashboard.filter.referredOut.hasReferred` | Has Referred Samples |
 | `label.dashboard.filter.referredOut.fullyReferred` | Fully Referred Out |
 | `label.dashboard.badge.awaitingExternal` | Awaiting External Results ({{count}}) |
 | `error.referOut.noReferringLab` | Select a referring lab before saving. |
-| `error.referOut.bulkNoTests` | No in-house tests to refer. All tests on this order are already referred. |
+| `error.referOut.bulkNoSamples` | No in-house samples to refer. All samples on this order are already referred. |
+| `error.referOut.perTestBlocked` | This sample has multiple tests. Referring it sends every test with the specimen. To keep some tests in-house, collect a separate sample at Step 2 first. |
 
 ---
 
@@ -231,11 +262,12 @@ Appended to parent FRS §11.
 
 | ID | Rule |
 |----|------|
-| **VR-REF-1** | ReferringLab is required on the per-row Refer Out form. Save disabled until populated. |
-| **VR-REF-2** | Bulk Refer Out is disabled if `referred_count == total_test_count` (all tests already referred). |
+| **VR-REF-1** | ReferringLab is required on the per-sample Refer Out form and on the Bulk Refer Out modal. Save disabled until populated. |
+| **VR-REF-2** | Bulk Refer Out is disabled if `referred_sample_count == total_sample_count` (all active samples already referred). |
 | **VR-REF-3** | Expected Return Date (if provided) MUST be in the future. Past dates rejected. |
 | **VR-REF-4** | Reason text is limited to 500 characters. |
 | **VR-REF-5** | Undo Referral is disabled once the referring lab has acknowledged receipt (FHIR `Task` response arrived). After acknowledgment, voiding requires an admin role (reuses existing Refer Out void permission). |
+| **VR-REF-6** | Attempting to call `POST /rest/analysis/{id}/referral` (legacy per-test endpoint, if exposed) against an analysis whose sibling analyses on the same sample are not being referred MUST return 400 with `error.referOut.perTestBlocked`. Enforces BR-REF-7 at the API boundary. |
 
 ---
 
@@ -245,8 +277,8 @@ Appended to parent FRS §12.
 
 | Permission | Scope |
 |-----------|-------|
-| **Refer Out** (existing) | Required to create a referral via LBL-6 or LBL-7. UI layer: hide Refer Out actions when permission is absent. API layer: `POST /rest/referral` and `POST /rest/order/{id}/referral/bulk` return 403 when caller lacks permission. |
-| **Void Referral** (existing) | Required for LBL-11 Undo Referral. UI: action hidden when absent. API: `PUT /rest/order/{id}/referral/{id}/undo` returns 403. |
+| **Refer Out** (existing) | Required to create a referral via LBL-6 or LBL-7. UI layer: hide Refer Out actions when permission is absent. API layer: `POST /rest/sample/{sampleId}/referral` and `POST /rest/order/{id}/referral/bulk` return 403 when caller lacks permission. |
+| **Void Referral** (existing) | Required for LBL-11 Undo Referral. UI: action hidden when absent. API: `PUT /rest/sample/{sampleId}/referral/undo` returns 403. |
 | No new permission keys added. Existing Refer Out module permissions are reused. | |
 
 ---
@@ -309,9 +341,16 @@ Appended to parent FRS §12.
 
 ---
 
-## 12. Open Questions
+## 12. Open Questions — Resolved 2026-04-23
 
-- **OQ-1 (REF-4 scope):** Should external results attached to a `REFERRED_OUT` order automatically transition the order to `APPROVED`, or must a validator explicitly approve? v2.1 preserves existing behavior (explicit validator action) — confirm.
-- **OQ-2 (LBL-12 FHIR):** For FHIR-capable referring labs, should the UI offer a "Send now" vs "Save for batch send" choice, or is immediate send the only mode? Default here is immediate.
-- **OQ-3 (DSH-13 badge):** Is "Awaiting External Results" a useful top-level dashboard badge, or is it enough to surface via the filter alone? Current designation is P2.
-- **OQ-4 (REF-10 lab-unit flag):** Is `allowBulkReferOut` a real concern from any deployment, or can LBL-7 always be enabled? Defaults to always-enabled until a lab asks.
+All open questions were resolved with the product owner during the v2.1 review:
+
+- **OQ-1 (REF-4 scope) — RESOLVED:** For **fully** `REFERRED_OUT` orders, external result entry auto-transitions the order to `APPROVED` with the external lab recorded as the validating actor (see REF-4 above). For **partially** referred orders, explicit in-house validator action is still required (see REF-4a).
+- **OQ-2 (LBL-12 FHIR send timing) — RESOLVED:** Immediate send on save. No "Send now vs batch" UI. LBL-12 updated accordingly.
+- **OQ-3 (DSH-13 badge) — RESOLVED:** Dropped from v2.1. The DSH-10 filter is sufficient for now. A dedicated Referred-Out dashboard will be designed as a separate initiative and will re-specify external-results tracking (TAT, stale thresholds, pending counts).
+- **OQ-4 (REF-10 allowBulkReferOut flag) — RESOLVED:** Dropped. Bulk Refer Out is always enabled for every lab unit. No admin flag.
+
+## 13. Follow-ups (Out of Scope for v2.1)
+
+- **Referred-Out dashboard (new initiative).** Dedicated dashboard for tracking external-results-pending orders, TAT per referring lab, stale thresholds, and follow-up triage. Replaces the deferred DSH-13 badge with a richer view. To be scoped separately.
+- **External validator audit detail.** REF-4 records `APPROVED_BY = EXTERNAL:{{referringLabId}}`. A future enhancement MAY capture the external validator's individual identity (from FHIR `Practitioner` reference in the inbound result bundle) rather than just the lab.

--- a/mockup-viewer/public/designs/sample-collection/sample-collection-referral-addendum.html
+++ b/mockup-viewer/public/designs/sample-collection/sample-collection-referral-addendum.html
@@ -1,645 +1,437 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Label &amp; Store — Refer Out Addendum — OpenELIS Preview</title>
-  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <meta charset="utf-8" />
+  <title>OpenELIS — Label &amp; Store + Refer Out (Sample-level) Preview</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
   <style>
-    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
-    .preview-banner {
-      background: #0f62fe; color: #fff;
-      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    /* --------------------------------------------------------------------
+       Minimal Carbon-flavored preview styles — mirrors @carbon/react looks
+       enough to read the mockup without pulling the full CSS bundle.
+    -------------------------------------------------------------------- */
+    :root {
+      --bg:       #ffffff;
+      --bg-alt:  #f4f4f4;
+      --bg-ui:   #e0e0e0;
+      --ink:     #161616;
+      --ink-muted: #525252;
+      --blue-60:  #0f62fe;
+      --purple-60:#8a3ffc;
+      --cyan-70:  #00539a;
+      --red-60:   #da1e28;
+      --teal-60:  #009d9a;
+      --gray-60:  #525252;
+      --gray-20:  #e0e0e0;
+      --success-bg: #defbe6;
+      --info-bg: #edf5ff;
+      --warn-bg: #fff8e1;
     }
-    .preview-content { padding: 1rem 2rem; max-width: 1440px; margin: 0 auto; }
-    .section { background: #fff; border: 1px solid #e0e0e0; margin-bottom: 1rem; }
-    .section-heading {
+    * { box-sizing: border-box; }
+    body {
+      font-family: 'IBM Plex Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+      margin: 0;
+      padding: 0;
+      background: var(--bg-alt);
+      color: var(--ink);
+      font-size: 14px;
+      line-height: 1.4;
+    }
+    .page { max-width: 1400px; margin: 0 auto; padding: 2rem; background: var(--bg); }
+    h1, h2, h3, h4, h5 { font-weight: 400; margin-top: 0; }
+    h2 { font-size: 1.75rem; margin-bottom: 0.5rem; }
+    h3 { font-size: 1.25rem; margin-bottom: 0.75rem; }
+    h5 { font-size: 1rem; margin-bottom: 0.5rem; }
+    .muted { color: var(--ink-muted); font-size: 0.875rem; }
+
+    .tile { background: var(--bg); border: 1px solid var(--gray-20); padding: 1rem 1.25rem; margin-bottom: 1rem; }
+
+    .ctx-card { display: flex; flex-wrap: wrap; gap: 1.5rem; align-items: center; }
+    .ctx-card > div { min-width: 90px; }
+    .ctx-card strong { font-size: 0.75rem; color: var(--ink-muted); display: block; margin-bottom: 0.25rem; text-transform: uppercase; letter-spacing: 0.02em; }
+
+    .tag {
+      display: inline-block;
+      padding: 0.15rem 0.6rem;
+      border-radius: 10px;
+      font-size: 0.75rem;
+      margin-right: 0.3rem;
+      margin-bottom: 0.25rem;
+      white-space: nowrap;
+    }
+    .tag.gray   { background: var(--gray-20); color: var(--ink); }
+    .tag.purple { background: #e8daff; color: #491d8b; }
+    .tag.blue   { background: #d0e2ff; color: #002d9c; }
+    .tag.cyan   { background: #bae6ff; color: #003a6d; }
+    .tag.teal   { background: #9ef0f0; color: #003a3a; }
+    .tag.red    { background: #ffd7d9; color: #750e13; }
+
+    .btn {
+      background: var(--blue-60);
+      color: white;
+      border: 1px solid var(--blue-60);
+      padding: 0.5rem 1rem;
+      cursor: pointer;
+      font-family: inherit;
+      font-size: 0.875rem;
+    }
+    .btn.secondary { background: white; color: var(--blue-60); }
+    .btn.tertiary  { background: white; color: var(--ink); border-color: var(--ink); }
+    .btn.ghost     { background: transparent; color: var(--blue-60); border: none; padding: 0.25rem 0.5rem; }
+    .btn.disabled, .btn:disabled { background: var(--gray-20); color: var(--ink-muted); border-color: var(--gray-20); cursor: not-allowed; }
+
+    table { width: 100%; border-collapse: collapse; background: var(--bg); }
+    th, td { text-align: left; padding: 0.75rem; border-bottom: 1px solid var(--gray-20); font-size: 0.875rem; vertical-align: top; }
+    th { background: var(--bg-alt); font-weight: 600; }
+
+    .notif {
+      border-left: 3px solid var(--blue-60);
       padding: 0.75rem 1rem;
-      border-bottom: 1px solid #e0e0e0;
-      background: #fafafa;
+      margin-bottom: 1rem;
+      background: var(--info-bg);
     }
-    .section-heading h3 { margin: 0; font-weight: 600; font-size: 14px; }
-    .section-heading p { margin: 0.25rem 0 0; color: #525252; font-size: 12px; }
-    .toolbar {
-      display: flex; align-items: center; justify-content: space-between;
-      padding: 0.5rem 1rem; border-bottom: 1px solid #e0e0e0; background: #fafafa;
+    .notif.success { border-color: #24a148; background: var(--success-bg); }
+    .notif.warn    { border-color: #f1c21b; background: var(--warn-bg); }
+    .notif.info    { border-color: var(--blue-60); background: var(--info-bg); }
+    .notif strong  { display: block; margin-bottom: 0.25rem; }
+    .notif span    { font-size: 0.8125rem; color: var(--ink-muted); }
+
+    .expand {
+      background: var(--bg-alt);
+      border-left: 4px solid var(--purple-60);
+      padding: 1rem 1.5rem;
     }
-    .cds--data-table td, .cds--data-table th { padding: 0.75rem 1rem; vertical-align: middle; }
-    .stepper {
-      display: flex; gap: 0; margin-bottom: 1rem; background: #fff;
-      padding: 1rem 1.5rem; border: 1px solid #e0e0e0;
+
+    .labels-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 1rem;
+      margin-bottom: 1rem;
     }
-    .step { flex: 1; display: flex; align-items: center; gap: 0.5rem; padding: 0.5rem 0; position: relative; }
-    .step-circle {
-      width: 20px; height: 20px; border-radius: 50%; border: 2px solid #8d8d8d;
-      display: inline-flex; align-items: center; justify-content: center;
-      font-size: 11px; color: #525252; flex-shrink: 0;
+    .labels-grid label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--ink-muted);
+      margin-bottom: 0.25rem;
     }
-    .step.complete .step-circle { background: #198038; border-color: #198038; color: #fff; }
-    .step.current .step-circle { background: #0f62fe; border-color: #0f62fe; color: #fff; }
-    .step.disabled { opacity: 0.5; }
-    .step-label { font-size: 13px; }
-    .step.current .step-label { font-weight: 600; }
-    .ctx-card {
-      background: #fff; border: 1px solid #e0e0e0; padding: 1rem 1.5rem;
-      display: grid; grid-template-columns: auto 2fr 1fr 1.5fr; gap: 1.5rem; margin-bottom: 1rem;
+    .num-input {
+      display: flex;
+      border: 1px solid var(--gray-20);
+      width: 120px;
     }
-    .ctx-item-label { font-size: 11px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px; }
-    .ctx-item-value { font-size: 14px; font-weight: 500; margin-top: 2px; }
-    .ctx-item-value.big { font-size: 20px; font-weight: 600; }
-    .ctx-item-sub { font-size: 11px; color: #525252; }
-    .inline-form {
-      background: #f4f4f4; padding: 1rem; border-left: 3px solid #8a3ffc;
+    .num-input button { border: none; background: var(--bg-alt); padding: 0 0.5rem; cursor: pointer; }
+    .num-input input  { border: none; padding: 0.5rem; width: 60px; text-align: center; font-family: inherit; }
+
+    .toolbar-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 0.5rem;
     }
-    .inline-form h5 { margin: 0 0 0.75rem; font-size: 13px; font-weight: 600; }
-    .form-grid { display: grid; grid-template-columns: 2fr 1fr; gap: 0.75rem; margin-bottom: 0.75rem; }
-    .form-grid.single { grid-template-columns: 1fr; }
-    .form-actions { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
-    .inline-field label { font-size: 11px; color: #525252; display: block; margin-bottom: 4px; font-weight: 500; }
-    .inline-field input, .inline-field textarea, .inline-field select {
-      width: 100%; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
-      background: #fff; font-family: inherit; font-size: 13px;
+    .accordion-header {
+      background: var(--bg-alt);
+      padding: 0.75rem 1rem;
+      border: 1px solid var(--gray-20);
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-weight: 600;
     }
-    .breadcrumb { font-size: 12px; color: #525252; margin-bottom: 0.75rem; }
-    .breadcrumb a { color: #0f62fe; text-decoration: none; }
-    .breadcrumb .current { color: #161616; }
-    .modal-backdrop {
-      position: fixed; inset: 0; background: rgba(22,22,22,0.5);
-      display: flex; align-items: center; justify-content: center; z-index: 10;
+    .accordion-body { padding: 1rem; border: 1px solid var(--gray-20); border-top: none; }
+
+    .footer-nav { display: flex; justify-content: space-between; margin-top: 2rem; padding-top: 1rem; border-top: 1px solid var(--gray-20); }
+
+    select, input[type="text"], textarea {
+      width: 100%;
+      padding: 0.5rem;
+      font-family: inherit;
+      font-size: 0.875rem;
+      border: 1px solid var(--gray-20);
+      background: var(--bg);
+      margin-bottom: 0.5rem;
     }
-    .modal {
-      background: #fff; width: 560px; max-width: 90vw; max-height: 90vh; overflow: auto;
-      display: flex; flex-direction: column;
+    label.field-label {
+      display: block;
+      font-size: 0.75rem;
+      color: var(--ink-muted);
+      margin-bottom: 0.25rem;
     }
-    .modal-header {
-      padding: 1rem 1.5rem 0.5rem; font-size: 18px; font-weight: 400;
-    }
-    .modal-body { padding: 1rem 1.5rem; }
-    .modal-footer { padding: 1rem 1.5rem; display: flex; justify-content: flex-end; gap: 0; border-top: 1px solid #e0e0e0; }
-    .modal-footer .cds--btn { flex: 1; max-width: 50%; justify-content: flex-start; padding: 0.875rem 1rem; }
-    .notif-preview { margin: 0.75rem 0; }
-    .referred-details { font-size: 11px; color: #525252; margin-top: 4px; font-style: italic; }
-    .dashboard-preview { margin-top: 2rem; padding: 1.5rem; background: #fff; border: 1px solid #e0e0e0; }
-    .dashboard-preview h3 { margin-top: 0; }
-    .filter-row { display: flex; gap: 0.75rem; align-items: flex-end; margin-bottom: 1rem; padding: 1rem; background: #fafafa; }
-    .filter-row label { font-size: 11px; color: #525252; display: block; margin-bottom: 4px; }
-    .filter-row .cds--select { min-width: 180px; }
-    .badge-pill {
-      display: inline-flex; align-items: center; gap: 0.5rem;
-      background: #e8daff; color: #491d8b; padding: 4px 12px; border-radius: 12px;
-      font-size: 12px; font-weight: 500;
-    }
-    .badge-pill-count {
-      background: #491d8b; color: #fff; padding: 1px 8px; border-radius: 10px; font-size: 11px;
-    }
+    .section-title { margin: 2rem 0 0.75rem; padding-top: 1rem; border-top: 1px solid var(--gray-20); }
+    .section-title small { font-weight: 400; color: var(--ink-muted); }
+    .chip-cell .tag { margin-bottom: 0.25rem; }
   </style>
 </head>
-<body class="cds--white">
-  <div class="preview-banner">
-    Visual Preview &nbsp;|&nbsp; Label &amp; Store — Refer Out Addendum &nbsp;|&nbsp; OpenELIS Sample Collection Redesign v2.1 &nbsp;|&nbsp; Not a live application
+<body>
+
+<div class="page">
+
+  <h2>Step 3 — Label &amp; Store</h2>
+  <p class="muted">
+    Print labels, assign storage, and refer samples to external labs.
+    Referrals are assigned per physical sample — every test on a referred sample travels with the specimen.
+  </p>
+
+  <!-- ======================================================================
+       Order context card — with Referred chip (REF-8)
+  ======================================================================= -->
+  <div class="tile ctx-card">
+    <div><strong>Lab #</strong>2026-00412</div>
+    <div><strong>Patient</strong>Siti Rahayu</div>
+    <div><strong>Patient ID</strong>P-88103</div>
+    <div><strong>Facility</strong>Puskesmas Kebayoran</div>
+    <div><strong>Priority</strong><span class="tag teal">Routine</span></div>
+    <div><strong>Samples</strong>2</div>
+    <div><strong>Referred</strong><span class="tag purple">Referred (1 of 2 samples)</span></div>
   </div>
-  <div class="preview-content" id="root"></div>
-  <script type="text/babel">
-    const { useState, useMemo, useCallback, Fragment } = React;
 
-    // ---------------------------------------------------------------
-    // Mock data
-    // ---------------------------------------------------------------
-    const REFERRING_LABS = [
-      { id: 'lab-01', text: 'Balai Besar Teknik Kesehatan Lingkungan (BBTKL) Jakarta', fhirEnabled: true },
-      { id: 'lab-02', text: 'Laboratorium Kesehatan Daerah — Yogyakarta', fhirEnabled: true },
-      { id: 'lab-03', text: 'Eijkman Institute — Molecular Reference Lab', fhirEnabled: false },
-      { id: 'lab-04', text: 'National Reference Laboratory — Antananarivo', fhirEnabled: true },
-    ];
+  <!-- ======================================================================
+       Print Labels section (LBL-2) — collapsed accordion style
+  ======================================================================= -->
+  <div class="accordion-header">
+    Print Labels (LBL-2) — travels with every sample, including referred ones
+    <span>▼</span>
+  </div>
+  <div class="accordion-body">
+    <p class="muted" style="margin-top:0;margin-bottom:1rem;">
+      Labels travel with specimens — including referred ones. Keep label quantity ≥ 1 for any sample being shipped externally.
+    </p>
+    <div class="labels-grid">
+      <div>
+        <label>Order Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="1" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Sample Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="2" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Slide Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="0" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Block Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="0" /><button>+</button></div>
+      </div>
+      <div>
+        <label>Freezer Label</label>
+        <div class="num-input"><button>−</button><input type="text" value="1" /><button>+</button></div>
+      </div>
+    </div>
+    <button class="btn secondary">🖨 Print All Labels</button>
+  </div>
 
-    const INITIAL_ROWS = [
-      { id: 'r1', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412',
-        storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Viral Load (PCR)', referralState: 'inhouse' },
-      { id: 'r2', sampleId: 'S.2026-00412.1', sampleType: 'Whole Blood EDTA', labNumber: '2026-00412',
-        storage: 'Fridge A / Shelf 2 / Pos 14', test: 'HIV Drug Resistance Genotyping', referralState: 'inhouse' },
-      { id: 'r3', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412',
-        storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis B DNA Quantitative', referralState: 'inhouse' },
-      { id: 'r4', sampleId: 'S.2026-00412.2', sampleType: 'Plasma', labNumber: '2026-00412',
-        storage: 'Freezer B / Rack 1 / Pos 3', test: 'Hepatitis C RNA Quantitative', referralState: 'inhouse' },
-    ];
+  <!-- ======================================================================
+       Toolbar — bulk refer out + counts
+  ======================================================================= -->
+  <div class="toolbar-row" style="margin-top:1.5rem;">
+    <div class="muted">1 in-house sample • 1 referred</div>
+    <button class="btn tertiary">Bulk Refer Out ↗</button>
+  </div>
 
-    // Dashboard mock data (for lower preview panel)
-    const DASHBOARD_ORDERS = [
-      { lab: '2026-00408', patient: 'Budi Hartono', facility: 'Puskesmas Kramat Jati', priority: 'Routine',
-        status: 'Awaiting QA', referredTag: null, step: 4 },
-      { lab: '2026-00410', patient: 'Fitri Ananda', facility: 'RS Cipto Mangunkusumo', priority: 'Urgent',
-        status: 'Labeling', referredTag: 'Referred (1 of 3)', step: 3 },
-      { lab: '2026-00412', patient: 'Sari Wulandari', facility: 'RS Hasan Sadikin Bandung', priority: 'Routine',
-        status: 'Labeling', referredTag: 'Referred (2 of 4)', step: 3 },
-      { lab: '2026-00413', patient: 'Arya Pratama', facility: 'Klinik Harapan', priority: 'Routine',
-        status: 'Referred Out', referredTag: 'Referred (all)', step: 4, fullyReferred: true },
-      { lab: '2026-00414', patient: 'Nadia Safitri', facility: 'RS Pondok Indah', priority: 'Routine',
-        status: 'Completed', referredTag: null, step: 4 },
-    ];
+  <!-- ======================================================================
+       Samples table — sample-centric rows (LBL-5)
+  ======================================================================= -->
+  <table>
+    <thead>
+      <tr>
+        <th style="width:2rem;"></th>
+        <th>Sample ID</th>
+        <th>Type / Qty</th>
+        <th>Tests on this sample</th>
+        <th>Storage Location</th>
+        <th>Labels</th>
+        <th>Refer Out</th>
+        <th style="width:3rem;"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <!-- Row 1: In-house sample with inline refer-out form expanded -->
+      <tr>
+        <td><button class="btn ghost">▲</button></td>
+        <td><strong>S.2026-00412.1</strong><br /><span class="muted">Collected 2026-04-22 09:14</span></td>
+        <td>Whole Blood (EDTA)<br /><span class="muted">4 mL</span></td>
+        <td class="chip-cell">
+          <span class="tag cyan">HIV Viral Load</span>
+          <span class="tag cyan">CD4 Count</span>
+        </td>
+        <td><button class="btn ghost">F-02 / S-3 / B-14 / A4</button></td>
+        <td><button class="btn ghost">🖨 Print (2)</button></td>
+        <td><span class="tag gray">In-house</span></td>
+        <td><button class="btn ghost">⋯</button></td>
+      </tr>
 
-    // ---------------------------------------------------------------
-    // Helpers
-    // ---------------------------------------------------------------
-    function StatusTag({ state, labName, onRetry }) {
-      if (state === 'inhouse') return <span className="cds--tag cds--tag--gray">In-house</span>;
-      if (state === 'referred') return (
-        <span className="cds--tag cds--tag--purple" title={labName}>Referred — {truncate(labName, 32)}</span>
-      );
-      if (state === 'sent') return <span className="cds--tag cds--tag--blue">Awaiting External Results</span>;
-      if (state === 'failed') return (
-        <span style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-          <span className="cds--tag cds--tag--red">Send Failed</span>
-          <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={onRetry}>Retry Send</button>
-        </span>
-      );
-      return null;
-    }
-
-    function truncate(s, n) { return s && s.length > n ? s.slice(0, n - 1) + '…' : s; }
-
-    function deriveOrderStatus(rows) {
-      const active = rows.filter(r => !r.voided);
-      const referredCount = active.filter(r => r.referralState !== 'inhouse').length;
-      const total = active.length;
-      if (total === 0) return 'LABELING';
-      if (referredCount === total) return 'REFERRED_OUT';
-      return 'LABELING';
-    }
-
-    function HeaderStatusBadge({ orderStatus, rows }) {
-      if (orderStatus === 'REFERRED_OUT') return <span className="cds--tag cds--tag--purple">Referred Out</span>;
-      const referredCount = rows.filter(r => r.referralState !== 'inhouse').length;
-      const total = rows.length;
-      if (referredCount > 0) return (
-        <Fragment>
-          <span className="cds--tag cds--tag--blue">Labeling</span>
-          <span className="cds--tag cds--tag--purple" style={{ marginLeft: '0.25rem' }}>
-            Referred ({referredCount} of {total})
-          </span>
-        </Fragment>
-      );
-      return <span className="cds--tag cds--tag--blue">Labeling</span>;
-    }
-
-    // ---------------------------------------------------------------
-    // Inline per-row refer form
-    // ---------------------------------------------------------------
-    function InlineReferForm({ row, onSave, onCancel, xoaEnabled }) {
-      const [referringLabId, setReferringLabId] = useState('');
-      const [reason, setReason] = useState('');
-      const [expectedReturn, setExpectedReturn] = useState('');
-      const [notifyCustomer, setNotifyCustomer] = useState(true);
-      const [error, setError] = useState(null);
-
-      const save = () => {
-        if (!referringLabId) {
-          setError('Select a referring lab before saving.');
-          return;
-        }
-        const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-        onSave({ rowId: row.id, lab, reason, expectedReturn, notifyCustomer });
-      };
-
-      return (
-        <div className="inline-form">
-          <h5>Refer Out — {row.test}</h5>
-          {error && (
-            <div className="cds--inline-notification cds--inline-notification--error" style={{ marginBottom: '0.75rem' }}>
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">{error}</div>
-                </div>
-              </div>
+      <!-- Inline expansion row (LBL-6) -->
+      <tr>
+        <td colspan="8" style="padding:0;">
+          <div class="expand">
+            <h5>Refer Sample to External Lab</h5>
+            <div class="notif info" style="margin-bottom:1rem;">
+              <strong>Sample-level referral</strong>
+              <span>This will refer Whole Blood (EDTA) (S.2026-00412.1) and all 2 tests on it: HIV Viral Load, CD4 Count.</span>
             </div>
-          )}
-          <div className="form-grid">
-            <div className="inline-field">
-              <label>Referring Lab *</label>
-              <select value={referringLabId} onChange={(e) => setReferringLabId(e.target.value)}>
-                <option value="">Select a referring lab…</option>
-                {REFERRING_LABS.map(lab => (
-                  <option key={lab.id} value={lab.id}>
-                    {lab.text}{lab.fhirEnabled ? '' : ' (paper/manifest only)'}
-                  </option>
-                ))}
-              </select>
-            </div>
-            <div className="inline-field">
-              <label>Expected Return Date</label>
-              <input type="date" value={expectedReturn} onChange={(e) => setExpectedReturn(e.target.value)} />
-            </div>
-          </div>
-          <div className="form-grid single">
-            <div className="inline-field">
-              <label>Reason (optional, max 500)</label>
-              <textarea rows="2" maxLength="500" value={reason} onChange={(e) => setReason(e.target.value)} />
-            </div>
-          </div>
-          {xoaEnabled && (
-            <div className="inline-field" style={{ marginBottom: '0.5rem' }}>
-              <label style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-                <input type="checkbox" checked={notifyCustomer} onChange={(e) => setNotifyCustomer(e.target.checked)} />
-                Notify customer of referral
-              </label>
-            </div>
-          )}
-          <div className="form-actions">
-            <button className="cds--btn cds--btn--primary cds--btn--sm" onClick={save}>Save Referral</button>
-            <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={onCancel}>Cancel</button>
-          </div>
-        </div>
-      );
-    }
-
-    // ---------------------------------------------------------------
-    // Bulk modal
-    // ---------------------------------------------------------------
-    function BulkReferModal({ open, onClose, onConfirm, pendingRows, xoaEnabled }) {
-      const [referringLabId, setReferringLabId] = useState('');
-      const [reason, setReason] = useState('');
-      const [expectedReturn, setExpectedReturn] = useState('');
-      const [notifyCustomer, setNotifyCustomer] = useState(true);
-
-      if (!open) return null;
-
-      const sampleCount = new Set(pendingRows.map(r => r.sampleId)).size;
-      const testCount = pendingRows.length;
-      const lab = REFERRING_LABS.find(l => l.id === referringLabId);
-
-      const reset = () => { setReferringLabId(''); setReason(''); setExpectedReturn(''); setNotifyCustomer(true); };
-      const closeAndReset = () => { reset(); onClose(); };
-      const handleConfirm = () => {
-        if (!referringLabId || testCount === 0) return;
-        onConfirm({ lab, reason, expectedReturn, notifyCustomer });
-        reset();
-      };
-
-      return (
-        <div className="modal-backdrop" onClick={closeAndReset}>
-          <div className="modal" onClick={(e) => e.stopPropagation()}>
-            <div className="modal-header">Refer All Tests to External Lab</div>
-            <div className="modal-body">
-              {testCount === 0 ? (
-                <div className="cds--inline-notification cds--inline-notification--info">
-                  <div className="cds--inline-notification__details">
-                    <div className="cds--inline-notification__text-wrapper">
-                      <div className="cds--inline-notification__title">
-                        No in-house tests to refer. All tests on this order are already referred.
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ) : (
-                <Fragment>
-                  <div className="form-grid single" style={{ marginBottom: '1rem' }}>
-                    <div className="inline-field">
-                      <label>Referring Lab *</label>
-                      <select value={referringLabId} onChange={(e) => setReferringLabId(e.target.value)}>
-                        <option value="">Select a referring lab…</option>
-                        {REFERRING_LABS.map(lab => (
-                          <option key={lab.id} value={lab.id}>
-                            {lab.text}{lab.fhirEnabled ? '' : ' (paper/manifest only)'}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                  </div>
-                  <div className="form-grid">
-                    <div className="inline-field">
-                      <label>Expected Return Date</label>
-                      <input type="date" value={expectedReturn} onChange={(e) => setExpectedReturn(e.target.value)} />
-                    </div>
-                    <div className="inline-field">
-                      <label>Reason (optional)</label>
-                      <input type="text" maxLength="500" value={reason} onChange={(e) => setReason(e.target.value)} />
-                    </div>
-                  </div>
-                  {xoaEnabled && (
-                    <div className="inline-field" style={{ marginBottom: '0.75rem' }}>
-                      <label style={{ display: 'inline-flex', gap: '0.5rem', alignItems: 'center' }}>
-                        <input type="checkbox" checked={notifyCustomer} onChange={(e) => setNotifyCustomer(e.target.checked)} />
-                        Notify customer of referral
-                      </label>
-                    </div>
-                  )}
-                  <div className="cds--inline-notification cds--inline-notification--warning">
-                    <div className="cds--inline-notification__details">
-                      <div className="cds--inline-notification__text-wrapper">
-                        <div className="cds--inline-notification__title">
-                          This will refer {testCount} test{testCount === 1 ? '' : 's'} on {sampleCount} sample{sampleCount === 1 ? '' : 's'}{lab ? ` to ${lab.text}` : ''}.
-                        </div>
-                        <div className="cds--inline-notification__subtitle">
-                          {lab && !lab.fhirEnabled ? 'This lab is paper/manifest only — no FHIR transmission will occur.'
-                           : lab ? 'FHIR ServiceRequest will be transmitted to the receiving lab.'
-                           : 'Select a referring lab to see transmission details.'}
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </Fragment>
-              )}
-            </div>
-            <div className="modal-footer">
-              <button className="cds--btn cds--btn--secondary" onClick={closeAndReset}>Cancel</button>
-              <button className="cds--btn cds--btn--primary" disabled={!referringLabId || testCount === 0} onClick={handleConfirm}>
-                Refer All
-              </button>
-            </div>
-          </div>
-        </div>
-      );
-    }
-
-    // ---------------------------------------------------------------
-    // Main app
-    // ---------------------------------------------------------------
-    function App() {
-      const [rows, setRows] = useState(INITIAL_ROWS);
-      const [expandedRowId, setExpandedRowId] = useState(null);
-      const [bulkOpen, setBulkOpen] = useState(false);
-      const [notification, setNotification] = useState(null);
-      const [dashboardFilter, setDashboardFilter] = useState('any');
-
-      const xoaEnabled = true;
-      const allowBulkReferOut = true;
-      const orderStatus = useMemo(() => deriveOrderStatus(rows), [rows]);
-      const pendingInhouseRows = useMemo(() => rows.filter(r => r.referralState === 'inhouse'), [rows]);
-
-      const toggleExpand = (rowId) => setExpandedRowId(prev => prev === rowId ? null : rowId);
-
-      const savePerRowReferral = ({ rowId, lab, reason, expectedReturn, notifyCustomer }) => {
-        setRows(prev => prev.map(r =>
-          r.id === rowId
-            ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-                reason, expectedReturn, notifyCustomer }
-            : r
-        ));
-        setExpandedRowId(null);
-        setNotification({ kind: 'success', title: `Referred 1 test to ${lab.text}.` });
-        setTimeout(() => setNotification(null), 5000);
-      };
-
-      const confirmBulk = ({ lab, reason, expectedReturn, notifyCustomer }) => {
-        const pendingIds = pendingInhouseRows.map(r => r.id);
-        setRows(prev => prev.map(r =>
-          pendingIds.includes(r.id)
-            ? { ...r, referralState: 'referred', referringLab: lab.text, fhirEnabled: lab.fhirEnabled,
-                reason, expectedReturn, notifyCustomer }
-            : r
-        ));
-        setBulkOpen(false);
-        setNotification({ kind: 'success', title: `Referred ${pendingIds.length} tests to ${lab.text}.` });
-        setTimeout(() => setNotification(null), 5000);
-      };
-
-      const undoReferral = (rowId) => {
-        setRows(prev => prev.map(r => r.id === rowId ? {
-          ...r, referralState: 'inhouse', referringLab: null, fhirEnabled: null,
-          reason: null, expectedReturn: null, notifyCustomer: null
-        } : r));
-        setNotification({ kind: 'info', title: 'Referral undone. Test returned to in-house queue.' });
-        setTimeout(() => setNotification(null), 4000);
-      };
-
-      // Dashboard filter
-      const filteredDashboard = DASHBOARD_ORDERS.filter(o => {
-        if (dashboardFilter === 'any') return true;
-        if (dashboardFilter === 'hasReferred') return o.referredTag !== null;
-        if (dashboardFilter === 'fullyReferred') return o.fullyReferred;
-        return true;
-      });
-
-      return (
-        <Fragment>
-          {/* Step 3 Label & Store */}
-          <div className="breadcrumb">
-            <a href="#">Add Order</a> / <a href="#">Order 2026-00412</a> / <span className="current">Label &amp; Store</span>
-          </div>
-
-          <div className="stepper">
-            <div className="step complete"><span className="step-circle">✓</span><span className="step-label">Enter Order</span></div>
-            <div className="step complete"><span className="step-circle">✓</span><span className="step-label">Collect Sample</span></div>
-            <div className="step current"><span className="step-circle">3</span><span className="step-label">Label &amp; Store</span></div>
-            <div className={'step ' + (orderStatus === 'REFERRED_OUT' ? 'disabled' : '')}>
-              <span className="step-circle">4</span>
-              <span className="step-label">
-                QA Review {orderStatus === 'REFERRED_OUT' && <em style={{ fontSize: '11px', color: '#525252' }}>(skipped — fully referred)</em>}
-              </span>
-            </div>
-          </div>
-
-          {/* Order Context Card */}
-          <div className="ctx-card">
-            <div>
-              <div className="ctx-item-label">Lab Number</div>
-              <div className="ctx-item-value big">2026-00412</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Patient</div>
-              <div className="ctx-item-value">Ibu Sari Wulandari</div>
-              <div className="ctx-item-sub">F · 34 · NIK 3174012345678901</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Tests</div>
-              <div className="ctx-item-value">{rows.length} tests · {new Set(rows.map(r => r.sampleId)).size} samples</div>
-            </div>
-            <div>
-              <div className="ctx-item-label">Status</div>
-              <div style={{ marginTop: '0.25rem', display: 'flex', gap: '0.25rem', flexWrap: 'wrap' }}>
-                <HeaderStatusBadge orderStatus={orderStatus} rows={rows} />
-              </div>
-            </div>
-          </div>
-
-          {notification && (
-            <div className={'cds--inline-notification cds--inline-notification--' + notification.kind + ' notif-preview'}>
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">{notification.title}</div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {orderStatus === 'REFERRED_OUT' && (
-            <div className="cds--inline-notification cds--inline-notification--info notif-preview">
-              <div className="cds--inline-notification__details">
-                <div className="cds--inline-notification__text-wrapper">
-                  <div className="cds--inline-notification__title">Order fully referred out</div>
-                  <div className="cds--inline-notification__subtitle">
-                    All tests are referred to an external lab. Step 4 QA Review is skipped — the order will complete when external results return via referral result entry.
-                  </div>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Samples & Tests table */}
-          <div className="section">
-            <div className="section-heading">
-              <h3>Samples &amp; Tests</h3>
-              <p>Assign storage location, print labels, and refer individual tests or the whole order to an external lab.</p>
-            </div>
-            <div className="toolbar">
-              <button
-                className="cds--btn cds--btn--secondary cds--btn--sm"
-                disabled={!allowBulkReferOut || pendingInhouseRows.length === 0}
-                onClick={() => setBulkOpen(true)}
-              >
-                Bulk Refer Out{pendingInhouseRows.length > 0 ? ` (${pendingInhouseRows.length})` : ''}
-              </button>
-              <button className="cds--btn cds--btn--primary cds--btn--sm">Save &amp; Next</button>
-            </div>
-            <div className="cds--data-table-container">
-              <table className="cds--data-table">
-                <thead>
-                  <tr>
-                    <th>Sample</th><th>Type</th><th>Storage</th><th>Test</th><th>Refer Out</th><th></th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {rows.map(row => {
-                    const isExpanded = expandedRowId === row.id;
-                    return (
-                      <Fragment key={row.id}>
-                        <tr>
-                          <td><code style={{ fontSize: '12px' }}>{row.sampleId}</code></td>
-                          <td>{row.sampleType}</td>
-                          <td><span style={{ fontSize: '11px', color: '#525252' }}>{row.storage}</span></td>
-                          <td>{row.test}</td>
-                          <td>
-                            <StatusTag state={row.referralState} labName={row.referringLab} />
-                            {row.referralState === 'referred' && row.referringLab && (
-                              <div className="referred-details">
-                                {row.fhirEnabled ? 'FHIR transmission queued' : 'Paper/manifest referral'}
-                                {row.expectedReturn ? ' · return by ' + row.expectedReturn : ''}
-                              </div>
-                            )}
-                          </td>
-                          <td style={{ textAlign: 'right' }}>
-                            {row.referralState === 'inhouse' ? (
-                              <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={() => toggleExpand(row.id)}>
-                                {isExpanded ? 'Close' : 'Refer Out'}
-                              </button>
-                            ) : (
-                              <button className="cds--btn cds--btn--ghost cds--btn--sm" onClick={() => undoReferral(row.id)}>
-                                Undo Referral
-                              </button>
-                            )}
-                          </td>
-                        </tr>
-                        {isExpanded && (
-                          <tr>
-                            <td colSpan="6" style={{ padding: 0 }}>
-                              <InlineReferForm row={row} xoaEnabled={xoaEnabled}
-                                onCancel={() => setExpandedRowId(null)}
-                                onSave={savePerRowReferral} />
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          {/* Dashboard filter preview */}
-          <div className="dashboard-preview">
-            <h3 style={{ fontWeight: 600, fontSize: '16px' }}>Order Dashboard — Referred Out filter</h3>
-            <p style={{ color: '#525252', fontSize: '13px', marginTop: 0 }}>
-              New filter on the Order Entry dashboard. Try changing it to see which orders qualify.
-            </p>
-            <div className="filter-row">
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
               <div>
-                <label>Status</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" disabled>
-                    <option>All</option>
-                  </select>
-                </div>
+                <label class="field-label">Referring Lab (required)</label>
+                <select>
+                  <option>Select a referring lab…</option>
+                  <option selected>BBTKL Jakarta (FHIR) • TAT 5 days</option>
+                  <option>Eijkman Institute (FHIR) • TAT 3 days</option>
+                  <option>Prodia Reference Lab • TAT 7 days</option>
+                  <option>SILNAS Bandung (FHIR) • TAT 4 days</option>
+                </select>
               </div>
               <div>
-                <label>Priority</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" disabled>
-                    <option>Any</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label style={{ fontWeight: 600, color: '#8a3ffc' }}>Referred Out (new)</label>
-                <div className="cds--select">
-                  <select className="cds--select-input" value={dashboardFilter} onChange={(e) => setDashboardFilter(e.target.value)}>
-                    <option value="any">Any</option>
-                    <option value="hasReferred">Has Referred Tests</option>
-                    <option value="fullyReferred">Fully Referred Out</option>
-                  </select>
-                </div>
-              </div>
-              <div style={{ marginLeft: 'auto' }}>
-                <span className="badge-pill">
-                  Awaiting External Results <span className="badge-pill-count">3</span>
-                </span>
+                <label class="field-label">Expected Return Date (optional)</label>
+                <input type="text" placeholder="yyyy-mm-dd" value="2026-04-28" />
               </div>
             </div>
-            <div className="cds--data-table-container">
-              <table className="cds--data-table">
-                <thead>
-                  <tr>
-                    <th>Lab Number</th><th>Patient</th><th>Facility</th><th>Priority</th>
-                    <th>Status</th><th>Step</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredDashboard.map(o => (
-                    <tr key={o.lab}>
-                      <td><code style={{ fontSize: '12px' }}>{o.lab}</code></td>
-                      <td>{o.patient}</td>
-                      <td style={{ fontSize: '12px' }}>{o.facility}</td>
-                      <td>{o.priority}</td>
-                      <td>
-                        <span className={'cds--tag cds--tag--' + (o.status === 'Referred Out' ? 'purple'
-                          : o.status === 'Completed' ? 'green' : o.status === 'Awaiting QA' ? 'warm-gray' : 'blue')}>
-                          {o.status}
-                        </span>
-                        {o.referredTag && o.status !== 'Referred Out' && (
-                          <span className="cds--tag cds--tag--purple" style={{ marginLeft: '0.25rem' }}>
-                            {o.referredTag}
-                          </span>
-                        )}
-                      </td>
-                      <td style={{ fontSize: '12px', color: '#525252' }}>
-                        Step {o.step}{o.fullyReferred ? ' (skipped)' : ''}
-                      </td>
-                    </tr>
-                  ))}
-                  {filteredDashboard.length === 0 && (
-                    <tr><td colSpan="6" style={{ textAlign: 'center', color: '#525252', padding: '2rem' }}>
-                      No orders match this filter.
-                    </td></tr>
-                  )}
-                </tbody>
-              </table>
+            <label class="field-label" style="margin-top:0.5rem;">Reason (optional)</label>
+            <textarea rows="2" placeholder="e.g., Local VL platform offline until Monday.">Local VL platform offline; sending full panel upstream.</textarea>
+            <label><input type="checkbox" checked /> Notify customer of referral (X-01 REFERRAL_OUT event)</label>
+            <div style="margin-top:1rem;">
+              <button class="btn">Save Referral ↗</button>
+              <button class="btn ghost">Cancel</button>
             </div>
           </div>
+        </td>
+      </tr>
 
-          <BulkReferModal
-            open={bulkOpen}
-            onClose={() => setBulkOpen(false)}
-            onConfirm={confirmBulk}
-            pendingRows={pendingInhouseRows}
-            xoaEnabled={xoaEnabled}
-          />
-        </Fragment>
-      );
-    }
+      <!-- Row 2: Referred sample -->
+      <tr>
+        <td><button class="btn ghost">▼</button></td>
+        <td><strong>S.2026-00412.2</strong><br /><span class="muted">Collected 2026-04-22 09:18</span></td>
+        <td>Plasma<br /><span class="muted">2 mL</span></td>
+        <td class="chip-cell">
+          <span class="tag purple">Hepatitis B DNA PCR</span>
+          <span class="tag purple">HCV Antibody</span>
+        </td>
+        <td><button class="btn ghost">F-04 / S-1 / B-07 / C2</button></td>
+        <td><button class="btn ghost">🖨 Print (1)</button></td>
+        <td><span class="tag purple">Referred — Eijkman Institute</span></td>
+        <td><button class="btn ghost">⋯</button></td>
+      </tr>
+    </tbody>
+  </table>
 
-    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
-  </script>
+  <!-- Info banner for mixed partial-referral state -->
+  <div class="notif info" style="margin-top:1rem;">
+    <strong>Partial referral in progress.</strong>
+    <span>This order has 1 in-house sample (HIV Viral Load, CD4 Count) and 1 referred sample. Order will continue through QA Review for the in-house sample. (REF-5, BR-REF-3)</span>
+  </div>
+
+  <div class="footer-nav">
+    <button class="btn secondary">← Back to Step 2 (Collect Sample)</button>
+    <button class="btn">Save &amp; Next → Step 4 (QA Review)</button>
+  </div>
+
+  <!-- ======================================================================
+       Fully-referred example (all samples)
+  ======================================================================= -->
+  <h3 class="section-title">Fully-referred example <small>(same screen, different order state)</small></h3>
+  <div class="notif info">
+    <strong>All samples referred — QA will be skipped (REF-2, REF-3).</strong>
+    <span>Order auto-transitions to REFERRED_OUT on save. The QA Review queue will not show this order. When external results return, the order auto-approves (REF-4).</span>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Sample ID</th>
+        <th>Type</th>
+        <th>Tests</th>
+        <th>Storage</th>
+        <th>Refer Out</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td><strong>S.2026-00415.1</strong></td>
+        <td>Plasma — 3 mL</td>
+        <td class="chip-cell">
+          <span class="tag purple">HIV Viral Load</span>
+          <span class="tag purple">CD4 Count</span>
+          <span class="tag purple">Hepatitis B DNA PCR</span>
+        </td>
+        <td>F-02 / S-1 / B-03 / B7</td>
+        <td><span class="tag blue">Sent to External — BBTKL Jakarta</span></td>
+      </tr>
+    </tbody>
+  </table>
+  <div class="footer-nav">
+    <button class="btn secondary">← Back to Step 2</button>
+    <button class="btn">Close Order (Referred Out) ✓</button>
+  </div>
+
+  <!-- ======================================================================
+       Dashboard filter preview (DSH-10, DSH-11)
+  ======================================================================= -->
+  <h3 class="section-title">Order Dashboard — Referred Out filter <small>(DSH-10, DSH-11)</small></h3>
+  <div style="display:flex;gap:1rem;align-items:end;margin-bottom:1rem;">
+    <div style="max-width:260px;flex:1;">
+      <label class="field-label">Referred Out</label>
+      <select>
+        <option>Any</option>
+        <option>Has Referred Samples</option>
+        <option>Fully Referred Out</option>
+      </select>
+    </div>
+    <div class="muted">Combines with existing filters via AND.</div>
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Lab #</th>
+        <th>Patient / Subject</th>
+        <th>Facility</th>
+        <th>Status</th>
+        <th>Referred Samples</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>2026-00412</td>
+        <td>Siti Rahayu</td>
+        <td>Puskesmas Kebayoran</td>
+        <td><span class="tag blue">Labeling</span><span class="tag purple">Referred (1 of 2 samples)</span></td>
+        <td>1 of 2</td>
+      </tr>
+      <tr>
+        <td>2026-00413</td>
+        <td>Budi Santoso</td>
+        <td>RS Cipto</td>
+        <td><span class="tag purple">Referred Out</span><span class="tag purple">Referred (all samples)</span></td>
+        <td>2 of 2</td>
+      </tr>
+      <tr>
+        <td>2026-00414</td>
+        <td>ENV-KBY-0412-01</td>
+        <td>Kebayoran River</td>
+        <td><span class="tag blue">QA Review</span></td>
+        <td>0 of 3</td>
+      </tr>
+      <tr>
+        <td>2026-00415</td>
+        <td>Ayu Lestari</td>
+        <td>Klinik Harapan</td>
+        <td><span class="tag purple">Referred Out</span><span class="tag purple">Referred (all samples)</span></td>
+        <td>1 of 1</td>
+      </tr>
+      <tr>
+        <td>2026-00416</td>
+        <td>Dewi Sartika</td>
+        <td>Puskesmas Setiabudi</td>
+        <td><span class="tag blue">Labeling</span><span class="tag purple">Referred (1 of 3 samples)</span></td>
+        <td>1 of 3</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="muted" style="margin-top:2rem;font-size:0.75rem;">
+    OpenELIS Sample Collection Redesign — Referral Out addendum preview v2.1 (2026-04-23).
+    FRS: sample-collection-referral-addendum-frs-v2.1.md.
+    Mockup source: sample-collection-referral-addendum-mockup.jsx (Carbon React).
+  </p>
+
+</div>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary

Update to Sample Collection Redesign v2.1 Referral Addendum (issue #92) — adds order entry context screens to the mockup.

- **OrderContextCard component** — shows lab number, patient name, patient ID, facility, and priority tag at the top of Step 3
- **Order-quantity label printing controls** — NumberInput for order/sample/slide/block/freezer label quantities with batch print action
- **REFERRED_OUT transition notification** — InlineNotification informing tech that the order will bypass Step 4 QA on full referral save
- **Updated Step 3 panel** — full order-level referral context woven into the Label & Store step

Mockup: 481 → 725 lines. FRS: 317 → 356 lines.

## Files changed

| File | Change |
|---|---|
| designs/sample-collection/sample-collection-referral-addendum.jsx | +244 lines — OrderContextCard, label qty controls, REFERRED_OUT notification |
| designs/sample-collection/sample-collection-referral-addendum.md | +39 lines — FRS updates for order entry context |
| designs/sample-collection/sample-collection-referral-addendum.html | Updated HTML preview |
| mockup-viewer/public/...html | Updated public preview copy |

## Test plan

- [ ] Gallery builds without error
- [ ] Step 3 mockup shows OrderContextCard at /sample-collection/...referral-addendum
- [ ] Label quantity controls render and update print batch description
- [ ] REFERRED_OUT notification shown when all tests referred

Generated with Claude