### PR TITLE
feat: ingest Apr 27 updates — test-catalog v2.3, FHIR publication set…

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -17,7 +17,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Panel | [panel.jsx](designs/admin-config/panel.jsx) | [panel.md](designs/admin-config/panel.md) |
 | Range Editor | [range-editor.jsx](designs/admin-config/range-editor.jsx) | [range-editor.md](designs/admin-config/range-editor.md) |
 | Result Options | [result-options.jsx](designs/admin-config/result-options.jsx) | [result-options.md](designs/admin-config/result-options.md) |
-| Test Catalog | [test-catalog.jsx](designs/admin-config/test-catalog.jsx) | [test-catalog.md](designs/admin-config/test-catalog.md) |
+| Test Catalog | [test-catalog.jsx](designs/admin-config/test-catalog.jsx) · [preview](designs/admin-config/test-catalog.html) | [test-catalog.md](designs/admin-config/test-catalog.md) |
 | RBAC Management | [rbac-ui-mockup.html](designs/rbac/rbac-ui-mockup.html) | [rbac-revamp-prd.md](designs/rbac/rbac-revamp-prd.md) |
 | Password Policy Enhancements | [password-enhancements.jsx](designs/admin-config/password-enhancements.jsx) | [password-enhancements.md](designs/admin-config/password-enhancements.md) |
 | Catalog Subscription | [catalog-subscription-carbon.jsx](designs/admin-config/catalog-subscription-carbon.jsx) \| [preview](designs/admin-config/catalog-subscription.html) | [catalog-subscription.md](designs/admin-config/catalog-subscription.md) |
@@ -40,7 +40,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Vector Specimen Types & Taxonomy | [vector-reference-data.jsx](designs/vector-surveillance/vector-reference-data.jsx) | [vector-reference-data.md](designs/vector-surveillance/vector-reference-data.md) |
 | Vector Collection Workflow | [vector-collection-workflow.jsx](designs/vector-surveillance/vector-collection-workflow.jsx) · [preview](designs/vector-surveillance/vector-collection-workflow.html) | [vector-collection-workflow.md](designs/vector-surveillance/vector-collection-workflow.md) |
 | Vector Testing & Identification | [vector-testing-identification.jsx](designs/vector-surveillance/vector-testing-identification.jsx) · [preview](designs/vector-surveillance/vector-testing-identification.html) | [vector-testing-identification.md](designs/vector-surveillance/vector-testing-identification.md) |
-| Vector Surveillance Reporting | [vector-surveillance-reporting.jsx](designs/vector-surveillance/vector-surveillance-reporting.jsx) · [preview](designs/vector-surveillance/vector-surveillance-reporting.html) | [vector-surveillance-reporting.md](designs/vector-surveillance/vector-surveillance-reporting.md) |
+| Vector Surveillance Reporting | [vector-surveillance-reporting.jsx](designs/vector-surveillance/vector-surveillance-reporting.jsx) · [preview](designs/vector-surveillance/vector-surveillance-reporting.html) | [vector-surveillance-reporting.md](designs/vector-surveillance/vector-surveillance-reporting.md) · [FHIR considerations](designs/vector-surveillance/vector-surveillance-reporting-fhir-considerations.md) |
 
 ## Analyzer Integration
 
@@ -161,6 +161,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Help Menu | [help-menu.jsx](designs/system/help-menu.jsx) | [help-menu.md](designs/system/help-menu.md) |
 | Analyzer Import | [analyzer-import.jsx](designs/system/analyzer-import.jsx) | [analyzer-import.md](designs/system/analyzer-import.md) |
 | FHIR Outbound Push | [fhir-outbound-push.jsx](designs/system/fhir-outbound-push.jsx) | [fhir-outbound-push.md](designs/system/fhir-outbound-push.md) |
+| FHIR Publication Settings | [fhir-publication-settings.jsx](designs/system/fhir-publication-settings.jsx) | — |
 | Lab Management Dashboard | [lab-management-dashboard.html](designs/system/lab-management-dashboard.html) | [lab-management-dashboard.md](designs/system/lab-management-dashboard.md) |
 | Catalyst Lab Data Assistant | [Figma](https://www.figma.com/make/poDXKSr2IBgKbbjB1Fh9Sj/OpenELIS-Global-Template--Copy-?node-id=0-1) | — |
 | Electronic Signature | [electronic-signature.jsx](designs/system/electronic-signature.jsx) | [electronic-signature.md](designs/system/electronic-signature.md) |

--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -160,21 +160,33 @@
 - id: test-catalog
   type: mockup
   path: designs/admin-config/test-catalog.jsx
+  preview: designs/admin-config/test-catalog.html
   category: admin-config
-  description: Comprehensive test catalog management
+  description: >
+    Test Catalog admin editor v2.3 — 14-section routed editor covering identity, result types,
+    ranges, sample storage, panels, analyzers, alerts, AMR mapping, regulatory compliance
+    thresholds, LOINC/SNOMED/CIEL/OCL terminology, and order entry configuration. Replaces
+    five separate admin pages (Test, Section, Panel, Method, Reagent). v2.3 adds Terminology
+    Mappings section, Sample & Results Configuration, click-to-open row interaction, 226 i18n keys.
   paired_with: test-catalog-spec
-  links: {}
+  links:
+    jira: ["OGC-173"]
+    gallery: https://digi-uw.github.io/openelis-work/#/admin-config/test-catalog
   added: "2026-03-03"
+  updated: "2026-04-27"
+  status: draft
 
 - id: test-catalog-spec
   type: spec
   path: designs/admin-config/test-catalog.md
   category: admin-config
-  description: Test catalog FRS
+  description: Test Catalog Management FRS v2.3 — JSX-FRS reconciliation pass with 226 i18n keys, Terminology Mappings, Sample & Results Configuration, and Alert Rules taxonomy reconciliation
   paired_with: test-catalog
   links:
     jira: ["OGC-173"]
+    gallery: https://digi-uw.github.io/openelis-work/#/admin-config/test-catalog
   added: "2026-03-03"
+  updated: "2026-04-27"
 
 # ─── Analyzer Integration ───────────────────────────────────
 
@@ -1377,10 +1389,26 @@
   spec: designs/system/fhir-outbound-push.md
   category: system
   description: Event-driven FHIR R4 outbound push to national hub — bundle assembly, retry queue, delivery log, and admin config for endpoint/auth/per-resource toggles
+  related: [fhir-publication-settings]
   links:
     github: https://github.com/DIGI-UW/openelis-work/issues/62
     gallery: https://digi-uw.github.io/openelis-work/#/system/fhir-outbound-push
   added: "2026-03-24"
+
+- id: fhir-publication-settings
+  type: mockup
+  path: designs/system/fhir-publication-settings.jsx
+  category: system
+  description: >
+    Admin configuration page for FHIR R4 outbound publication — endpoint URL, per-resource
+    toggles (DiagnosticReport, Observation, ServiceRequest, Device, Organization), auth modes
+    (API key, OAuth 2.0, Basic auth, Private Key JWT with public key upload), DHIS2 push URL,
+    and live connection test. Companion admin UI for the FHIR Outbound Push pipeline (OGC-446).
+  related: [fhir-outbound-push]
+  links:
+    gallery: https://digi-uw.github.io/openelis-work/#/system/fhir-publication-settings
+  added: "2026-04-27"
+  status: draft
 
 - id: storage-disposition-fhir
   type: both
@@ -1872,6 +1900,21 @@
     - QC
     - infection-rate
   added: "2026-04-20"
+  updated: "2026-04-27"
+  status: draft
+
+- id: vector-surveillance-reporting-fhir-considerations
+  type: spec
+  path: designs/vector-surveillance/vector-surveillance-reporting-fhir-considerations.md
+  category: vector-surveillance
+  description: >
+    V-04 FHIR architecture considerations — FHIR R4 coverage assessment for vector surveillance
+    data, extension design aligned with WHO Vector Surveillance DAK/FHIR IG, CodeSystem URI
+    namespacing under openelis-global.org/fhir/, and implementation guidance for Piotr's review.
+  related: [vector-surveillance-reporting]
+  links:
+    jira: ["OGC-527"]
+  added: "2026-04-27"
   status: draft
 
 - id: lh-delivery-sent-messages
@@ -2117,6 +2160,7 @@
     - crosswalk
     - planning
   added: "2026-04-24"
+  updated: "2026-04-27"
   status: draft
 
 - id: eqa-v2-ept-platform-crosswalk

--- a/designs/admin-config/test-catalog.html
+++ b/designs/admin-config/test-catalog.html
@@ -1,0 +1,2070 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Catalog Management v2.3 — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    * { box-sizing: border-box; }
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; color: #161616; }
+    .preview-banner { background: #0f62fe; color: #fff; padding: 8px 16px; font-size: 12px; font-weight: 500; font-family: monospace; }
+    .preview-content { padding: 0; max-width: 1600px; margin: 0 auto; background: #fff; min-height: 100vh; }
+    .app-header { background: #fff; border-bottom: 1px solid #e0e0e0; padding: 16px 24px; display: flex; justify-content: space-between; align-items: center; }
+    .app-header h1 { margin: 0; font-size: 24px; font-weight: 600; }
+    .app-header-actions { display: flex; gap: 12px; }
+    .test-list-container { display: flex; flex-direction: column; padding: 24px; }
+    .toolbar { display: flex; gap: 12px; margin-bottom: 16px; align-items: center; }
+    .search-box { flex: 1; position: relative; }
+    .search-box input { width: 100%; padding: 8px 12px; border: 1px solid #d0d0d0; border-radius: 4px; font-size: 14px; }
+    .search-box input:focus { outline: none; border-color: #0f62fe; box-shadow: inset 0 0 0 2px rgba(15, 98, 254, 0.1); }
+    .btn { padding: 8px 16px; border: 1px solid #d0d0d0; background: #fff; border-radius: 4px; cursor: pointer; font-size: 14px; font-weight: 500; transition: all 0.2s; }
+    .btn:hover { background: #f4f4f4; }
+    .btn-primary { background: #0f62fe; color: #fff; border-color: #0f62fe; }
+    .btn-primary:hover { background: #0353e9; }
+    .btn-secondary { background: #fff; border-color: #d0d0d0; color: #161616; }
+    .btn-ghost { background: transparent; border: none; color: #0f62fe; padding: 6px 8px; }
+    .btn-ghost:hover { background: #e8e8e8; }
+    .btn-danger { background: #da1e28; color: #fff; border-color: #da1e28; }
+    .btn-danger:hover { background: #ba1b23; }
+    .btn-sm { padding: 6px 12px; font-size: 13px; }
+    .filters-toggle { background: #fff; border: 1px solid #d0d0d0; padding: 8px 12px; border-radius: 4px; cursor: pointer; font-size: 14px; }
+    .filters-panel { background: #f4f4f4; border: 1px solid #d0d0d0; border-radius: 4px; padding: 16px; margin-bottom: 16px; display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+    .filter-group label { display: block; font-size: 12px; font-weight: 600; margin-bottom: 6px; color: #525252; }
+    .filter-group select { width: 100%; padding: 8px; border: 1px solid #d0d0d0; border-radius: 4px; font-size: 13px; background: #fff; }
+    .table-container { width: 100%; overflow-x: auto; border: 1px solid #e0e0e0; border-radius: 4px; }
+    .data-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+    .data-table thead { background: #f4f4f4; border-bottom: 2px solid #d0d0d0; }
+    .data-table th { padding: 12px; text-align: left; font-weight: 600; color: #161616; }
+    .data-table td { padding: 12px; border-bottom: 1px solid #e0e0e0; }
+    .data-table tbody tr:hover { background: #f4f4f4; }
+    .data-table input[type="checkbox"] { cursor: pointer; width: 18px; height: 18px; }
+    .batch-actions { background: #0f62fe; color: #fff; padding: 12px 16px; border-radius: 4px; display: flex; gap: 12px; align-items: center; margin-bottom: 16px; }
+    .batch-actions-count { flex: 1; }
+    .batch-actions button { background: rgba(255,255,255,0.2); color: #fff; border: 1px solid rgba(255,255,255,0.3); padding: 6px 12px; border-radius: 3px; cursor: pointer; font-size: 13px; font-weight: 500; }
+    .batch-actions button:hover { background: rgba(255,255,255,0.3); }
+    .tag { display: inline-block; padding: 4px 8px; border-radius: 12px; font-size: 12px; font-weight: 500; margin: 0 4px 0 0; white-space: nowrap; }
+    .tag-blue { background: #d0e2ff; color: #0043ce; }
+    .tag-green { background: #d1fce0; color: #0d6f1f; }
+    .tag-purple { background: #f3e8ff; color: #6e008d; }
+    .tag-red { background: #fee5e5; color: #ae1a1a; }
+    .tag-teal { background: #d1f3f6; color: #004f62; }
+    .tag-gray { background: #e8e8e8; color: #3f3f3f; }
+    .tag-warm-gray { background: #f2dcc3; color: #7d3e23; }
+    .pagination { display: flex; justify-content: space-between; align-items: center; margin-top: 16px; padding: 12px; background: #f4f4f4; border-radius: 4px; font-size: 13px; }
+    .pagination-info { color: #525252; }
+    .pagination-controls { display: flex; gap: 6px; }
+    .pagination-controls button { padding: 4px 8px; border: 1px solid #d0d0d0; background: #fff; border-radius: 3px; cursor: pointer; }
+    .pagination-controls button:hover { background: #e8e8e8; }
+    .pagination-controls button:disabled { opacity: 0.4; cursor: not-allowed; }
+
+    /* Two-column layout: SideNav + Content */
+    .editor-container { display: flex; min-height: calc(100vh - 80px); }
+    .editor-sidenav { width: 280px; background: #fff; border-right: 1px solid #e0e0e0; overflow-y: auto; }
+    .editor-content { flex: 1; padding: 24px; overflow-y: auto; }
+    .sidenav-header { padding: 16px; border-bottom: 1px solid #e0e0e0; font-size: 13px; font-weight: 600; color: #525252; }
+    .sidenav-item { padding: 12px 16px; cursor: pointer; font-size: 13px; border-left: 3px solid transparent; color: #525252; transition: all 0.2s; }
+    .sidenav-item:hover { background: #f4f4f4; }
+    .sidenav-item-active { background: #e3f2fd; border-left-color: #0f62fe; color: #0f62fe; font-weight: 600; }
+
+    .section-header { margin-bottom: 24px; }
+    .section-header h2 { margin: 0; font-size: 20px; font-weight: 600; color: #161616; }
+    .section-header p { margin: 4px 0 0 0; font-size: 13px; color: #525252; }
+
+    .form-group { margin-bottom: 20px; }
+    .form-group label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 8px; color: #161616; }
+    .form-group input, .form-group select, .form-group textarea { width: 100%; padding: 8px; border: 1px solid #d0d0d0; border-radius: 4px; font-size: 13px; font-family: inherit; }
+    .form-group input:focus, .form-group select:focus, .form-group textarea:focus { outline: none; border-color: #0f62fe; box-shadow: inset 0 0 0 2px rgba(15, 98, 254, 0.1); }
+    .form-group textarea { resize: vertical; min-height: 100px; }
+    .required::after { content: ' *'; color: #da1e28; }
+
+    .checkbox-group { border: 1px solid #d0d0d0; border-radius: 4px; padding: 12px; max-height: 200px; overflow-y: auto; background: #fff; }
+    .checkbox-item { display: flex; align-items: center; gap: 8px; padding: 6px 0; }
+    .checkbox-item input { width: 16px; height: 16px; cursor: pointer; }
+    .checkbox-item label { cursor: pointer; font-size: 13px; }
+
+    .radio-group { display: flex; gap: 16px; }
+    .radio-item { display: flex; align-items: center; gap: 6px; }
+    .radio-item input { cursor: pointer; }
+    .radio-item label { cursor: pointer; font-size: 13px; }
+
+    .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; z-index: 1000; }
+    .modal { background: #fff; border-radius: 4px; width: 90%; max-width: 600px; max-height: 90vh; overflow-y: auto; box-shadow: 0 4px 16px rgba(0,0,0,0.2); }
+    .modal-header { padding: 16px; border-bottom: 1px solid #e0e0e0; display: flex; justify-content: space-between; align-items: center; }
+    .modal-header h2 { margin: 0; font-size: 16px; font-weight: 600; }
+    .modal-close { background: none; border: none; font-size: 20px; cursor: pointer; color: #525252; }
+    .modal-body { padding: 16px; }
+    .modal-footer { padding: 16px; border-top: 1px solid #e0e0e0; display: flex; justify-content: flex-end; gap: 8px; background: #f4f4f4; }
+
+    .tile { background: #fff; border: 1px solid #e0e0e0; border-radius: 4px; padding: 16px; margin-bottom: 16px; }
+    .tile-header { font-size: 14px; font-weight: 600; margin-bottom: 12px; color: #161616; display: flex; justify-content: space-between; align-items: center; }
+    .tile-body { font-size: 13px; color: #525252; }
+
+    .accordion { border: 1px solid #e0e0e0; border-radius: 4px; overflow: hidden; margin-bottom: 16px; }
+    .accordion-item { border-bottom: 1px solid #e0e0e0; }
+    .accordion-item:last-child { border-bottom: none; }
+    .accordion-header { padding: 12px; background: #f4f4f4; cursor: pointer; display: flex; justify-content: space-between; align-items: center; font-weight: 600; font-size: 13px; user-select: none; }
+    .accordion-header:hover { background: #e8e8e8; }
+    .accordion-header-active { background: #e3f2fd; color: #0f62fe; }
+    .accordion-body { padding: 12px; background: #fff; display: none; }
+    .accordion-body-active { display: block; }
+
+    .info-banner { background: #d1f3f6; border-left: 4px solid #0090a3; padding: 12px; margin-bottom: 16px; border-radius: 2px; font-size: 13px; color: #004f62; }
+    .info-banner-icon { margin-right: 8px; }
+
+    .section-divider { border-bottom: 2px solid #e0e0e0; margin: 24px 0; }
+
+    .grid-2col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .grid-3col { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+
+    .domain-tag-clinical { background: #bce5fe; color: #003da5; }
+    .domain-tag-environmental { background: #a7f0ba; color: #0d6f1f; }
+    .domain-tag-vector { background: #f6d3fc; color: #6e008d; }
+
+    .amr-badge { background: #f3e8ff; color: #6e008d; padding: 2px 6px; border-radius: 3px; font-size: 11px; font-weight: 600; }
+
+    .list-item { padding: 12px; background: #fff; border: 1px solid #e0e0e0; border-radius: 4px; margin-bottom: 8px; display: flex; justify-content: space-between; align-items: center; }
+    .list-item-name { font-weight: 500; }
+    .list-item-actions { display: flex; gap: 6px; }
+
+    .mono { font-family: 'IBM Plex Mono', monospace; font-size: 12px; }
+    .inline-form { background: #f9f9f9; border: 1px dashed #d0d0d0; padding: 12px; border-radius: 4px; margin-bottom: 12px; }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">⚡ Visual Preview — Test Catalog Management v2.3 | OpenELIS Design Mockup | Not a live application</div>
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // Mock Data
+    const mockTests = [
+      { id: 1, name: 'Glucose, Fasting', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '2345-7', status: 'Active', domain: 'CLINICAL', amr: false },
+      { id: 2, name: 'HbA1c', section: 'Chemistry', sampleType: 'Whole Blood', resultType: 'Numeric', loinc: '4548-4', status: 'Active', domain: 'CLINICAL', amr: false },
+      { id: 3, name: 'HBsAg', section: 'Serology', sampleType: 'Serum', resultType: 'Select List', loinc: '16962-2', status: 'Active', domain: 'CLINICAL', amr: false },
+      { id: 4, name: 'HIV Viral Load', section: 'Molecular', sampleType: 'Plasma', resultType: 'Numeric', loinc: '10689-0', status: 'Active', domain: 'CLINICAL', amr: false },
+      { id: 5, name: 'CBC', section: 'Hematology', sampleType: 'Whole Blood', resultType: 'Numeric', loinc: '58410-2', status: 'Active', domain: 'CLINICAL', amr: false },
+      { id: 6, name: 'Bilirubin, Total', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '1975-2', status: 'Inactive', domain: 'CLINICAL', amr: false },
+      { id: 7, name: 'Water Turbidity', section: 'Environmental', sampleType: 'Water', resultType: 'Numeric', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+      { id: 8, name: 'Lead in Drinking Water', section: 'Environmental', sampleType: 'Water', resultType: 'Numeric', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+      { id: 9, name: 'PM2.5', section: 'Environmental', sampleType: 'Air', resultType: 'Numeric', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+      { id: 10, name: 'Fecal Coliform', section: 'Environmental', sampleType: 'Water', resultType: 'Select List', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+      { id: 11, name: 'Aedes pool RT-PCR Dengue', section: 'Molecular', sampleType: 'Mosquito Pool', resultType: 'Select List', loinc: null, status: 'Active', domain: 'VECTOR', amr: false },
+      { id: 12, name: 'Anopheles speciation', section: 'Molecular', sampleType: 'Mosquito Pool', resultType: 'Select List', loinc: null, status: 'Active', domain: 'VECTOR', amr: false },
+      { id: 13, name: 'Ampicillin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'Select List', loinc: '18901-5', status: 'Active', domain: 'CLINICAL', amr: true },
+      { id: 14, name: 'Ciprofloxacin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'Select List', loinc: '18909-8', status: 'Active', domain: 'CLINICAL', amr: true },
+    ];
+
+    function DomainTag({ domain }) {
+      const tagClass = {
+        'CLINICAL': 'domain-tag-clinical tag-blue',
+        'ENVIRONMENTAL': 'domain-tag-environmental tag-green',
+        'VECTOR': 'domain-tag-vector tag-purple',
+      }[domain] || 'tag-gray';
+      const label = { 'CLINICAL': 'Clinical', 'ENVIRONMENTAL': 'Environmental', 'VECTOR': 'Vector' }[domain] || domain;
+      return <span className={`tag ${tagClass}`}>{label}</span>;
+    }
+
+    function TestListView({ onEdit, onAdd }) {
+      const [filters, setFilters] = useState({ section: '', sampleType: '', resultType: '', status: '', domain: 'All Domains', amr: 'All' });
+      const [showFilters, setShowFilters] = useState(false);
+      const [currentPage, setCurrentPage] = useState(1);
+      const pageSize = 10;
+
+      const filteredTests = useMemo(() => {
+        return mockTests.filter(test => {
+          if (filters.section && test.section !== filters.section) return false;
+          if (filters.sampleType && test.sampleType !== filters.sampleType) return false;
+          if (filters.resultType && test.resultType !== filters.resultType) return false;
+          if (filters.status && test.status !== filters.status) return false;
+          if (filters.domain !== 'All Domains' && test.domain !== filters.domain) return false;
+          if (filters.amr === 'AMR Only' && !test.amr) return false;
+          if (filters.amr === 'Non-AMR' && test.amr) return false;
+          return true;
+        });
+      }, [filters]);
+
+      const paginatedTests = useMemo(() => {
+        const start = (currentPage - 1) * pageSize;
+        return filteredTests.slice(start, start + pageSize);
+      }, [filteredTests, currentPage]);
+
+      const totalPages = Math.ceil(filteredTests.length / pageSize);
+
+      return (
+        <div className="test-list-container">
+          <div className="toolbar">
+            <div className="search-box">
+              <input type="text" placeholder="Search tests by name..." />
+            </div>
+            <button className="filters-toggle" onClick={() => setShowFilters(!showFilters)}>
+              🔽 Filters
+            </button>
+            <button className="btn btn-primary" onClick={onAdd}>+ Add Test</button>
+          </div>
+
+          {showFilters && (
+            <div className="filters-panel">
+              <div className="filter-group">
+                <label>Section</label>
+                <select value={filters.section} onChange={(e) => setFilters({...filters, section: e.target.value})}>
+                  <option value="">All Sections</option>
+                  <option value="Chemistry">Chemistry</option>
+                  <option value="Hematology">Hematology</option>
+                  <option value="Serology">Serology</option>
+                  <option value="Microbiology">Microbiology</option>
+                  <option value="Environmental">Environmental</option>
+                  <option value="Molecular">Molecular</option>
+                </select>
+              </div>
+              <div className="filter-group">
+                <label>Sample Type</label>
+                <select value={filters.sampleType} onChange={(e) => setFilters({...filters, sampleType: e.target.value})}>
+                  <option value="">All Types</option>
+                  <option value="Serum">Serum</option>
+                  <option value="Plasma">Plasma</option>
+                  <option value="Whole Blood">Whole Blood</option>
+                  <option value="Water">Water</option>
+                  <option value="Mosquito Pool">Mosquito Pool</option>
+                </select>
+              </div>
+              <div className="filter-group">
+                <label>Result Type</label>
+                <select value={filters.resultType} onChange={(e) => setFilters({...filters, resultType: e.target.value})}>
+                  <option value="">All Types</option>
+                  <option value="Numeric">Numeric</option>
+                  <option value="Select List">Select List</option>
+                  <option value="Free Text">Free Text</option>
+                </select>
+              </div>
+              <div className="filter-group">
+                <label>Status</label>
+                <select value={filters.status} onChange={(e) => setFilters({...filters, status: e.target.value})}>
+                  <option value="">All Statuses</option>
+                  <option value="Active">Active</option>
+                  <option value="Inactive">Inactive</option>
+                </select>
+              </div>
+              <div className="filter-group">
+                <label>Domain</label>
+                <select value={filters.domain} onChange={(e) => setFilters({...filters, domain: e.target.value})}>
+                  <option value="All Domains">All Domains</option>
+                  <option value="CLINICAL">Clinical</option>
+                  <option value="ENVIRONMENTAL">Environmental</option>
+                  <option value="VECTOR">Vector</option>
+                </select>
+              </div>
+              <div className="filter-group">
+                <label>AMR Status</label>
+                <select value={filters.amr} onChange={(e) => setFilters({...filters, amr: e.target.value})}>
+                  <option value="All">All</option>
+                  <option value="AMR Only">AMR Only</option>
+                  <option value="Non-AMR">Non-AMR</option>
+                </select>
+              </div>
+            </div>
+          )}
+
+          <div className="table-container">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Test Name</th>
+                  <th>Domain</th>
+                  <th>Section</th>
+                  <th>Sample Type</th>
+                  <th>Result Type</th>
+                  <th>LOINC</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {paginatedTests.map(test => (
+                  <tr key={test.id} onClick={() => onEdit(test)} style={{ cursor: 'pointer' }}>
+                    <td>
+                      <button onClick={(e) => { e.stopPropagation(); onEdit(test); }} style={{ background: 'none', border: 'none', padding: 0, color: '#0f62fe', fontWeight: 600, cursor: 'pointer', fontSize: 14, textAlign: 'left' }}>{test.name}</button>
+                      {test.amr && <span className="amr-badge" style={{ marginLeft: 8 }}>AMR</span>}
+                    </td>
+                    <td><DomainTag domain={test.domain} /></td>
+                    <td>{test.section}</td>
+                    <td>{test.sampleType}</td>
+                    <td>{test.resultType}</td>
+                    <td>{test.loinc ? <code className="mono">{test.loinc}</code> : '–'}</td>
+                    <td><span className={`tag ${test.status === 'Active' ? 'tag-green' : 'tag-gray'}`}>{test.status}</span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="pagination">
+            <div className="pagination-info">Showing {(currentPage - 1) * pageSize + 1}–{Math.min(currentPage * pageSize, filteredTests.length)} of {filteredTests.length}</div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <select onChange={(e) => { /* change pageSize */ }} style={{ padding: '6px' }}>
+                <option>10 / page</option>
+                <option>25 / page</option>
+                <option>50 / page</option>
+              </select>
+              <div className="pagination-controls">
+                <button onClick={() => setCurrentPage(p => Math.max(1, p - 1))} disabled={currentPage === 1}>← Prev</button>
+                {Array.from({length: Math.min(5, totalPages)}, (_, i) => (
+                  <button key={i + 1} onClick={() => setCurrentPage(i + 1)} style={{ background: currentPage === i + 1 ? '#0f62fe' : '#fff', color: currentPage === i + 1 ? '#fff' : '#161616' }}>{i + 1}</button>
+                ))}
+                <button onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))} disabled={currentPage === totalPages}>Next →</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function BasicInfoTab({ test, setTest }) {
+      return (
+        <div>
+          <div className="section-header">
+            <h2>Basic Information</h2>
+            <p>Core test identity and classification</p>
+          </div>
+
+          <div className="form-group">
+            <label className="required">Test Name</label>
+            <input type="text" value={test.name} onChange={(e) => setTest({...test, name: e.target.value})} />
+          </div>
+
+          <div className="form-group">
+            <label>Reporting Name</label>
+            <input type="text" />
+          </div>
+
+          <div className="form-group">
+            <label>Test Code</label>
+            <input type="text" placeholder="e.g., GLU" />
+          </div>
+
+          <div className="form-group">
+            <label>Description</label>
+            <textarea placeholder="Enter test description..."></textarea>
+          </div>
+
+          <div className="form-group">
+            <label className="required">Test Section(s)</label>
+            <div className="checkbox-group">
+              {['Chemistry', 'Hematology', 'Serology', 'Immunology', 'Microbiology', 'Urinalysis', 'Parasitology', 'Molecular'].map(s => (
+                <div key={s} className="checkbox-item">
+                  <input type="checkbox" id={`sec-${s}`} />
+                  <label htmlFor={`sec-${s}`}>{s}</label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label className="required">Domain</label>
+            <div className="radio-group">
+              <div className="radio-item">
+                <input type="radio" name="domain" value="CLINICAL" id="domain-clinical" checked={test.domain === 'CLINICAL'} onChange={(e) => setTest({...test, domain: e.target.value})} />
+                <label htmlFor="domain-clinical">Clinical</label>
+              </div>
+              <div className="radio-item">
+                <input type="radio" name="domain" value="ENVIRONMENTAL" id="domain-env" checked={test.domain === 'ENVIRONMENTAL'} onChange={(e) => setTest({...test, domain: e.target.value})} />
+                <label htmlFor="domain-env">Environmental</label>
+              </div>
+              <div className="radio-item">
+                <input type="radio" name="domain" value="VECTOR" id="domain-vec" checked={test.domain === 'VECTOR'} onChange={(e) => setTest({...test, domain: e.target.value})} />
+                <label htmlFor="domain-vec">Vector</label>
+              </div>
+            </div>
+          </div>
+
+          <div className="section-divider"></div>
+          <div className="form-group" style={{ display: 'flex', gap: 12, alignItems: 'flex-end' }}>
+            <div style={{ flex: 1 }}>
+              <label>
+                <input type="checkbox" /> <strong>Active Test</strong>
+              </label>
+            </div>
+            <div style={{ flex: 1 }}>
+              <label>
+                <input type="checkbox" /> <strong>Orderable</strong>
+              </label>
+            </div>
+            <div style={{ flex: 1 }}>
+              <label>
+                <input type="checkbox" /> <strong>Internal QA</strong> — No Results Release
+              </label>
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label><input type="checkbox" /> <strong>AMR Test</strong></label>
+            {test.amr && (
+              <div className="tile" style={{ marginTop: 12 }}>
+                <div className="tile-header">WHONET Configuration</div>
+                <div className="form-group">
+                  <label>WHONET Antibiotic Code</label>
+                  <select>
+                    <option>AMP - Ampicillin</option>
+                    <option>AMC - Amoxicillin/Clavulanic acid</option>
+                    <option>CIP - Ciprofloxacin</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <label>Antibiotic Class</label>
+                  <select>
+                    <option>Penicillins</option>
+                    <option>Cephalosporins</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <label>Test Method</label>
+                  <select>
+                    <option>Disk Diffusion</option>
+                    <option>MIC</option>
+                  </select>
+                </div>
+                <div className="form-group">
+                  <label>Breakpoint Standard</label>
+                  <select>
+                    <option>CLSI 2024</option>
+                    <option>EUCAST 2024</option>
+                  </select>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+
+    function SampleResultsTab() {
+      const [resultType, setResultType] = useState('Numeric');
+      const [selectOptions, setSelectOptions] = useState([
+        { id: 1, value: 'Positive', display: 'Positive', active: true },
+        { id: 2, value: 'Negative', display: 'Negative', active: true },
+        { id: 3, value: 'Indeterminate', display: 'Indeterminate', active: true },
+      ]);
+      const [showInterpModal, setShowInterpModal] = useState(false);
+
+      return (
+        <div>
+          <div className="section-header">
+            <h2>Sample & Results Configuration</h2>
+            <p>Define sample types and result format</p>
+          </div>
+
+          <div className="form-group">
+            <label className="required">Sample Type(s)</label>
+            <div className="checkbox-group">
+              {['Serum', 'Plasma', 'Whole Blood', 'Urine', 'CSF', 'Water', 'Mosquito Pool'].map(s => (
+                <div key={s} className="checkbox-item">
+                  <input type="checkbox" id={`st-${s}`} />
+                  <label htmlFor={`st-${s}`}>{s}</label>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className="form-group">
+            <label>Default Sample Type</label>
+            <select><option>Select...</option></select>
+          </div>
+
+          <div className="form-group">
+            <label className="required">Result Type</label>
+            <select value={resultType} onChange={(e) => setResultType(e.target.value)}>
+              <option value="Numeric">Numeric</option>
+              <option value="Select List">Select List</option>
+              <option value="Multi-select">Multi-select</option>
+              <option value="Free Text">Free Text</option>
+            </select>
+          </div>
+
+          {resultType === 'Numeric' && (
+            <>
+              <div className="form-group">
+                <label>Unit of Measure</label>
+                <select><option>mg/dL</option><option>mmol/L</option><option>g/dL</option></select>
+              </div>
+              <div className="form-group">
+                <label>Significant Digits</label>
+                <input type="number" min="0" max="6" />
+              </div>
+            </>
+          )}
+
+          <div className="form-group">
+            <label>Default Result Value</label>
+            <input type="text" />
+          </div>
+
+          {(resultType === 'Select List' || resultType === 'Multi-select') && (
+            <div className="tile">
+              <div className="tile-header">Select List Options</div>
+              <div className="table-container" style={{ marginBottom: 12 }}>
+                <table className="data-table" style={{ fontSize: '12px' }}>
+                  <thead>
+                    <tr>
+                      <th>≡</th>
+                      <th>Value</th>
+                      <th>Display Order</th>
+                      <th>Active</th>
+                      <th>Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {selectOptions.map(opt => (
+                      <tr key={opt.id}>
+                        <td>≡</td>
+                        <td><code className="mono">{opt.value}</code></td>
+                        <td>1</td>
+                        <td><input type="checkbox" checked={opt.active} /></td>
+                        <td><button className="btn-ghost btn-sm">Edit</button> <button className="btn-ghost btn-sm">Delete</button></td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          <div className="section-divider"></div>
+
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+            <h3 style={{ margin: 0, fontSize: 14, fontWeight: 600 }}>Result Interpretations</h3>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="btn btn-secondary btn-sm">📋 Copy from Test...</button>
+              <button className="btn btn-primary btn-sm" onClick={() => setShowInterpModal(true)}>+ Add Interpretation</button>
+            </div>
+          </div>
+
+          <div className="table-container">
+            <table className="data-table" style={{ fontSize: '12px' }}>
+              <thead>
+                <tr>
+                  <th>≡</th>
+                  <th>Code</th>
+                  <th>Label</th>
+                  <th>Value/Range</th>
+                  <th>Text</th>
+                  <th>Active</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  { code: 'GLU-CRIT-H', label: 'Critical High', color: 'red', value: '> 500', text: 'Critical hyperglycemia. Immediate action required...' },
+                  { code: 'GLU-HI', label: 'High', color: 'orange', value: '140-500', text: 'Elevated glucose levels...' },
+                  { code: 'GLU-NL', label: 'Normal', color: 'green', value: '70-100', text: 'Within normal range...' },
+                  { code: 'GLU-LO', label: 'Low', color: 'yellow', value: '50-70', text: 'Below normal range...' },
+                  { code: 'GLU-CRIT-L', label: 'Critical Low', color: 'red', value: '< 50', text: 'Severe hypoglycemia...' },
+                ].map((int, idx) => (
+                  <tr key={idx}>
+                    <td>≡</td>
+                    <td><code className="mono">{int.code}</code></td>
+                    <td><span className={`tag tag-${int.color === 'red' ? 'red' : int.color === 'orange' ? 'warm-gray' : int.color === 'yellow' ? 'gray' : int.color}`}>{int.label}</span></td>
+                    <td>{int.value}</td>
+                    <td style={{ fontSize: '11px', color: '#525252', maxWidth: 200 }}>{int.text.substring(0, 40)}...</td>
+                    <td><input type="checkbox" checked={true} /></td>
+                    <td><button className="btn-ghost btn-sm">Edit</button> <button className="btn-ghost btn-sm">Delete</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {showInterpModal && (
+            <div className="modal-overlay" onClick={() => setShowInterpModal(false)}>
+              <div className="modal" onClick={(e) => e.stopPropagation()}>
+                <div className="modal-header">
+                  <h2>Add Interpretation</h2>
+                  <button className="modal-close" onClick={() => setShowInterpModal(false)}>✕</button>
+                </div>
+                <div className="modal-body">
+                  <div className="form-group">
+                    <label className="required">Code</label>
+                    <input type="text" placeholder="e.g., GLU-HI" />
+                  </div>
+                  <div className="form-group">
+                    <label className="required">Label</label>
+                    <input type="text" placeholder="e.g., High" />
+                  </div>
+                  <div className="form-group">
+                    <label className="required">Value / Range</label>
+                    <input type="text" />
+                  </div>
+                  <div className="form-group">
+                    <label className="required">Interpretation Text</label>
+                    <textarea placeholder="Detailed interpretation..."></textarea>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button className="btn btn-secondary" onClick={() => setShowInterpModal(false)}>Cancel</button>
+                  <button className="btn btn-primary">Save Interpretation</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function RangesTab() {
+      const [showCoveragePanel, setShowCoveragePanel] = useState(true);
+      const [viewMode, setViewMode] = useState('structured');
+      const [expandedTypes, setExpandedTypes] = useState({ normal: true, critical: true, valid: false, reporting: false });
+      const [showAddModal, setShowAddModal] = useState(null); // null or { rangeType, prefill? }
+      const [visualSex, setVisualSex] = useState('M');
+      const [visualAge, setVisualAge] = useState(3);
+      const [visualUnit, setVisualUnit] = useState('days');
+
+      const ranges = {
+        normal: {
+          M: [
+            { age: '0 – 24 hours', low: 1, high: 100 },
+            { age: '24 – 48 hours', low: 1, high: 120 },
+            { age: '48 – 72 hours', low: 1, high: 140 },
+            { age: '3 days – 5 days', low: 1, high: 155 },
+            { age: '14 days – 1 month', low: 1, high: 130 },
+            { age: '1 month – 1 year', low: 1, high: 115 },
+            { age: '1 year – ∞', low: 5, high: 40 },
+          ],
+          F: [
+            { age: '0 – 24 hours', low: 1, high: 105 },
+            { age: '24 – 48 hours', low: 1, high: 130 },
+            { age: '48 – 72 hours', low: 1, high: 155 },
+            { age: '3 days – 55 days', low: 1, high: 175 },
+            // intentional gap 55 days – 1 year
+            { age: '1 year – ∞', low: 5, high: 35 },
+          ],
+        },
+        critical: {
+          A: [
+            { age: '0 – 23 hours', low: null, high: 7.9 },
+            { age: '24 – 35 hours', low: null, high: 10.9 },
+            { age: '36 – 47 hours', low: null, high: 13.9 },
+            { age: '48 – 71 hours', low: null, high: 14.9 },
+            { age: '72 hours – 13 days', low: null, high: 17.9 },
+            { age: '14 days – ∞', low: null, high: 15.0 },
+          ],
+        },
+        valid: { A: [{ age: '0 hours – ∞', low: 0, high: 600 }] },
+        reporting: { A: [{ age: '0 hours – ∞', low: 0.1, high: 30 }] },
+      };
+
+      const rangeTypes = [
+        { id: 'normal', label: 'Normal Range', desc: 'Clinical reference values. Results outside flagged H/L on reports.', color: 'tag-green', barColor: '#a7f0ba' },
+        { id: 'valid', label: 'Valid Range', desc: 'Expected possible values. Entry outside prompts verification.', color: 'tag-blue', barColor: '#bce5fe' },
+        { id: 'critical', label: 'Critical Range', desc: 'Panic values requiring immediate clinical action.', color: 'tag-red', barColor: '#f8b8b8' },
+        { id: 'reporting', label: 'Reporting Range', desc: 'Instrument limits. Results outside may need dilution/rerun.', color: 'tag-purple', barColor: '#e0c3fc' },
+      ];
+
+      const sexLabel = { M: 'Male', F: 'Female', A: 'All' };
+      const sexTag = { M: 'tag-blue', F: 'tag-purple', A: 'tag-gray' };
+
+      // Visual view: get applicable range for selected demographic
+      const getApplicableForType = (typeId) => {
+        const sexRanges = ranges[typeId];
+        // Priority: matching sex, then 'All'
+        const candidates = [...(sexRanges[visualSex] || []), ...(sexRanges.A || [])];
+        return candidates[0] || null; // simplified — real version would match by age
+      };
+
+      // Flat list for table view
+      const allRangesFlat = [];
+      rangeTypes.forEach(type => {
+        const byType = ranges[type.id];
+        Object.keys(byType).forEach(sex => {
+          byType[sex].forEach(r => allRangesFlat.push({ ...r, type: type.id, typeLabel: type.label, typeColor: type.color, sex }));
+        });
+      });
+
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Reference Ranges</h2>
+              <p>Define age and sex-specific reference ranges for this test</p>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <button className={showCoveragePanel ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'} onClick={() => setShowCoveragePanel(!showCoveragePanel)}>✓ Validate Coverage</button>
+              <select value={viewMode} onChange={e => setViewMode(e.target.value)} style={{ padding: '6px 12px', border: '1px solid #d0d0d0', borderRadius: 4, fontSize: 13 }}>
+                <option value="structured">Structured View</option>
+                <option value="table">Table View</option>
+                <option value="visual">Visual View</option>
+              </select>
+            </div>
+          </div>
+
+          {showCoveragePanel && (
+            <div className="tile" style={{ background: '#f4f4f4', marginBottom: 16 }}>
+              <div className="tile-header" style={{ fontSize: 13 }}>Age Coverage Validation</div>
+              <div className="grid-2col">
+                <div className="tile" style={{ background: '#fff', marginBottom: 0 }}>
+                  <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <span className="tag tag-blue">Male</span>
+                    <span style={{ fontSize: 12, color: '#0d6f1f', fontWeight: 600 }}>✓ Complete Coverage</span>
+                  </div>
+                  <div style={{ padding: 8, background: '#d1fce0', borderRadius: 3, fontSize: 12, color: '#0d6f1f' }}>All age ranges from birth to maximum age are covered.</div>
+                </div>
+
+                <div className="tile" style={{ background: '#fff', marginBottom: 0 }}>
+                  <div style={{ marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <span className="tag tag-purple">Female</span>
+                    <span style={{ fontSize: 12, color: '#ae1a1a', fontWeight: 600 }}>⚠ 1 Issue Found</span>
+                  </div>
+                  <div style={{ background: '#fee5e5', border: '1px solid #f8b8b8', padding: 8, borderRadius: 3 }}>
+                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                      <div>
+                        <div style={{ fontSize: 11, fontWeight: 700, color: '#ae1a1a', marginBottom: 2 }}>GAP</div>
+                        <div style={{ fontSize: 13, color: '#ae1a1a' }}>Gap: 55 days to 1 year</div>
+                      </div>
+                      <button className="btn btn-sm" onClick={() => setShowAddModal({ rangeType: 'normal', prefill: { sex: 'F', ageFrom: 55, ageFromUnit: 'days', ageTo: 1, ageToUnit: 'years', low: 1, high: 130, source: '3 days – 55 days range' } })} style={{ background: '#d1f3f6', border: '1px solid #0090a3', color: '#004f62', fontSize: 11 }}>+ Fill Gap</button>
+                    </div>
+                    <div style={{ fontSize: 11, color: '#525252', marginTop: 6 }}>Suggested values from adjacent range: Low=1, High=130</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {viewMode === 'structured' && (
+            <div className="accordion">
+              {rangeTypes.map(type => {
+                const isExpanded = expandedTypes[type.id];
+                const byType = ranges[type.id];
+                const totalCount = Object.values(byType).reduce((sum, arr) => sum + arr.length, 0);
+                return (
+                  <div key={type.id} className="accordion-item">
+                    <div className={`accordion-header ${isExpanded ? 'accordion-header-active' : ''}`} onClick={() => setExpandedTypes(prev => ({ ...prev, [type.id]: !prev[type.id] }))}>
+                      <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+                        <span>{isExpanded ? '▼' : '▶'}</span>
+                        <span className={`tag ${type.color}`}>{type.label}</span>
+                        <span style={{ fontSize: 12, fontWeight: 'normal', color: '#525252' }}>{type.desc}</span>
+                      </div>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                        <span style={{ fontSize: 12, color: '#525252' }}>{totalCount} range(s)</span>
+                        <button className="btn-ghost btn-sm" onClick={e => { e.stopPropagation(); setShowAddModal({ rangeType: type.id }); }}>+ Add</button>
+                      </div>
+                    </div>
+                    {isExpanded && (
+                      <div className="accordion-body accordion-body-active">
+                        {Object.keys(byType).map(sex => {
+                          const sexRanges = byType[sex];
+                          if (sexRanges.length === 0) return null;
+                          return (
+                            <div key={sex} style={{ marginBottom: 12 }}>
+                              <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 6 }}>
+                                <span className={`tag ${sexTag[sex]}`}>{sexLabel[sex]}</span>
+                                <span style={{ fontSize: 11, color: '#525252' }}>({sexRanges.length} ranges)</span>
+                                <div style={{ flex: 1, height: 1, background: '#e0e0e0' }} />
+                              </div>
+                              {sexRanges.map((r, idx) => {
+                                // mini visual bar (0-200 scale)
+                                const lowPct = r.low !== null ? Math.max(0, Math.min(100, (r.low / 200) * 100)) : 0;
+                                const highPct = r.high !== null ? Math.max(0, Math.min(100, (r.high / 200) * 100)) : 100;
+                                return (
+                                  <div key={idx} style={{ padding: 8, background: '#f9f9f9', border: '1px solid #e8e8e8', borderRadius: 3, marginBottom: 4, display: 'flex', alignItems: 'center', gap: 16, fontSize: 12 }}>
+                                    <span style={{ width: 16, color: '#a8a8a8' }}>{idx + 1}.</span>
+                                    <div style={{ width: 160 }}>
+                                      <div style={{ fontSize: 10, color: '#525252' }}>Age Range</div>
+                                      <div style={{ fontWeight: 500 }}>{r.age}</div>
+                                    </div>
+                                    <div style={{ width: 60 }}>
+                                      <div style={{ fontSize: 10, color: '#525252' }}>Low</div>
+                                      <div style={{ fontWeight: 500 }}>{r.low !== null ? r.low : '—'}</div>
+                                    </div>
+                                    <div style={{ width: 60 }}>
+                                      <div style={{ fontSize: 10, color: '#525252' }}>High</div>
+                                      <div style={{ fontWeight: 500 }}>{r.high !== null ? r.high : '—'}</div>
+                                    </div>
+                                    <div style={{ flex: 1, height: 18, background: '#e8e8e8', borderRadius: 3, position: 'relative' }}>
+                                      {r.low !== null && r.high !== null && (
+                                        <div style={{ position: 'absolute', left: `${lowPct}%`, width: `${highPct - lowPct}%`, height: '100%', background: type.barColor, borderRadius: 3 }} />
+                                      )}
+                                    </div>
+                                    <div style={{ display: 'flex', gap: 2 }}>
+                                      <button className="btn-ghost btn-sm" title="Edit">✎</button>
+                                      <button className="btn-ghost btn-sm" title="Copy to other sex" onClick={() => setShowAddModal({ rangeType: type.id, prefill: { sex: sex === 'M' ? 'F' : 'M', ageFromText: r.age, low: r.low, high: r.high, source: `Copied from ${sexLabel[sex]}: ${r.age}` } })}>⇄</button>
+                                      <button className="btn-ghost btn-sm" title="Delete" style={{ color: '#da1e28' }}>✕</button>
+                                    </div>
+                                  </div>
+                                );
+                              })}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {viewMode === 'table' && (
+            <div className="table-container">
+              <table className="data-table">
+                <thead>
+                  <tr>
+                    <th>Type</th>
+                    <th>Sex</th>
+                    <th>Age Range</th>
+                    <th>Low</th>
+                    <th>High</th>
+                    <th style={{ width: 100 }}>Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {allRangesFlat.map((r, i) => (
+                    <tr key={i}>
+                      <td><span className={`tag ${r.typeColor}`}>{r.typeLabel}</span></td>
+                      <td><span className={`tag ${sexTag[r.sex]}`}>{sexLabel[r.sex]}</span></td>
+                      <td>{r.age}</td>
+                      <td>{r.low !== null ? r.low : '—'}</td>
+                      <td>{r.high !== null ? r.high : '—'}</td>
+                      <td>
+                        <button className="btn-ghost btn-sm">Edit</button>
+                        <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>Del</button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {viewMode === 'visual' && (
+            <div>
+              <div className="tile" style={{ background: '#f4f4f4' }}>
+                <label style={{ fontSize: 13, fontWeight: 600, marginRight: 12 }}>View ranges for:</label>
+                <select value={visualSex} onChange={e => setVisualSex(e.target.value)} style={{ padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, fontSize: 13, marginRight: 12 }}>
+                  <option value="M">Male</option>
+                  <option value="F">Female</option>
+                </select>
+                <label style={{ fontSize: 13, marginRight: 6 }}>Age:</label>
+                <input type="number" value={visualAge} onChange={e => setVisualAge(parseInt(e.target.value) || 0)} style={{ width: 80, padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, marginRight: 6 }} />
+                <select value={visualUnit} onChange={e => setVisualUnit(e.target.value)} style={{ padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, fontSize: 13 }}>
+                  <option value="hours">hours</option>
+                  <option value="days">days</option>
+                  <option value="weeks">weeks</option>
+                  <option value="months">months</option>
+                  <option value="years">years</option>
+                </select>
+              </div>
+
+              <div className="tile" style={{ background: '#f9f9f9' }}>
+                <div style={{ fontSize: 13, marginBottom: 16 }}>Showing ranges applicable to: <strong>{sexLabel[visualSex]}, {visualAge} {visualUnit} old</strong></div>
+                {[
+                  { id: 'valid', label: 'Valid', barColor: '#bce5fe', textColor: '#003da5' },
+                  { id: 'normal', label: 'Normal', barColor: '#a7f0ba', textColor: '#0d6f1f' },
+                  { id: 'critical', label: 'Critical', barColor: '#f8b8b8', textColor: '#ae1a1a' },
+                  { id: 'reporting', label: 'Reporting', barColor: '#e0c3fc', textColor: '#6e008d' },
+                ].map(({ id, label, barColor, textColor }) => {
+                  const r = getApplicableForType(id);
+                  const lowPct = r && r.low !== null ? Math.max(0, Math.min(100, (r.low / 200) * 100)) : 0;
+                  const highPct = r && r.high !== null ? Math.max(0, Math.min(100, (r.high / 200) * 100)) : 100;
+                  return (
+                    <div key={id} style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+                      <div style={{ width: 90, fontSize: 13, fontWeight: 500 }}>{label}</div>
+                      <div style={{ flex: 1, height: 32, background: '#e8e8e8', borderRadius: 3, position: 'relative' }}>
+                        {r ? (
+                          <>
+                            {r.low !== null && r.high !== null && (
+                              <div style={{ position: 'absolute', left: `${lowPct}%`, width: `${highPct - lowPct}%`, height: '100%', background: barColor, borderRadius: 3 }} />
+                            )}
+                            {r.low === null && r.high !== null && (
+                              <div style={{ position: 'absolute', left: 0, width: `${highPct}%`, height: '100%', background: barColor, borderTopLeftRadius: 3, borderBottomLeftRadius: 3 }} />
+                            )}
+                            <span style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', fontSize: 12, fontWeight: 500, color: textColor }}>
+                              {r.low ?? '—'} – {r.high ?? '—'}
+                            </span>
+                          </>
+                        ) : (
+                          <span style={{ position: 'absolute', left: 8, top: '50%', transform: 'translateY(-50%)', fontSize: 12, fontStyle: 'italic', color: '#a8a8a8' }}>Not defined for this demographic</span>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+
+                <div style={{ display: 'flex', gap: 16, paddingTop: 12, borderTop: '1px solid #e0e0e0', marginTop: 12 }}>
+                  {[{ c: '#bce5fe', l: 'Valid' }, { c: '#a7f0ba', l: 'Normal' }, { c: '#f8b8b8', l: 'Critical' }, { c: '#e0c3fc', l: 'Reporting' }].map(x => (
+                    <div key={x.l} style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                      <div style={{ width: 14, height: 14, background: x.c, borderRadius: 2 }} />
+                      <span style={{ fontSize: 11, color: '#525252' }}>{x.l}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {showAddModal && (
+            <div className="modal-overlay" onClick={() => setShowAddModal(null)}>
+              <div className="modal" onClick={e => e.stopPropagation()}>
+                <div className="modal-header">
+                  <h2>Add {rangeTypes.find(t => t.id === showAddModal.rangeType)?.label}</h2>
+                  <button className="modal-close" onClick={() => setShowAddModal(null)}>×</button>
+                </div>
+                {showAddModal.prefill?.source && (
+                  <div className="info-banner" style={{ margin: 16, marginBottom: 0 }}>
+                    ℹ️ Values from: {showAddModal.prefill.source}
+                  </div>
+                )}
+                <div className="modal-body">
+                  <div className="form-group">
+                    <label>Applies To</label>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      {[{ v: 'A', l: 'All', tag: 'tag-gray' }, { v: 'M', l: 'Male Only', tag: 'tag-blue' }, { v: 'F', l: 'Female Only', tag: 'tag-purple' }].map(o => (
+                        <label key={o.v} style={{ flex: 1, display: 'flex', justifyContent: 'center', alignItems: 'center', padding: 12, border: `2px solid ${(showAddModal.prefill?.sex || 'A') === o.v ? '#0f62fe' : '#d0d0d0'}`, background: (showAddModal.prefill?.sex || 'A') === o.v ? '#e3f2fd' : '#fff', borderRadius: 4, cursor: 'pointer' }}>
+                          <input type="radio" name="sex" defaultChecked={(showAddModal.prefill?.sex || 'A') === o.v} style={{ display: 'none' }} />
+                          <span className={`tag ${o.tag}`}>{o.l}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Age Range</label>
+                    <div className="grid-2col">
+                      <div>
+                        <small style={{ display: 'block', fontSize: 11, color: '#525252', marginBottom: 4 }}>From</small>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <input type="number" defaultValue={showAddModal.prefill?.ageFrom ?? 0} style={{ flex: 1, padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+                          <select defaultValue={showAddModal.prefill?.ageFromUnit || 'hours'} style={{ width: 100, padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }}>
+                            <option value="hours">hours</option><option value="days">days</option><option value="weeks">weeks</option><option value="months">months</option><option value="years">years</option>
+                          </select>
+                        </div>
+                      </div>
+                      <div>
+                        <small style={{ display: 'block', fontSize: 11, color: '#525252', marginBottom: 4 }}>To</small>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <input type="number" defaultValue={showAddModal.prefill?.ageTo ?? 999} style={{ flex: 1, padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+                          <select defaultValue={showAddModal.prefill?.ageToUnit || 'years'} style={{ width: 100, padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }}>
+                            <option value="hours">hours</option><option value="days">days</option><option value="weeks">weeks</option><option value="months">months</option><option value="years">years</option>
+                          </select>
+                        </div>
+                      </div>
+                    </div>
+                    <small style={{ display: 'block', fontSize: 11, color: '#525252', marginTop: 4 }}>Use 999 years for "no upper age limit" (infinity)</small>
+                  </div>
+                  <div className="form-group">
+                    <label>{showAddModal.rangeType === 'critical' ? 'Critical Thresholds' : 'Value Range'}</label>
+                    <div className="grid-2col">
+                      <div>
+                        <small style={{ display: 'block', fontSize: 11, color: '#525252', marginBottom: 4 }}>{showAddModal.rangeType === 'critical' ? 'Critical Low (values below this)' : 'Low'}</small>
+                        <input type="number" defaultValue={showAddModal.prefill?.low ?? ''} placeholder={showAddModal.rangeType === 'critical' ? 'Leave blank if N/A' : '0'} style={{ width: '100%', padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+                      </div>
+                      <div>
+                        <small style={{ display: 'block', fontSize: 11, color: '#525252', marginBottom: 4 }}>{showAddModal.rangeType === 'critical' ? 'Critical High (values above this)' : 'High'}</small>
+                        <input type="number" defaultValue={showAddModal.prefill?.high ?? ''} placeholder={showAddModal.rangeType === 'critical' ? 'Leave blank if N/A' : '100'} style={{ width: '100%', padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button className="btn btn-secondary btn-sm" onClick={() => setShowAddModal(null)}>Cancel</button>
+                  <button className="btn btn-primary btn-sm" onClick={() => setShowAddModal(null)}>Add Range</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function MethodsTab() {
+      const [showLinkPanel, setShowLinkPanel] = useState(false);
+      const [showCreateForm, setShowCreateForm] = useState(false);
+      const [showCopyModal, setShowCopyModal] = useState(false);
+      const [newCode, setNewCode] = useState('');
+      const [newName, setNewName] = useState('');
+
+      const linkedMethods = [
+        { code: 'HEX', name: 'Hexokinase', isDefault: true, date: '2024-01-01' },
+        { code: 'GOX', name: 'Glucose Oxidase', isDefault: false, date: '2020-01-01' },
+      ];
+      const availableMethods = [
+        { code: 'GOD-PAP', name: 'Enzymatic (GOD-PAP)' },
+        { code: 'CLR', name: 'Colorimetric' },
+        { code: 'ISE', name: 'Ion-Selective Electrode' },
+      ];
+
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Associated Methods</h2>
+              <p>Link analytical methods used to perform this test</p>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button className="btn btn-secondary btn-sm" onClick={() => setShowCopyModal(true)}>📋 Copy from Test...</button>
+              <button className="btn btn-primary btn-sm" onClick={() => { setShowLinkPanel(true); setShowCreateForm(false); }}>+ Link Method</button>
+            </div>
+          </div>
+
+          {showLinkPanel && (
+            <div className="inline-form">
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 }}>
+                <strong style={{ fontSize: 13 }}>Select Method to Link</strong>
+                <button className="btn-ghost btn-sm" onClick={() => { setShowLinkPanel(false); setShowCreateForm(true); }}>+ Create New Method</button>
+              </div>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+                {availableMethods.map(m => (
+                  <button key={m.code} className="btn btn-secondary btn-sm" style={{ textAlign: 'left', display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <code className="mono" style={{ background: '#e8e8e8', padding: '2px 4px', borderRadius: 2 }}>{m.code}</code>
+                    <span>{m.name}</span>
+                  </button>
+                ))}
+              </div>
+              <button className="btn-ghost btn-sm" style={{ marginTop: 8 }} onClick={() => setShowLinkPanel(false)}>Cancel</button>
+            </div>
+          )}
+
+          {showCreateForm && (
+            <div className="inline-form" style={{ background: '#e3f2fd', borderColor: '#0f62fe', borderStyle: 'solid' }}>
+              <label style={{ fontSize: 13, fontWeight: 600, display: 'block', marginBottom: 8 }}>Create New Method</label>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <input type="text" value={newCode} onChange={e => setNewCode(e.target.value.toUpperCase())} placeholder="Code (e.g., HEX)" className="mono" style={{ width: 120, padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, textTransform: 'uppercase' }} />
+                <input type="text" value={newName} onChange={e => setNewName(e.target.value)} placeholder="Method name (e.g., Hexokinase Method)" style={{ flex: 1, padding: 6, border: '1px solid #d0d0d0', borderRadius: 4 }} autoFocus />
+                <button className="btn btn-primary btn-sm" onClick={() => { setShowCreateForm(false); setNewCode(''); setNewName(''); }}>Create &amp; Link</button>
+                <button className="btn btn-secondary btn-sm" onClick={() => { setShowCreateForm(false); setNewCode(''); setNewName(''); }}>Cancel</button>
+              </div>
+              <small style={{ display: 'block', fontSize: 11, color: '#525252', marginTop: 6 }}>Code is used for quick macro-style entry in result screens</small>
+            </div>
+          )}
+
+          {linkedMethods.map(m => (
+            <div key={m.code} className="tile" style={{ padding: 12, borderColor: m.isDefault ? '#0f62fe' : '#e0e0e0', background: m.isDefault ? '#e3f2fd' : '#fff' }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ width: 40, height: 40, background: m.isDefault ? '#bce5fe' : '#e8e8e8', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18, color: m.isDefault ? '#0f62fe' : '#525252' }}>⚙</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <code className="mono" style={{ background: '#e8e8e8', padding: '2px 6px', borderRadius: 2, fontWeight: 500 }}>{m.code}</code>
+                    <strong style={{ fontSize: 14 }}>{m.name}</strong>
+                    {m.isDefault && <span className="tag tag-blue">Default</span>}
+                  </div>
+                  <div style={{ fontSize: 12, color: '#525252', marginTop: 4 }}>Effective: {m.date}</div>
+                </div>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  {!m.isDefault && <button className="btn-ghost btn-sm">Set Default</button>}
+                  <button className="btn-ghost btn-sm">Edit</button>
+                  <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>✕</button>
+                </div>
+              </div>
+            </div>
+          ))}
+
+          {showCopyModal && (
+            <div className="modal-overlay" onClick={() => setShowCopyModal(false)}>
+              <div className="modal" onClick={e => e.stopPropagation()}>
+                <div className="modal-header">
+                  <h2>Copy Methods from Another Test</h2>
+                  <button className="modal-close" onClick={() => setShowCopyModal(false)}>×</button>
+                </div>
+                <div className="modal-body">
+                  <div className="form-group">
+                    <label>Search for test</label>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <input type="text" placeholder="Enter test name..." style={{ flex: 1 }} />
+                      <button className="btn btn-secondary btn-sm">Search</button>
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Select test:</label>
+                    <div style={{ border: '1px solid #d0d0d0', borderRadius: 4, padding: 6, maxHeight: 160, overflowY: 'auto' }}>
+                      {['Fasting Glucose', 'Random Glucose', '2-Hour Glucose', 'HbA1c'].map((t, i) => (
+                        <label key={i} style={{ display: 'flex', gap: 8, alignItems: 'center', padding: 8, cursor: 'pointer', borderRadius: 3 }}>
+                          <input type="radio" name="sourceTest" />
+                          <span style={{ fontSize: 13 }}>{t}</span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Methods to copy:</label>
+                    <div style={{ border: '1px solid #d0d0d0', borderRadius: 4, padding: 12, background: '#f9f9f9' }}>
+                      {[
+                        { c: 'HEX', n: 'Hexokinase Method', def: true },
+                        { c: 'GOX', n: 'Glucose Oxidase Method', def: false },
+                        { c: 'ELEC', n: 'Electrode Method', def: false },
+                      ].map((m, i) => (
+                        <label key={i} style={{ display: 'flex', gap: 8, alignItems: 'center', padding: 4, cursor: 'pointer' }}>
+                          <input type="checkbox" defaultChecked={i < 2} />
+                          <code className="mono" style={{ background: '#e8e8e8', padding: '2px 4px', borderRadius: 2 }}>{m.c}</code>
+                          <span style={{ fontSize: 13 }}>{m.n}</span>
+                          {m.def && <span className="tag tag-blue">Default</span>}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button className="btn btn-secondary btn-sm" onClick={() => setShowCopyModal(false)}>Cancel</button>
+                  <button className="btn btn-primary btn-sm" onClick={() => setShowCopyModal(false)}>Copy Selected</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function SampleStorageSection() {
+      const [overrideRestricted, setOverrideRestricted] = useState(false);
+      return (
+        <div>
+          <div className="section-header">
+            <h2>Sample Storage</h2>
+            <p>Define recommended storage conditions, duration, disposal, and special handling</p>
+          </div>
+
+          <div className="tile">
+            <div className="tile-header">🌡️ Storage Requirements</div>
+            <div className="grid-2col">
+              <div className="form-group">
+                <label className="required">Storage Conditions</label>
+                <select defaultValue="refrigerator">
+                  <option value="ultra-low">Ultra-low freezer (-80°C to -60°C)</option>
+                  <option value="freezer">Freezer (-30°C to -15°C)</option>
+                  <option value="refrigerator">Refrigerator (2°C to 8°C)</option>
+                  <option value="cold-room">Cold room (4°C to 8°C)</option>
+                  <option value="cool-room">Cool room (15°C to 18°C)</option>
+                  <option value="room-temp">Room temperature (18°C to 25°C)</option>
+                  <option value="controlled-room">Controlled room temp (20°C to 25°C)</option>
+                  <option value="warm-incubator">Warm incubator (35°C to 37°C)</option>
+                  <option value="ambient">Ambient (uncontrolled)</option>
+                  <option value="custom">Custom (specify below)</option>
+                </select>
+                <small style={{ color: '#525252', fontSize: 12 }}>Temperature range for sample preservation</small>
+              </div>
+              <div className="form-group">
+                <label>Custom Storage Conditions</label>
+                <input type="text" placeholder="e.g., 2-8°C, protected from light" />
+              </div>
+              <div className="form-group">
+                <label className="required">Maximum Storage Duration</label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <input type="number" defaultValue="72" style={{ flex: 1 }} />
+                  <select style={{ width: 120 }}>
+                    <option>Hours</option>
+                    <option>Days</option>
+                    <option>Weeks</option>
+                    <option>Months</option>
+                  </select>
+                </div>
+              </div>
+              <div className="form-group">
+                <label>Stability Notes</label>
+                <input type="text" placeholder="e.g., Stable for 7 days refrigerated, 1 month frozen" />
+              </div>
+            </div>
+
+            <div style={{ marginTop: 16, paddingTop: 16, borderTop: '1px solid #e0e0e0' }}>
+              <label style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, display: 'block' }}>Special Handling Requirements</label>
+              <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 8 }}>
+                {['🔆 Protect from light', '❄️ Do not freeze', '🔥 Do not refrigerate', '⬆️ Keep upright', '🧪 Centrifuge before storage', '⚗️ Aliquot before storage'].map(item => (
+                  <label key={item} className="checkbox-item">
+                    <input type="checkbox" /> <span style={{ fontSize: 13 }}>{item}</span>
+                  </label>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="tile">
+            <div className="tile-header" style={{ color: '#da1e28' }}>🗑️ Disposal Requirements</div>
+            <div className="grid-2col">
+              <div className="form-group">
+                <label className="required">Disposal Method</label>
+                <select>
+                  <option>Biohazard/Infectious waste bin</option>
+                  <option>Sharps container</option>
+                  <option>Chemical deactivation</option>
+                  <option>Incineration</option>
+                  <option>Autoclave then general waste</option>
+                  <option>Pharmaceutical waste</option>
+                  <option>Radioactive waste</option>
+                  <option>General waste (non-hazardous only)</option>
+                  <option>Return to manufacturer</option>
+                </select>
+              </div>
+              <div className="form-group">
+                <label>Disposal Timeframe</label>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <input type="number" placeholder="e.g., 7" style={{ flex: 1 }} />
+                  <select style={{ width: 120 }}>
+                    <option>Days</option>
+                    <option>Weeks</option>
+                    <option>Months</option>
+                  </select>
+                </div>
+                <small style={{ color: '#525252', fontSize: 12 }}>Maximum time after test completion before disposal</small>
+              </div>
+            </div>
+          </div>
+
+          <div className="tile">
+            <div className="tile-header" style={{ color: '#a18217' }}>⚠️ Special Instructions</div>
+            <textarea rows={4} placeholder="Enter any special instructions for sample handling, storage, or disposal that don't fit in the fields above..." style={{ width: '100%', padding: 8, border: '1px solid #d0d0d0', borderRadius: 4, fontFamily: 'inherit', fontSize: 13 }} />
+          </div>
+
+          <div className="tile" style={{ borderColor: overrideRestricted ? '#da1e28' : '#e0e0e0' }}>
+            <div style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+              <input type="checkbox" checked={overrideRestricted} onChange={e => setOverrideRestricted(e.target.checked)} style={{ marginTop: 4, width: 18, height: 18, cursor: 'pointer' }} />
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 4 }}>
+                  <strong style={{ fontSize: 14 }}>Override Restricted</strong>
+                  <span className="tag tag-red">Locked</span>
+                </div>
+                <p style={{ fontSize: 13, color: '#525252', margin: 0 }}>When enabled, order entry staff cannot modify storage or disposal requirements for this test. Use for critical tests where sample handling must be strictly controlled (e.g., HIV, controlled substances).</p>
+                {overrideRestricted && (
+                  <div style={{ marginTop: 12, padding: 8, background: '#fee5e5', border: '1px solid #f8b8b8', borderRadius: 3 }}>
+                    <div style={{ fontSize: 13, color: '#ae1a1a', fontWeight: 600 }}>⚠ Storage and disposal settings are locked</div>
+                    <div style={{ fontSize: 12, color: '#ae1a1a', marginTop: 4 }}>Only Lab Managers can modify these requirements. Order entry staff will see these as read-only.</div>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="tile" style={{ background: 'linear-gradient(to right, #e3f2fd, #d1f3f6)', borderColor: '#a8d8e8' }}>
+            <div className="tile-header">📋 Storage Condition Quick Reference</div>
+            <div className="grid-3col" style={{ fontSize: 13 }}>
+              <div><strong>Ultra-low Freezer</strong><div style={{ color: '#525252' }}>-80°C to -60°C</div></div>
+              <div><strong>Freezer</strong><div style={{ color: '#525252' }}>-30°C to -15°C</div></div>
+              <div><strong>Refrigerator</strong><div style={{ color: '#525252' }}>2°C to 8°C</div></div>
+              <div><strong>Cool Room</strong><div style={{ color: '#525252' }}>15°C to 18°C</div></div>
+              <div><strong>Room Temperature</strong><div style={{ color: '#525252' }}>18°C to 25°C</div></div>
+              <div><strong>Warm Incubator</strong><div style={{ color: '#525252' }}>35°C to 37°C</div></div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function DisplayOrderSection() {
+      const [tests, setTests] = useState([
+        { id: 1, name: 'Glucose, Fasting', order: 1 },
+        { id: 2, name: 'Hemoglobin A1c', order: 2 },
+        { id: 3, name: 'Creatinine', order: 3 },
+        { id: 4, name: 'BUN', order: 4 },
+        { id: 5, name: 'ALT (SGPT)', order: 5 },
+        { id: 6, name: 'AST (SGOT)', order: 6 },
+        { id: 7, name: 'Bilirubin, Total', order: 7 },
+        { id: 8, name: 'Albumin', order: 8 },
+      ]);
+      const move = (idx, delta) => {
+        if (idx + delta < 0 || idx + delta >= tests.length) return;
+        const next = [...tests];
+        [next[idx], next[idx + delta]] = [next[idx + delta], next[idx]];
+        next.forEach((t, i) => (t.order = i + 1));
+        setTests(next);
+      };
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Test Display Order</h2>
+              <p>Drag and drop to reorder tests for this sample type</p>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <label style={{ fontSize: 13 }}>Sample Type:</label>
+              <select defaultValue="serum" style={{ padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, fontSize: 13 }}>
+                <option value="serum">Serum</option>
+                <option value="plasma">Plasma</option>
+                <option value="whole_blood">Whole Blood</option>
+                <option value="urine">Urine</option>
+              </select>
+            </div>
+          </div>
+
+          <div>
+            {tests.map((t, idx) => (
+              <div key={t.id} className="list-item" style={{ cursor: 'move' }}>
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center', flex: 1 }}>
+                  <span style={{ color: '#a8a8a8', cursor: 'grab', fontSize: 16 }}>≡</span>
+                  <span style={{ width: 28, color: '#525252', fontSize: 13, fontWeight: 600 }}>{t.order}.</span>
+                  <span className="list-item-name">{t.name}</span>
+                </div>
+                <div className="list-item-actions">
+                  <button className="btn-ghost btn-sm" disabled={idx === 0} onClick={() => move(idx, -1)} style={{ opacity: idx === 0 ? 0.3 : 1 }}>↑</button>
+                  <button className="btn-ghost btn-sm" disabled={idx === tests.length - 1} onClick={() => move(idx, 1)} style={{ opacity: idx === tests.length - 1 ? 0.3 : 1 }}>↓</button>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <p style={{ fontSize: 12, color: '#525252', marginTop: 16 }}>This order determines how tests appear in order entry and result entry for the selected sample type.</p>
+        </div>
+      );
+    }
+
+    function PanelsSection() {
+      const [showCreate, setShowCreate] = useState(false);
+      const [newPanelName, setNewPanelName] = useState('');
+      const [selected, setSelected] = useState({ 1: 3, 3: 2 }); // panel id → position
+      const [expanded, setExpanded] = useState(null);
+
+      const panels = [
+        { id: 1, name: 'Basic Metabolic Panel', count: 8, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium'] },
+        { id: 2, name: 'Comprehensive Metabolic Panel', count: 14, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium', 'Total Protein', 'Albumin', 'Bilirubin', 'ALP', 'AST', 'ALT'] },
+        { id: 3, name: 'Lipid Panel', count: 4, tests: ['Total Cholesterol', 'HDL', 'LDL', 'Triglycerides'] },
+        { id: 4, name: 'Liver Function Panel', count: 7, tests: ['Total Protein', 'Albumin', 'Bilirubin Total', 'Bilirubin Direct', 'ALP', 'AST', 'ALT'] },
+        { id: 5, name: 'Renal Function Panel', count: 5, tests: ['BUN', 'Creatinine', 'eGFR', 'BUN/Creatinine Ratio', 'Uric Acid'] },
+        { id: 6, name: 'Thyroid Panel', count: 3, tests: ['TSH', 'Free T4', 'Free T3'] },
+      ];
+
+      const togglePanel = (id, count) => {
+        setSelected(prev => {
+          const next = { ...prev };
+          if (next[id] !== undefined) {
+            delete next[id];
+            setExpanded(null);
+          } else {
+            next[id] = count + 1;
+            setExpanded(id);
+          }
+          return next;
+        });
+      };
+
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Panel Membership</h2>
+              <p>Select which panels should include this test and set display order</p>
+            </div>
+            <button className="btn-ghost btn-sm" onClick={() => setShowCreate(!showCreate)}>+ Create New Panel</button>
+          </div>
+
+          {showCreate && (
+            <div className="inline-form" style={{ background: '#e3f2fd', borderColor: '#0f62fe', borderStyle: 'solid' }}>
+              <label style={{ fontSize: 13, fontWeight: 600, marginBottom: 6, display: 'block' }}>New Panel Name</label>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <input type="text" value={newPanelName} onChange={e => setNewPanelName(e.target.value)} placeholder="Enter panel name..." style={{ flex: 1, padding: 8, border: '1px solid #d0d0d0', borderRadius: 4 }} autoFocus />
+                <button className="btn btn-primary btn-sm" onClick={() => { setShowCreate(false); setNewPanelName(''); }}>Create</button>
+                <button className="btn btn-secondary btn-sm" onClick={() => { setShowCreate(false); setNewPanelName(''); }}>Cancel</button>
+              </div>
+            </div>
+          )}
+
+          <div>
+            {panels.map(p => {
+              const isSelected = selected[p.id] !== undefined;
+              const pos = selected[p.id] || (p.count + 1);
+              const isExpanded = expanded === p.id;
+              return (
+                <div key={p.id} className="tile" style={{ borderColor: isSelected ? '#0f62fe' : '#e0e0e0', background: isSelected ? '#e3f2fd' : '#fff', borderWidth: isSelected ? 2 : 1, padding: 0 }}>
+                  <div style={{ padding: 12, cursor: 'pointer', display: 'flex', gap: 12, alignItems: 'center' }} onClick={() => togglePanel(p.id, p.count)}>
+                    <input type="checkbox" checked={isSelected} onChange={() => {}} style={{ width: 18, height: 18 }} />
+                    <div style={{ flex: 1 }}>
+                      <div style={{ fontWeight: 500, fontSize: 14 }}>{p.name}</div>
+                      <div style={{ fontSize: 12, color: '#525252' }}>{p.count} tests</div>
+                    </div>
+                    {isSelected && (
+                      <span className="tag tag-blue">Position: {pos}</span>
+                    )}
+                    {isSelected && (
+                      <button className="btn-ghost btn-sm" onClick={e => { e.stopPropagation(); setExpanded(isExpanded ? null : p.id); }}>{isExpanded ? '▼' : '▶'}</button>
+                    )}
+                  </div>
+                  {isSelected && isExpanded && (
+                    <div style={{ borderTop: '1px solid #c6daf8', padding: 12, background: '#fff' }}>
+                      <div style={{ display: 'flex', gap: 16 }}>
+                        <div style={{ width: 200 }}>
+                          <label style={{ fontSize: 12, fontWeight: 600, display: 'block', marginBottom: 6 }}>Display Position in Panel</label>
+                          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+                            <input type="number" min="1" max={p.count + 1} value={pos} onChange={e => setSelected(prev => ({ ...prev, [p.id]: parseInt(e.target.value) || 1 }))} style={{ width: 60, padding: 6, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+                            <span style={{ fontSize: 12, color: '#525252' }}>of {p.count + 1}</span>
+                          </div>
+                          <small style={{ fontSize: 11, color: '#a8a8a8', display: 'block', marginTop: 8 }}>Enter a number or drag the test in the preview list</small>
+                        </div>
+                        <div style={{ flex: 1 }}>
+                          <label style={{ fontSize: 12, fontWeight: 600, display: 'block', marginBottom: 6 }}>Panel Test Order Preview <span style={{ color: '#a8a8a8', fontWeight: 'normal' }}>— drag to reorder</span></label>
+                          <div style={{ background: '#fff', border: '1px solid #d0d0d0', borderRadius: 4, padding: 6, maxHeight: 160, overflowY: 'auto' }}>
+                            {(() => {
+                              const items = [];
+                              p.tests.forEach((test, idx) => {
+                                const position = idx + 1;
+                                if (position === pos) {
+                                  items.push(
+                                    <div key={`this-${idx}`} style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '6px 8px', background: '#bce5fe', border: '2px dashed #0f62fe', borderRadius: 3, marginBottom: 2, fontWeight: 600, color: '#003da5' }}>
+                                      <span style={{ color: '#0f62fe' }}>≡</span>
+                                      <span style={{ width: 20 }}>{pos}.</span>
+                                      <span style={{ flex: 1 }}>← THIS TEST</span>
+                                    </div>
+                                  );
+                                }
+                                items.push(
+                                  <div key={`row-${idx}`} style={{ display: 'flex', gap: 6, padding: '4px 8px', fontSize: 12 }}>
+                                    <span style={{ width: 20, color: '#a8a8a8', marginLeft: 16 }}>{position >= pos ? position + 1 : position}.</span>
+                                    <span>{test}</span>
+                                  </div>
+                                );
+                              });
+                              if (pos > p.count) {
+                                items.push(
+                                  <div key="this-end" style={{ display: 'flex', gap: 6, alignItems: 'center', padding: '6px 8px', background: '#bce5fe', border: '2px dashed #0f62fe', borderRadius: 3, marginTop: 2, fontWeight: 600, color: '#003da5' }}>
+                                    <span style={{ color: '#0f62fe' }}>≡</span>
+                                    <span style={{ width: 20 }}>{pos}.</span>
+                                    <span style={{ flex: 1 }}>← THIS TEST</span>
+                                  </div>
+                                );
+                              }
+                              return items;
+                            })()}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+
+          <p style={{ fontSize: 12, color: '#525252', marginTop: 12 }}>Click a selected panel to expand and set the display order. Use the number input or drag the test in the preview list.</p>
+        </div>
+      );
+    }
+
+    function LabelsSection() {
+      const [allowOverride, setAllowOverride] = useState(true);
+      const [labels, setLabels] = useState([
+        { id: 1, preset: 'specimen', presetName: 'Specimen Label (50×25mm)', defaultQty: 1, maxQty: 5, allowOverride: true },
+        { id: 2, preset: 'block', presetName: 'Block Label (26×12mm)', defaultQty: 4, maxQty: 20, allowOverride: true },
+        { id: 3, preset: 'slide', presetName: 'Slide Label (76×26mm)', defaultQty: 12, maxQty: 50, allowOverride: true },
+        { id: 4, preset: 'freezer', presetName: 'Freezer Label (38×19mm)', defaultQty: 2, maxQty: 10, allowOverride: false },
+      ]);
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Default Labels for This Test</h2>
+              <p>When this test is ordered, automatically suggest these labels</p>
+            </div>
+            <button className="btn btn-primary btn-sm">+ Add Label Type</button>
+          </div>
+
+          <div className="table-container">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Label Preset</th>
+                  <th style={{ width: 110 }}>Default Qty</th>
+                  <th style={{ width: 90 }}>Max Qty</th>
+                  <th style={{ width: 130 }}>Allow Override</th>
+                  <th style={{ width: 70 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {labels.map(l => (
+                  <tr key={l.id}>
+                    <td>{l.presetName}</td>
+                    <td><input type="number" defaultValue={l.defaultQty} style={{ width: 70, padding: 4, border: '1px solid #d0d0d0', borderRadius: 3 }} /></td>
+                    <td><input type="number" defaultValue={l.maxQty} style={{ width: 70, padding: 4, border: '1px solid #d0d0d0', borderRadius: 3 }} /></td>
+                    <td><input type="checkbox" defaultChecked={l.allowOverride} style={{ width: 16, height: 16 }} /></td>
+                    <td><button className="btn-ghost btn-sm">Del</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div className="tile" style={{ marginTop: 16 }}>
+            <div className="tile-header">Label Generation Settings</div>
+            <label className="checkbox-item" style={{ marginBottom: 4 }}>
+              <input type="checkbox" checked={allowOverride} onChange={e => setAllowOverride(e.target.checked)} />
+              <span>Allow label count override at order entry</span>
+            </label>
+            <small style={{ display: 'block', fontSize: 12, color: '#525252', marginLeft: 24 }}>When enabled, users can modify label quantities during order entry. Individual label types can still be locked via the "Allow Override" column above.</small>
+          </div>
+
+          <div className="tile" style={{ background: '#e3f2fd', borderColor: '#a8d8e8' }}>
+            <div className="tile-header" style={{ color: '#003da5' }}>ℹ️ Order Entry Preview</div>
+            <p style={{ fontSize: 13, color: '#003da5', marginBottom: 12 }}>When this test is ordered, the Labels section will be pre-populated as follows:</p>
+            <div style={{ background: '#fff', borderRadius: 4, padding: 8 }}>
+              <table className="data-table" style={{ fontSize: 13 }}>
+                <thead>
+                  <tr><th>Label Type</th><th style={{ width: 80, textAlign: 'center' }}>Qty</th><th>Source</th></tr>
+                </thead>
+                <tbody>
+                  {labels.map(l => (
+                    <tr key={l.id}>
+                      <td>{l.presetName}</td>
+                      <td style={{ textAlign: 'center' }}>{l.allowOverride ? l.defaultQty : <span style={{ background: '#e8e8e8', padding: '2px 6px', borderRadius: 3, color: '#525252' }}>{l.defaultQty}</span>}</td>
+                      <td style={{ fontSize: 12, color: '#525252' }}>This test</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <small style={{ display: 'block', fontSize: 12, color: '#525252', marginTop: 8 }}>⚠ Gray quantities are locked and cannot be modified at order entry</small>
+          </div>
+        </div>
+      );
+    }
+
+    function TerminologySection() {
+      const [mappings] = useState([
+        { id: 1, source: 'LOINC', code: '1558-6', relationship: 'SAME_AS', displayName: 'Fasting glucose [Mass/volume] in Serum or Plasma' },
+        { id: 2, source: 'SNOMED', code: '271062006', relationship: 'SAME_AS', displayName: 'Fasting blood glucose measurement' },
+      ]);
+      const sourceTagClass = { LOINC: 'tag-blue', SNOMED: 'tag-teal', CIEL: 'tag-purple', OCL: 'tag-warm-gray' };
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Terminology Mappings</h2>
+              <p>Link this test to standard terminology codes for FHIR interoperability</p>
+            </div>
+            <button className="btn-ghost btn-sm">+ Add Mapping</button>
+          </div>
+
+          <div>
+            {mappings.map(m => (
+              <div key={m.id} className="tile" style={{ padding: 12 }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 12 }}>
+                  <div style={{ display: 'flex', gap: 12, flex: 1 }}>
+                    <span className={`tag ${sourceTagClass[m.source]}`}>{m.source}</span>
+                    <div style={{ flex: 1 }}>
+                      <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 4 }}>
+                        <span className="mono" style={{ fontWeight: 500 }}>{m.code}</span>
+                        <span className="tag tag-warm-gray">{m.relationship.replace('_', ' ')}</span>
+                      </div>
+                      <div style={{ fontSize: 13, color: '#525252' }}>{m.displayName}</div>
+                    </div>
+                  </div>
+                  <div style={{ display: 'flex', gap: 4 }}>
+                    <button className="btn-ghost btn-sm">Edit</button>
+                    <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>Del</button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="inline-form" style={{ marginTop: 16 }}>
+            <h3 style={{ fontSize: 13, margin: '0 0 12px 0' }}>Add New Mapping</h3>
+            <div style={{ display: 'grid', gridTemplateColumns: '180px 1fr 180px 80px', gap: 8, alignItems: 'end' }}>
+              <div>
+                <label style={{ fontSize: 12, fontWeight: 600, marginBottom: 4, display: 'block' }}>Terminology Source</label>
+                <select style={{ width: '100%', padding: 6, border: '1px solid #d0d0d0', borderRadius: 4 }}>
+                  <option>Select...</option>
+                  <option>LOINC</option>
+                  <option>SNOMED CT</option>
+                  <option>CIEL</option>
+                  <option>OCL</option>
+                </select>
+              </div>
+              <div>
+                <label style={{ fontSize: 12, fontWeight: 600, marginBottom: 4, display: 'block' }}>Code</label>
+                <input type="text" placeholder="Enter code" style={{ width: '100%', padding: 6, border: '1px solid #d0d0d0', borderRadius: 4 }} />
+              </div>
+              <div>
+                <label style={{ fontSize: 12, fontWeight: 600, marginBottom: 4, display: 'block' }}>Relationship</label>
+                <select style={{ width: '100%', padding: 6, border: '1px solid #d0d0d0', borderRadius: 4 }}>
+                  <option>Same As</option>
+                  <option>Broader Than</option>
+                  <option>Narrower Than</option>
+                </select>
+              </div>
+              <button className="btn btn-primary btn-sm">Add</button>
+            </div>
+            <small style={{ display: 'block', fontSize: 11, color: '#a8a8a8', marginTop: 8 }}>Display name will be auto-populated from terminology lookup; editable if lookup fails.</small>
+          </div>
+        </div>
+      );
+    }
+
+    function ReagentsSection() {
+      const reagents = [
+        { id: 1, name: 'Glucose Reagent R1', manufacturer: 'Roche', usage: 'PRIMARY', qty: 100, unit: 'µL', stock: 2500 },
+        { id: 2, name: 'Glucose Reagent R2', manufacturer: 'Roche', usage: 'SECONDARY', qty: 50, unit: 'µL', stock: 1200 },
+      ];
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Associated Reagents</h2>
+              <p>Link reagents from inventory to track consumption</p>
+            </div>
+            <button className="btn btn-primary btn-sm">+ Link Reagent</button>
+          </div>
+
+          {reagents.map(r => (
+            <div key={r.id} className="tile" style={{ padding: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ width: 40, height: 40, background: '#d1f3f6', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>⚗️</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 4 }}>
+                    <strong style={{ fontSize: 14 }}>{r.name}</strong>
+                    <span className={r.usage === 'PRIMARY' ? 'tag tag-blue' : 'tag tag-green'}>{r.usage}</span>
+                  </div>
+                  <div style={{ fontSize: 13, color: '#525252' }}>{r.manufacturer} • {r.qty} {r.unit} per test</div>
+                </div>
+                <div style={{ textAlign: 'right' }}>
+                  <div style={{ fontWeight: 600, fontSize: 14 }}>{r.stock.toLocaleString()} {r.unit}</div>
+                  <div style={{ fontSize: 11, color: '#525252' }}>Current Stock</div>
+                </div>
+                <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>×</button>
+              </div>
+            </div>
+          ))}
+
+          <div className="info-banner">
+            ℹ️ Reagents are configured in <strong>Administration → Master Lists → Reagents</strong>. Linking a reagent here records consumption per test run for inventory tracking.
+          </div>
+        </div>
+      );
+    }
+
+    function AnalyzersSection() {
+      const [showLink, setShowLink] = useState(false);
+      const linked = [
+        { id: 1, name: 'Cobas c 501', manufacturer: 'Roche', sn: 'SN-2024-0142', location: 'Chemistry Lab A', status: 'Online' },
+        { id: 2, name: 'Cobas c 502', manufacturer: 'Roche', sn: 'SN-2024-0143', location: 'Chemistry Lab B', status: 'Online' },
+      ];
+      const available = [
+        { id: 3, name: 'AU680', manufacturer: 'Beckman Coulter', sn: 'SN-2023-0098', location: 'Chemistry Lab A', status: 'Online' },
+        { id: 4, name: 'Architect c8000', manufacturer: 'Abbott', sn: 'SN-2022-0456', location: 'Chemistry Lab C', status: 'Maintenance' },
+        { id: 5, name: 'Vitros 5600', manufacturer: 'Ortho Clinical', sn: 'SN-2024-0201', location: 'STAT Lab', status: 'Online' },
+      ];
+      const statusTag = { Online: 'tag-green', Maintenance: 'tag-warm-gray', Offline: 'tag-red' };
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Linked Analyzers</h2>
+              <p>Select which analyzers can perform this test</p>
+            </div>
+            <button className="btn btn-primary btn-sm" onClick={() => setShowLink(true)}>+ Link Analyzer</button>
+          </div>
+
+          {linked.map(a => (
+            <div key={a.id} className="tile" style={{ padding: 12 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                <div style={{ width: 40, height: 40, background: '#e8e8e8', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 18 }}>💻</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 4 }}>
+                    <strong style={{ fontSize: 14 }}>{a.name}</strong>
+                    <span className={`tag ${statusTag[a.status]}`}>{a.status}</span>
+                  </div>
+                  <div style={{ fontSize: 13, color: '#525252' }}>{a.manufacturer} • {a.location}</div>
+                  <div style={{ fontSize: 11, color: '#a8a8a8', marginTop: 2 }}>S/N: {a.sn}</div>
+                </div>
+                <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>× Unlink</button>
+              </div>
+            </div>
+          ))}
+
+          <div className="info-banner">
+            ℹ️ <strong>About Analyzer Linking:</strong> Analyzers are configured in <strong>Administration → Master Lists → Analyzers</strong>. Test code mapping is configured separately in the analyzer interface setup. Linking an analyzer indicates this test can be performed on that instrument.
+          </div>
+
+          {showLink && (
+            <div className="modal-overlay" onClick={() => setShowLink(false)}>
+              <div className="modal" onClick={e => e.stopPropagation()}>
+                <div className="modal-header">
+                  <h2>Link Analyzers</h2>
+                  <button className="modal-close" onClick={() => setShowLink(false)}>×</button>
+                </div>
+                <div className="modal-body">
+                  <label style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, display: 'block' }}>Select Analyzers</label>
+                  <div style={{ border: '1px solid #d0d0d0', borderRadius: 4, maxHeight: 280, overflowY: 'auto' }}>
+                    {available.map(a => (
+                      <label key={a.id} style={{ display: 'flex', gap: 12, alignItems: 'center', padding: 12, borderBottom: '1px solid #f0f0f0', cursor: 'pointer' }}>
+                        <input type="checkbox" style={{ width: 18, height: 18 }} />
+                        <div style={{ flex: 1 }}>
+                          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                            <strong style={{ fontSize: 14 }}>{a.name}</strong>
+                            <span className={`tag ${statusTag[a.status]}`}>{a.status}</span>
+                          </div>
+                          <div style={{ fontSize: 12, color: '#525252' }}>{a.manufacturer} • {a.location}</div>
+                        </div>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button className="btn btn-secondary btn-sm" onClick={() => setShowLink(false)}>Cancel</button>
+                  <button className="btn btn-primary btn-sm" onClick={() => setShowLink(false)}>Link Selected</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function AlertsSection() {
+      const [showAdd, setShowAdd] = useState(false);
+      const [rules, setRules] = useState([
+        { id: 1, name: 'Critical Value Alert', enabled: true, trigger: 'Critical Value', triggerColor: 'tag-red', channels: ['SMS', 'Email'], recipients: ['Ordering Physician'], smsTemplate: 'CRITICAL: {{test_name}} result {{result}} {{unit}} for {{patient_name}}. Please review immediately.' },
+        { id: 2, name: 'Abnormal Result Notification', enabled: true, trigger: 'Abnormal (High or Low)', triggerColor: 'tag-warm-gray', channels: ['Email'], recipients: ['Ordering Physician'], smsTemplate: '' },
+        { id: 3, name: 'Positive Result Alert', enabled: false, trigger: 'Equals "Positive"', triggerColor: 'tag-blue', channels: ['SMS'], recipients: ['Patient'], smsTemplate: 'Lab result ready for {{patient_name}}. Please contact your healthcare provider.' },
+      ]);
+      const channelTag = { SMS: 'tag-blue', Email: 'tag-purple' };
+      const toggle = id => setRules(prev => prev.map(r => r.id === id ? { ...r, enabled: !r.enabled } : r));
+
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Alert Rules</h2>
+              <p>Configure automated notifications when specific result conditions are met</p>
+            </div>
+            <button className="btn btn-primary btn-sm" onClick={() => setShowAdd(true)}>+ Add Rule</button>
+          </div>
+
+          {rules.map(r => (
+            <div key={r.id} className="tile" style={{ padding: 0, opacity: r.enabled ? 1 : 0.7 }}>
+              <div style={{ padding: 12, background: '#f4f4f4', borderBottom: '1px solid #e0e0e0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                  <div style={{ width: 8, height: 8, borderRadius: '50%', background: r.enabled ? '#24a148' : '#a8a8a8' }} />
+                  <strong style={{ fontSize: 14 }}>{r.name}</strong>
+                  <span className={r.enabled ? 'tag tag-green' : 'tag tag-gray'}>{r.enabled ? 'Enabled' : 'Disabled'}</span>
+                </div>
+                <div style={{ display: 'flex', gap: 4 }}>
+                  <button className="btn-ghost btn-sm" onClick={() => toggle(r.id)}>{r.enabled ? 'Disable' : 'Enable'}</button>
+                  <button className="btn-ghost btn-sm">Edit</button>
+                  <button className="btn-ghost btn-sm" style={{ color: '#da1e28' }}>Del</button>
+                </div>
+              </div>
+              <div style={{ padding: 12 }}>
+                <div style={{ display: 'flex', gap: 24, marginBottom: 12 }}>
+                  <div>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: 4 }}>When</div>
+                    <span className={`tag ${r.triggerColor}`}>{r.trigger}</span>
+                  </div>
+                  <div>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: 4 }}>Notify Via</div>
+                    <div>{r.channels.map(c => <span key={c} className={`tag ${channelTag[c]}`}>{c === 'SMS' ? '📱 ' : '📧 '}{c}</span>)}</div>
+                  </div>
+                  <div>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: 4 }}>Recipients</div>
+                    <div>{r.recipients.map(rec => <span key={rec} className="tag tag-gray">{rec}</span>)}</div>
+                  </div>
+                </div>
+                {r.smsTemplate && (
+                  <div style={{ paddingTop: 12, borderTop: '1px solid #f0f0f0' }}>
+                    <div style={{ fontSize: 11, fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: 4 }}>SMS Template</div>
+                    <div className="mono" style={{ fontSize: 12, padding: 8, background: '#f4f4f4', borderRadius: 3 }}>{r.smsTemplate}</div>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+
+          {showAdd && (
+            <div className="modal-overlay" onClick={() => setShowAdd(false)}>
+              <div className="modal" style={{ maxWidth: 720 }} onClick={e => e.stopPropagation()}>
+                <div className="modal-header">
+                  <h2>Add Alert Rule</h2>
+                  <button className="modal-close" onClick={() => setShowAdd(false)}>×</button>
+                </div>
+                <div className="modal-body">
+                  <div className="form-group">
+                    <label>Rule Name</label>
+                    <input type="text" placeholder="e.g., Critical Value SMS Alert" />
+                  </div>
+                  <div className="form-group">
+                    <label>Alert when result is:</label>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      <label className="radio-item"><input type="radio" name="trigger" /> All Results</label>
+                      <label className="radio-item"><input type="radio" name="trigger" /> Abnormal (outside normal range)</label>
+                      <label className="radio-item"><input type="radio" name="trigger" defaultChecked /> Critical (panic value)</label>
+                      <label className="radio-item"><input type="radio" name="trigger" /> Specific Value: <input type="text" placeholder="e.g., Positive" style={{ width: 140, marginLeft: 8 }} /></label>
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Send via:</label>
+                    <div style={{ display: 'flex', gap: 16 }}>
+                      <label className="checkbox-item"><input type="checkbox" /> 📱 SMS</label>
+                      <label className="checkbox-item"><input type="checkbox" /> 📧 Email</label>
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>Recipients:</label>
+                    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                      <label className="checkbox-item"><input type="checkbox" /> Ordering Physician (from order)</label>
+                      <label className="checkbox-item"><input type="checkbox" /> Patient (from patient record)</label>
+                      <label className="checkbox-item"><input type="checkbox" /> Custom recipient:</label>
+                      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginLeft: 24 }}>
+                        <input type="text" placeholder="Phone: +1 555-123-4567" />
+                        <input type="email" placeholder="Email: user@example.com" />
+                      </div>
+                    </div>
+                  </div>
+                  <div className="form-group">
+                    <label>SMS Template (160 char recommended)</label>
+                    <textarea rows={3} placeholder="CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}. Review immediately." className="mono" />
+                    <small style={{ display: 'block', fontSize: 11, color: '#525252', marginTop: 4 }}>Variables: {'{{patient_name}}, {{patient_id}}, {{test_name}}, {{result}}, {{unit}}, {{reference_range}}'}</small>
+                  </div>
+                </div>
+                <div className="modal-footer">
+                  <button className="btn btn-secondary btn-sm" onClick={() => setShowAdd(false)}>Cancel</button>
+                  <button className="btn btn-primary btn-sm" onClick={() => setShowAdd(false)}>Save Alert Rule</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function ReflexCalcSection() {
+      const reflexBy = [
+        { id: 1, condition: '> 200 mg/dL', target: 'Hemoglobin A1c', mode: 'Suggest', modeColor: 'tag-warm-gray' },
+        { id: 2, condition: '= "Abnormal"', target: 'Glucose Tolerance Test', mode: 'Auto-order', modeColor: 'tag-green' },
+      ];
+      const reflexInto = [
+        { id: 101, sourceTest: 'Glucose Tolerance Test', condition: '2-hour result > 140' },
+      ];
+      const calcs = [
+        { id: 201, name: 'LDL Cholesterol (Calculated)', formula: 'Total_Chol - HDL - (Triglycerides / 5)' },
+      ];
+      return (
+        <div>
+          <div className="tile">
+            <div className="tile-header">⚡ Reflex Tests</div>
+            <p style={{ fontSize: 13, color: '#525252', marginTop: -8, marginBottom: 12 }}>Automatic test ordering based on results</p>
+
+            <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, marginTop: 16 }}>Rules triggered BY this test:</h3>
+            {reflexBy.map(r => (
+              <div key={r.id} style={{ padding: 12, background: '#f4f4f4', border: '1px solid #e0e0e0', borderRadius: 4, marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center', fontSize: 13 }}>
+                  <span style={{ color: '#525252' }}>IF result</span>
+                  <strong>{r.condition}</strong>
+                  <span style={{ color: '#525252' }}>→ ORDER</span>
+                  <strong style={{ color: '#0f62fe' }}>{r.target}</strong>
+                  <span className={`tag ${r.modeColor}`}>{r.mode}</span>
+                </div>
+                <a href="#" style={{ fontSize: 13, color: '#0f62fe', fontWeight: 500 }}>Edit in Master Lists →</a>
+              </div>
+            ))}
+
+            <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, marginTop: 16 }}>Rules that ORDER this test:</h3>
+            {reflexInto.map(r => (
+              <div key={r.id} style={{ padding: 12, background: '#e3f2fd', border: '1px solid #bce5fe', borderRadius: 4, marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ fontSize: 13 }}>
+                  <span style={{ color: '#0f62fe' }}>↳ </span>
+                  <strong>{r.sourceTest}</strong>
+                  <span style={{ color: '#525252' }}> when {r.condition}</span>
+                </div>
+                <a href="#" style={{ fontSize: 13, color: '#0f62fe', fontWeight: 500 }}>Edit in Master Lists →</a>
+              </div>
+            ))}
+
+            <a href="#" style={{ display: 'inline-block', marginTop: 8, fontSize: 13, color: '#0f62fe', fontWeight: 500 }}>+ Add New Reflex Rule in Master Lists →</a>
+          </div>
+
+          <div className="tile">
+            <div className="tile-header">⚡ Calculated Results</div>
+            <p style={{ fontSize: 13, color: '#525252', marginTop: -8, marginBottom: 12 }}>Formulas that compute results from other test values</p>
+
+            <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 8 }}>Calculations that USE this test as input:</h3>
+            {calcs.map(c => (
+              <div key={c.id} style={{ padding: 12, background: '#f3e8ff', border: '1px solid #e0c3fc', borderRadius: 4, marginBottom: 8, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+                  <div style={{ width: 32, height: 32, background: '#e0c3fc', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16 }}>⚡</div>
+                  <div>
+                    <div style={{ fontSize: 13, fontWeight: 500 }}>{c.name}</div>
+                    <div className="mono" style={{ fontSize: 11, color: '#525252', marginTop: 2 }}>{c.formula}</div>
+                  </div>
+                </div>
+                <a href="#" style={{ fontSize: 13, color: '#0f62fe', fontWeight: 500 }}>Edit in Master Lists →</a>
+              </div>
+            ))}
+
+            <h3 style={{ fontSize: 13, fontWeight: 600, marginBottom: 8, marginTop: 16 }}>This test IS a calculated result:</h3>
+            <div style={{ padding: 16, border: '2px dashed #d0d0d0', borderRadius: 4, textAlign: 'center' }}>
+              <div style={{ fontSize: 24, marginBottom: 8 }}>⚡</div>
+              <div style={{ fontSize: 13, color: '#525252', marginBottom: 8 }}>This test's result is not calculated from other values</div>
+              <a href="#" style={{ fontSize: 13, color: '#0f62fe', fontWeight: 500 }}>+ Configure in Master Lists →</a>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function ComplianceSection() {
+      const thresholds = [
+        { id: 1, std: 'PP No. 22/2021 — Baku Mutu Air', grp: 'Parameter Fisika', type: 'MAX', value: '≤ 25 NTU', date: '2021-02-02' },
+        { id: 2, std: 'WHO Drinking Water Guidelines', grp: 'Chemical Contaminants', type: 'MAX', value: '≤ 5 NTU', date: '2022-03-21' },
+        { id: 3, std: 'EPA Method 180.1', grp: 'Reporting Limits', type: 'RANGE', value: '0.1–4000 NTU', date: '2018-01-15' },
+      ];
+      const typeTag = { MAX: 'tag-red', MIN: 'tag-blue', RANGE: 'tag-teal', DESCRIPTIVE: 'tag-purple' };
+      return (
+        <div>
+          <div className="section-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+            <div>
+              <h2>Compliance Thresholds</h2>
+              <p>Regulatory compliance thresholds for this test</p>
+            </div>
+            <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+              <label style={{ fontSize: 13 }}>Group by:</label>
+              <select style={{ padding: 6, border: '1px solid #d0d0d0', borderRadius: 4, fontSize: 13 }}>
+                <option>Standard</option>
+                <option>Parameter Group</option>
+              </select>
+              <button className="btn btn-primary btn-sm">+ Add Threshold</button>
+            </div>
+          </div>
+
+          <p style={{ fontSize: 13, color: '#525252', marginBottom: 12 }}>Environmental tests use these instead of (or alongside) clinical reference ranges. Full compliance standards are managed at <strong>Admin → Test Management → Compliance Standards</strong>.</p>
+
+          <div className="table-container">
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Standard</th>
+                  <th>Parameter Group</th>
+                  <th style={{ width: 100 }}>Type</th>
+                  <th>Value</th>
+                  <th style={{ width: 130 }}>Effective Date</th>
+                  <th style={{ width: 70 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {thresholds.map(t => (
+                  <tr key={t.id}>
+                    <td>{t.std}</td>
+                    <td>{t.grp}</td>
+                    <td><span className={`tag ${typeTag[t.type]}`}>{t.type}</span></td>
+                    <td style={{ fontWeight: 500 }}>{t.value}</td>
+                    <td style={{ color: '#525252', fontSize: 12 }}>{t.date}</td>
+                    <td><button className="btn-ghost btn-sm">Edit</button></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      );
+    }
+
+    function TestEditor({ test, setTest, onBack }) {
+      const [currentSection, setCurrentSection] = useState('basic');
+      const sections = [
+        { id: 'basic', label: 'Basic Info' },
+        { id: 'sample', label: 'Sample & Results' },
+        { id: 'methods', label: 'Methods' },
+        { id: 'ranges', label: 'Ranges' },
+        { id: 'storage', label: 'Sample Storage' },
+        { id: 'order', label: 'Display Order' },
+        { id: 'panels', label: 'Panels' },
+        { id: 'labels', label: 'Labels' },
+        { id: 'terminology', label: 'Terminology' },
+        { id: 'reagents', label: 'Reagents' },
+        { id: 'analyzers', label: 'Analyzers' },
+        { id: 'alerts', label: 'Alerts' },
+        { id: 'reflex', label: 'Reflex & Calc' },
+      ];
+
+      // Hide Compliance if Clinical domain
+      const visibleSections = test.domain === 'CLINICAL'
+        ? sections
+        : [...sections, { id: 'compliance', label: 'Compliance' }];
+
+      return (
+        <div>
+          <div className="app-header">
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <button className="btn-ghost" onClick={onBack}>← Test List</button>
+              <h1>{test.name}</h1>
+            </div>
+            <div className="app-header-actions">
+              <button className="btn btn-secondary">Cancel</button>
+              <button className="btn btn-primary">Save Test</button>
+            </div>
+          </div>
+
+          <div className="editor-container">
+            <div className="editor-sidenav">
+              <div className="sidenav-header">Test Catalog Management</div>
+              {visibleSections.map(sec => (
+                <div
+                  key={sec.id}
+                  className={`sidenav-item ${currentSection === sec.id ? 'sidenav-item-active' : ''}`}
+                  onClick={() => setCurrentSection(sec.id)}
+                >
+                  {sec.label}
+                </div>
+              ))}
+            </div>
+
+            <div className="editor-content">
+              {(test.domain === 'ENVIRONMENTAL' || test.domain === 'VECTOR') && currentSection === 'ranges' && (
+                <div className="info-banner">
+                  ℹ️ This is an {test.domain === 'ENVIRONMENTAL' ? 'Environmental' : 'Vector'} test. Compliance thresholds are typically the primary evaluation surface for this domain.
+                </div>
+              )}
+
+              {currentSection === 'basic' && <BasicInfoTab test={test} setTest={setTest} />}
+              {currentSection === 'sample' && <SampleResultsTab />}
+              {currentSection === 'methods' && <MethodsTab />}
+              {currentSection === 'ranges' && <RangesTab />}
+              {currentSection === 'storage' && <SampleStorageSection />}
+              {currentSection === 'order' && <DisplayOrderSection />}
+              {currentSection === 'panels' && <PanelsSection />}
+              {currentSection === 'labels' && <LabelsSection />}
+              {currentSection === 'terminology' && <TerminologySection />}
+              {currentSection === 'reagents' && <ReagentsSection />}
+              {currentSection === 'analyzers' && <AnalyzersSection />}
+              {currentSection === 'alerts' && <AlertsSection />}
+              {currentSection === 'reflex' && <ReflexCalcSection />}
+              {currentSection === 'compliance' && <ComplianceSection />}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function App() {
+      const [screen, setScreen] = useState('list');
+      const [selectedTest, setSelectedTest] = useState(null);
+      const [test, setTest] = useState(null);
+
+      const handleEdit = (t) => {
+        setSelectedTest(t);
+        setTest(t);
+        setScreen('editor');
+      };
+
+      const handleAdd = () => {
+        const blankTest = { id: null, name: 'New Test', section: '', sampleType: '', resultType: '', loinc: null, status: 'Active', domain: 'CLINICAL', amr: false };
+        setSelectedTest(blankTest);
+        setTest(blankTest);
+        setScreen('editor');
+      };
+
+      if (screen === 'editor' && selectedTest) {
+        return (
+          <TestEditor
+            test={test || selectedTest}
+            setTest={setTest}
+            onBack={() => { setScreen('list'); setSelectedTest(null); setTest(null); }}
+          />
+        );
+      }
+
+      return (
+        <div>
+          <div className="app-header">
+            <h1>Test Catalog Management</h1>
+          </div>
+          <TestListView onEdit={handleEdit} onAdd={handleAdd} />
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/designs/admin-config/test-catalog.jsx
+++ b/designs/admin-config/test-catalog.jsx
@@ -1,4394 +1,2103 @@
 import React, { useState, useMemo } from 'react';
-import { Search, Plus, Filter, Download, Upload, Cloud, Edit, Copy, Trash2, ChevronDown, ChevronRight, Info, X, Check, AlertTriangle, ChevronLeft, Settings, Bell, Link, FlaskConical, FileText, Tag, Beaker, Activity, HelpCircle, GripVertical, Eye, EyeOff, AlertCircle, CheckCircle, ArrowUp, ArrowDown, Layers, Move, GitBranch, Zap, Mail, MessageSquare, Phone, Thermometer, Snowflake, Clock, Printer, Cpu } from 'lucide-react';
+import {
+  Grid, Column, Stack,
+  SideNav, SideNavItems, SideNavMenu, SideNavMenuItem, SideNavLink,
+  DataTable, TableContainer, Table, TableHead, TableRow, TableHeader, TableBody, TableCell,
+  TableToolbar, TableToolbarContent, TableToolbarSearch,
+  TextInput, TextArea, Select, SelectItem, NumberInput, MultiSelect,
+  Checkbox, RadioButton, RadioButtonGroup, Toggle,
+  Button, IconButton, InlineNotification, Tag, Modal, Loading,
+  Accordion, AccordionItem,
+  Tile, Pagination, Search, OverflowMenu, OverflowMenuItem, FormGroup,
+} from '@carbon/react';
+import {
+  Add, Edit, TrashCan, ChevronDown, ChevronUp, Information, Renew,
+  Download, Upload, Save, Draggable, Search as SearchIcon, Catalog,
+  Settings, NotificationFilled, Email, Phone, Thermometer, Snowflake, Beaker,
+  Activity, FlowConnection, ChartLine, Printer, Cpu, FlaskConical,
+  CheckmarkOutline, WarningAlt, Filter, Locked, Unlocked, Close, Copy,
+} from '@carbon/icons-react';
 
-// ============================================
-// UTILITY FUNCTIONS
-// ============================================
+// ==================== I18N HELPER ====================
+const t = (key, fallback) => fallback || key;
 
-const normalizeToDays = (value, unit) => {
-  switch(unit) {
-    case 'hours': return value / 24;
-    case 'days': return value;
-    case 'weeks': return value * 7;
-    case 'months': return value * 30.44;
-    case 'years': return value * 365.25;
-    default: return value;
-  }
-};
+// ==================== MOCK DATA ====================
+const mockTests = [
+  { id: 1, name: 'Glucose, Fasting', section: 'Chemistry', sampleType: 'Serum', resultType: 'NUMERIC', loinc: '2345-7', status: 'Active', domain: 'CLINICAL', amr: false },
+  { id: 2, name: 'HbA1c', section: 'Chemistry', sampleType: 'Whole Blood', resultType: 'NUMERIC', loinc: '4548-4', status: 'Active', domain: 'CLINICAL', amr: false },
+  { id: 3, name: 'HBsAg', section: 'Serology', sampleType: 'Serum', resultType: 'SELECT_LIST', loinc: '16962-2', status: 'Active', domain: 'CLINICAL', amr: false },
+  { id: 4, name: 'HIV Viral Load', section: 'Molecular', sampleType: 'Plasma', resultType: 'NUMERIC', loinc: '10689-0', status: 'Active', domain: 'CLINICAL', amr: false },
+  { id: 5, name: 'CBC', section: 'Hematology', sampleType: 'Whole Blood', resultType: 'NUMERIC', loinc: '58410-2', status: 'Active', domain: 'CLINICAL', amr: false },
+  { id: 6, name: 'Bilirubin, Total', section: 'Chemistry', sampleType: 'Serum', resultType: 'NUMERIC', loinc: '1975-2', status: 'Inactive', domain: 'CLINICAL', amr: false },
+  { id: 7, name: 'Water Turbidity', section: 'Environmental', sampleType: 'Water', resultType: 'NUMERIC', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+  { id: 8, name: 'Lead in Drinking Water', section: 'Environmental', sampleType: 'Water', resultType: 'NUMERIC', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+  { id: 9, name: 'PM2.5', section: 'Environmental', sampleType: 'Air', resultType: 'NUMERIC', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+  { id: 10, name: 'Fecal Coliform', section: 'Environmental', sampleType: 'Water', resultType: 'SELECT_LIST', loinc: null, status: 'Active', domain: 'ENVIRONMENTAL', amr: false },
+  { id: 11, name: 'Aedes pool RT-PCR Dengue', section: 'Molecular', sampleType: 'Mosquito Pool', resultType: 'SELECT_LIST', loinc: null, status: 'Active', domain: 'VECTOR', amr: false },
+  { id: 12, name: 'Anopheles speciation', section: 'Molecular', sampleType: 'Mosquito Pool', resultType: 'SELECT_LIST', loinc: null, status: 'Active', domain: 'VECTOR', amr: false },
+  { id: 13, name: 'Ampicillin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'SELECT_LIST', loinc: '18901-5', status: 'Active', domain: 'CLINICAL', amr: true },
+  { id: 14, name: 'Ciprofloxacin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'SELECT_LIST', loinc: '18909-8', status: 'Active', domain: 'CLINICAL', amr: true },
+];
 
-const formatAge = (value, unit) => {
-  if (value === 999 && unit === 'years') return 'âˆž';
-  return `${value} ${unit}`;
-};
+// ==================== HELPER COMPONENTS ====================
+/**
+ * DomainTag — renders a colored tag based on test domain (CLINICAL, ENVIRONMENTAL, VECTOR)
+ */
+function DomainTag({ domain }) {
+  const tagMap = {
+    'CLINICAL': { kind: 'blue', label: 'Clinical' },
+    'ENVIRONMENTAL': { kind: 'teal', label: 'Environmental' },
+    'VECTOR': { kind: 'purple', label: 'Vector' },
+  };
+  const config = tagMap[domain] || { kind: 'gray', label: domain };
+  return <Tag type={config.kind}>{config.label}</Tag>;
+}
 
-const formatAgeRange = (range) => {
-  const from = formatAge(range.ageFrom, range.ageFromUnit);
-  const to = formatAge(range.ageTo, range.ageToUnit);
-  return `${from} â€“ ${to}`;
-};
-
-const getSexLabel = (sex) => {
-  switch(sex) {
-    case 'M': return 'Male';
-    case 'F': return 'Female';
-    case 'A': return 'All';
-    default: return sex;
-  }
-};
-
-const getSexBadgeColor = (sex) => {
-  switch(sex) {
-    case 'M': return 'bg-blue-100 text-blue-700';
-    case 'F': return 'bg-pink-100 text-pink-700';
-    case 'A': return 'bg-gray-100 text-gray-700';
-    default: return 'bg-gray-100 text-gray-700';
-  }
-};
-
-const getRangeTypeColor = (type) => {
-  switch(type) {
-    case 'normal': return { bg: 'bg-green-50', border: 'border-green-200', badge: 'bg-green-100 text-green-700', bar: 'bg-green-400' };
-    case 'valid': return { bg: 'bg-blue-50', border: 'border-blue-200', badge: 'bg-blue-100 text-blue-700', bar: 'bg-blue-300' };
-    case 'critical': return { bg: 'bg-red-50', border: 'border-red-200', badge: 'bg-red-100 text-red-700', bar: 'bg-red-400' };
-    case 'reporting': return { bg: 'bg-purple-50', border: 'border-purple-200', badge: 'bg-purple-100 text-purple-700', bar: 'bg-purple-300' };
-    default: return { bg: 'bg-gray-50', border: 'border-gray-200', badge: 'bg-gray-100 text-gray-700', bar: 'bg-gray-300' };
-  }
-};
-
-// Sort ranges by normalized age
-const sortRanges = (ranges) => {
-  return [...ranges].sort((a, b) => {
-    const aDays = normalizeToDays(a.ageFrom, a.ageFromUnit);
-    const bDays = normalizeToDays(b.ageFrom, b.ageFromUnit);
-    return aDays - bDays;
+// ==================== TEST LIST VIEW ====================
+/**
+ * TestListView — displays paginated, filterable list of tests with click-to-open
+ */
+function TestListView({ onEdit, onAdd }) {
+  const [filters, setFilters] = useState({
+    section: '',
+    sampleType: '',
+    resultType: '',
+    status: '',
+    domain: 'All Domains',
+    amr: 'All',
   });
-};
+  const [showFilters, setShowFilters] = useState(false);
+  const [searchText, setSearchText] = useState('');
+  const [currentPage, setCurrentPage] = useState(1);
+  const pageSize = 10;
 
-// ============================================
-// ENHANCED RANGE EDITOR WITH FUNCTIONAL VALIDATION
-// ============================================
-
-const RangeEditorV3 = () => {
-  const [viewMode, setViewMode] = useState('structured');
-  const [expandedGroups, setExpandedGroups] = useState(['normal', 'critical']);
-  const [showAddModal, setShowAddModal] = useState(false);
-  const [prefillData, setPrefillData] = useState(null);
-  const [showValidationPanel, setShowValidationPanel] = useState(true);
-
-  // Range data with hour-level normal ranges for neonates
-  // Intentional gap in Female: 56 days to 1 year is missing!
-  const [rangeData, setRangeData] = useState({
-    normal: [
-      // Male ranges - starting from hours
-      { id: 1, sex: 'M', ageFrom: 0, ageFromUnit: 'hours', ageTo: 24, ageToUnit: 'hours', low: 1, high: 100 },
-      { id: 2, sex: 'M', ageFrom: 24, ageFromUnit: 'hours', ageTo: 48, ageToUnit: 'hours', low: 1, high: 120 },
-      { id: 3, sex: 'M', ageFrom: 48, ageFromUnit: 'hours', ageTo: 72, ageToUnit: 'hours', low: 1, high: 140 },
-      { id: 4, sex: 'M', ageFrom: 72, ageFromUnit: 'hours', ageTo: 5, ageToUnit: 'days', low: 1, high: 155 },
-      { id: 5, sex: 'M', ageFrom: 5, ageFromUnit: 'days', ageTo: 14, ageToUnit: 'days', low: 1, high: 140 },
-      { id: 6, sex: 'M', ageFrom: 14, ageFromUnit: 'days', ageTo: 1, ageToUnit: 'months', low: 1, high: 130 },
-      { id: 7, sex: 'M', ageFrom: 1, ageFromUnit: 'months', ageTo: 1, ageToUnit: 'years', low: 1, high: 115 },
-      { id: 8, sex: 'M', ageFrom: 1, ageFromUnit: 'years', ageTo: 999, ageToUnit: 'years', low: 5, high: 40 },
-      // Female ranges - with intentional GAP from 56 days to 1 year
-      { id: 9, sex: 'F', ageFrom: 0, ageFromUnit: 'hours', ageTo: 24, ageToUnit: 'hours', low: 1, high: 105 },
-      { id: 10, sex: 'F', ageFrom: 24, ageFromUnit: 'hours', ageTo: 48, ageToUnit: 'hours', low: 1, high: 130 },
-      { id: 11, sex: 'F', ageFrom: 48, ageFromUnit: 'hours', ageTo: 72, ageToUnit: 'hours', low: 1, high: 155 },
-      { id: 12, sex: 'F', ageFrom: 72, ageFromUnit: 'hours', ageTo: 55, ageToUnit: 'days', low: 1, high: 175 },
-      // GAP HERE: 55 days to 1 year is missing!
-      { id: 13, sex: 'F', ageFrom: 1, ageFromUnit: 'years', ageTo: 999, ageToUnit: 'years', low: 5, high: 35 },
-    ],
-    valid: [
-      { id: 101, sex: 'A', ageFrom: 0, ageFromUnit: 'hours', ageTo: 999, ageToUnit: 'years', low: 0, high: 600 },
-    ],
-    critical: [
-      { id: 201, sex: 'A', ageFrom: 0, ageFromUnit: 'hours', ageTo: 23, ageToUnit: 'hours', low: null, high: 7.9 },
-      { id: 202, sex: 'A', ageFrom: 24, ageFromUnit: 'hours', ageTo: 35, ageToUnit: 'hours', low: null, high: 10.9 },
-      { id: 203, sex: 'A', ageFrom: 36, ageFromUnit: 'hours', ageTo: 47, ageToUnit: 'hours', low: null, high: 13.9 },
-      { id: 204, sex: 'A', ageFrom: 48, ageFromUnit: 'hours', ageTo: 71, ageToUnit: 'hours', low: null, high: 14.9 },
-      { id: 205, sex: 'A', ageFrom: 72, ageFromUnit: 'hours', ageTo: 13, ageToUnit: 'days', low: null, high: 17.9 },
-      { id: 206, sex: 'A', ageFrom: 14, ageFromUnit: 'days', ageTo: 999, ageToUnit: 'years', low: null, high: 15.0 },
-    ],
-    reporting: [
-      { id: 301, sex: 'A', ageFrom: 0, ageFromUnit: 'hours', ageTo: 999, ageToUnit: 'years', low: 0.1, high: 30 },
-    ],
-  });
-
-  // Coverage validation logic
-  const validateCoverage = useMemo(() => {
-    const results = { 
-      male: { complete: true, issues: [] }, 
-      female: { complete: true, issues: [] } 
-    };
-    
-    ['M', 'F'].forEach(sex => {
-      const sexLabel = sex === 'M' ? 'male' : 'female';
-      const ranges = rangeData.normal.filter(r => r.sex === sex || r.sex === 'A');
-      
-      // Normalize to days and sort
-      const normalized = ranges.map(r => ({
-        ...r,
-        fromDays: normalizeToDays(r.ageFrom, r.ageFromUnit),
-        toDays: normalizeToDays(r.ageTo, r.ageToUnit),
-      })).sort((a, b) => a.fromDays - b.fromDays);
-
-      if (normalized.length === 0) {
-        results[sexLabel].complete = false;
-        results[sexLabel].issues.push({
-          type: 'gap',
-          from: { value: 0, unit: 'hours' },
-          to: { value: 999, unit: 'years' },
-          message: `No normal ranges defined for ${sex === 'M' ? 'males' : 'females'}`,
-          suggestedFill: null,
-        });
-      } else {
-        // Check if starts at 0
-        if (normalized[0].fromDays > 0.01) { // Small tolerance for floating point
-          results[sexLabel].complete = false;
-          results[sexLabel].issues.push({
-            type: 'gap',
-            from: { value: 0, unit: 'hours' },
-            to: { value: normalized[0].ageFrom, unit: normalized[0].ageFromUnit },
-            message: `Gap from birth to ${normalized[0].ageFrom} ${normalized[0].ageFromUnit}`,
-            suggestedFill: normalized[0],
-          });
-        }
-
-        // Check for gaps between ranges
-        for (let i = 0; i < normalized.length - 1; i++) {
-          const current = normalized[i];
-          const next = normalized[i + 1];
-          const gapDays = next.fromDays - current.toDays;
-          
-          // Allow small tolerance for contiguous ranges
-          if (gapDays > 0.5) { // More than half a day gap
-            results[sexLabel].complete = false;
-            results[sexLabel].issues.push({
-              type: 'gap',
-              from: { value: current.ageTo, unit: current.ageToUnit },
-              to: { value: next.ageFrom, unit: next.ageFromUnit },
-              message: `Gap: ${current.ageTo} ${current.ageToUnit} to ${next.ageFrom} ${next.ageFromUnit}`,
-              suggestedFill: current,
-            });
-          }
-          
-          // Check for overlaps
-          if (next.fromDays < current.toDays - 0.01) {
-            results[sexLabel].issues.push({
-              type: 'overlap',
-              from: { value: next.ageFrom, unit: next.ageFromUnit },
-              to: { value: current.ageTo, unit: current.ageToUnit },
-              message: `Overlap at ${next.ageFrom} ${next.ageFromUnit}`,
-              ranges: [current, next],
-            });
-          }
-        }
-
-        // Check if ends at infinity
-        const last = normalized[normalized.length - 1];
-        if (last.toDays < normalizeToDays(100, 'years')) {
-          results[sexLabel].complete = false;
-          results[sexLabel].issues.push({
-            type: 'gap',
-            from: { value: last.ageTo, unit: last.ageToUnit },
-            to: { value: 999, unit: 'years' },
-            message: `Gap from ${last.ageTo} ${last.ageToUnit} to maximum age`,
-            suggestedFill: last,
-          });
-        }
-      }
+  const filteredTests = useMemo(() => {
+    return mockTests.filter((test) => {
+      if (searchText && !test.name.toLowerCase().includes(searchText.toLowerCase())) return false;
+      if (filters.section && test.section !== filters.section) return false;
+      if (filters.sampleType && test.sampleType !== filters.sampleType) return false;
+      if (filters.resultType && test.resultType !== filters.resultType) return false;
+      if (filters.status && test.status !== filters.status) return false;
+      if (filters.domain !== 'All Domains' && test.domain !== filters.domain) return false;
+      if (filters.amr === 'AMR Only' && !test.amr) return false;
+      if (filters.amr === 'Non-AMR' && test.amr) return false;
+      return true;
     });
+  }, [filters, searchText]);
 
-    return results;
-  }, [rangeData.normal]);
+  const paginatedTests = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredTests.slice(start, start + pageSize);
+  }, [filteredTests, currentPage]);
 
-  const handleFillGap = (issue, sex) => {
-    const template = issue.suggestedFill;
-    setPrefillData({
-      rangeType: 'normal',
-      sex: sex === 'male' ? 'M' : 'F',
-      ageFrom: issue.from.value,
-      ageFromUnit: issue.from.unit,
-      ageTo: issue.to.value,
-      ageToUnit: issue.to.unit,
-      low: template?.low || '',
-      high: template?.high || '',
-      templateSource: template ? `Values from: ${template.ageFrom} ${template.ageFromUnit} â€“ ${template.ageTo} ${template.ageToUnit}` : null,
-    });
-    setShowAddModal('normal');
-  };
+  const totalPages = Math.ceil(filteredTests.length / pageSize);
 
-  const handleCopyFromRange = (range, targetSex) => {
-    setPrefillData({
-      rangeType: 'normal',
-      sex: targetSex,
-      ageFrom: range.ageFrom,
-      ageFromUnit: range.ageFromUnit,
-      ageTo: range.ageTo,
-      ageToUnit: range.ageToUnit,
-      low: range.low,
-      high: range.high,
-      templateSource: `Copied from ${getSexLabel(range.sex)}: ${formatAgeRange(range)}`,
-    });
-    setShowAddModal('normal');
-  };
-
-  const toggleExpand = (type) => {
-    setExpandedGroups(prev => 
-      prev.includes(type) ? prev.filter(t => t !== type) : [...prev, type]
-    );
-  };
-
-  const rangeTypes = [
-    { id: 'normal', label: 'Normal Range', description: 'Clinical reference values. Results outside flagged H/L on reports.' },
-    { id: 'valid', label: 'Valid Range', description: 'Expected possible values. Entry outside prompts verification.' },
-    { id: 'critical', label: 'Critical Range', description: 'Panic values requiring immediate clinical action.' },
-    { id: 'reporting', label: 'Reporting Range', description: 'Instrument limits. Results outside may need dilution/rerun.' },
+  const headers = [
+    { key: 'name', header: t('admin.testCatalog.list.header.testName', 'Test Name') },
+    { key: 'domain', header: t('admin.testCatalog.list.header.domain', 'Domain') },
+    { key: 'section', header: t('admin.testCatalog.list.header.section', 'Section') },
+    { key: 'sampleType', header: t('admin.testCatalog.list.header.sampleType', 'Sample Type') },
+    { key: 'resultType', header: t('admin.testCatalog.list.header.resultType', 'Result Type') },
+    { key: 'loinc', header: t('admin.testCatalog.list.header.loinc', 'LOINC') },
+    { key: 'status', header: t('admin.testCatalog.list.header.status', 'Status') },
   ];
 
+  const rows = paginatedTests.map((test) => ({
+    id: `row-${test.id}`,
+    name: test.name,
+    domain: test.domain,
+    section: test.section,
+    sampleType: test.sampleType,
+    resultType: test.resultType,
+    loinc: test.loinc || '–',
+    status: test.status,
+    _test: test,
+  }));
+
   return (
-    <div className="bg-white rounded-lg border border-gray-200">
-      {/* Header */}
-      <div className="p-4 border-b border-gray-200">
-        <div className="flex items-center justify-between">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Reference Ranges</h2>
-            <p className="text-sm text-gray-500 mt-1">Define age and sex-specific reference ranges for this test</p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={() => setShowValidationPanel(!showValidationPanel)}
-              className={`flex items-center gap-2 px-3 py-1.5 text-sm border rounded-md transition-colors ${
-                showValidationPanel ? 'bg-teal-50 border-teal-500 text-teal-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'
-              }`}
-            >
-              <CheckCircle size={16} />
-              Validate Coverage
-            </button>
-            <select 
-              value={viewMode}
-              onChange={(e) => setViewMode(e.target.value)}
-              className="px-3 py-1.5 text-sm border border-gray-300 rounded-md"
-            >
-              <option value="structured">Structured View</option>
-              <option value="table">Table View</option>
-              <option value="visual">Visual View</option>
-            </select>
-          </div>
-        </div>
+    <div style={{ padding: '24px' }}>
+      <div style={{ marginBottom: '24px' }}>
+        <h1>{t('admin.testCatalog.list.header.title', 'Test Catalog Management')}</h1>
       </div>
 
-      {/* Coverage Validation Panel */}
-      {showValidationPanel && (
-        <CoverageValidationPanel 
-          coverage={validateCoverage} 
-          onFillGap={handleFillGap}
-          rangeData={rangeData}
-          onCopyFromRange={handleCopyFromRange}
+      {/* Toolbar */}
+      <div style={{ display: 'flex', gap: '12px', marginBottom: '16px', alignItems: 'center' }}>
+        <Search
+          labelText={t('admin.testCatalog.list.action.search', 'Search tests by name')}
+          placeholder={t('admin.testCatalog.list.action.search', 'Search tests by name')}
+          value={searchText}
+          onChange={(e) => setSearchText(e.target.value)}
+          style={{ flex: 1 }}
         />
-      )}
-
-      {/* Main Content */}
-      <div className="p-4">
-        {viewMode === 'structured' && (
-          <div className="space-y-4">
-            {rangeTypes.map((type) => {
-              const colors = getRangeTypeColor(type.id);
-              const ranges = rangeData[type.id] || [];
-              const isExpanded = expandedGroups.includes(type.id);
-              
-              return (
-                <div key={type.id} className={`border rounded-lg ${colors.border}`}>
-                  {/* Range Type Header */}
-                  <button
-                    onClick={() => toggleExpand(type.id)}
-                    className={`w-full flex items-center justify-between p-4 ${colors.bg} rounded-t-lg`}
-                  >
-                    <div className="flex items-center gap-3">
-                      {isExpanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
-                      <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${colors.badge}`}>
-                        {type.label}
-                      </span>
-                      <span className="text-sm text-gray-600">{type.description}</span>
-                    </div>
-                    <div className="flex items-center gap-3">
-                      <span className="text-sm text-gray-500">{ranges.length} range(s)</span>
-                      <button 
-                        onClick={(e) => { e.stopPropagation(); setPrefillData(null); setShowAddModal(type.id); }}
-                        className="p-1 text-gray-500 hover:text-teal-600 hover:bg-white rounded"
-                      >
-                        <Plus size={18} />
-                      </button>
-                    </div>
-                  </button>
-
-                  {/* Range List - Grouped by Sex, Sorted by Age */}
-                  {isExpanded && (
-                    <div className="p-4">
-                      {ranges.length === 0 ? (
-                        <div className="text-center py-8 text-gray-500">
-                          <p>No {type.label.toLowerCase()}s defined</p>
-                          <button 
-                            onClick={() => { setPrefillData(null); setShowAddModal(type.id); }}
-                            className="mt-2 text-teal-600 hover:text-teal-700 font-medium text-sm"
-                          >
-                            + Add {type.label}
-                          </button>
-                        </div>
-                      ) : (
-                        <div className="space-y-4">
-                          {/* Group by Sex */}
-                          {['M', 'F', 'A'].map(sex => {
-                            const sexRanges = sortRanges(ranges.filter(r => r.sex === sex));
-                            if (sexRanges.length === 0) return null;
-                            
-                            return (
-                              <div key={sex}>
-                                <div className="flex items-center gap-2 mb-2">
-                                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getSexBadgeColor(sex)}`}>
-                                    {getSexLabel(sex)}
-                                  </span>
-                                  <span className="text-xs text-gray-500">({sexRanges.length} ranges)</span>
-                                  <div className="flex-1 h-px bg-gray-200"></div>
-                                </div>
-                                <div className="space-y-2 ml-4">
-                                  {sexRanges.map((range, idx) => (
-                                    <div 
-                                      key={range.id}
-                                      className="flex items-center justify-between p-3 bg-white border border-gray-200 rounded-lg hover:border-gray-300 group"
-                                    >
-                                      <div className="flex items-center gap-4">
-                                        <span className="text-xs text-gray-400 w-6">{idx + 1}.</span>
-                                        <div className="w-40">
-                                          <span className="text-xs text-gray-500">Age Range</span>
-                                          <p className="text-sm font-medium text-gray-900">{formatAgeRange(range)}</p>
-                                        </div>
-                                        <div className="w-20">
-                                          <span className="text-xs text-gray-500">Low</span>
-                                          <p className="text-sm font-medium text-gray-900">
-                                            {range.low !== null ? range.low : 'â€”'}
-                                          </p>
-                                        </div>
-                                        <div className="w-20">
-                                          <span className="text-xs text-gray-500">High</span>
-                                          <p className="text-sm font-medium text-gray-900">
-                                            {range.high !== null ? range.high : 'â€”'}
-                                          </p>
-                                        </div>
-                                        {/* Mini visual bar */}
-                                        <div className="w-32 h-6 bg-gray-100 rounded relative overflow-hidden">
-                                          {range.low !== null && range.high !== null && (
-                                            <div 
-                                              className={`absolute h-full ${colors.bar} rounded`}
-                                              style={{ 
-                                                left: `${Math.max(0, (range.low / 200) * 100)}%`,
-                                                width: `${Math.min(100, ((range.high - range.low) / 200) * 100)}%`
-                                              }}
-                                            ></div>
-                                          )}
-                                        </div>
-                                      </div>
-                                      <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                        <button className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded" title="Edit">
-                                          <Edit size={14} />
-                                        </button>
-                                        <button 
-                                          className="p-1.5 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded" 
-                                          title="Copy to other sex"
-                                          onClick={() => handleCopyFromRange(range, sex === 'M' ? 'F' : 'M')}
-                                        >
-                                          <Copy size={14} />
-                                        </button>
-                                        <button className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded" title="Delete">
-                                          <Trash2 size={14} />
-                                        </button>
-                                      </div>
-                                    </div>
-                                  ))}
-                                </div>
-                              </div>
-                            );
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        )}
-
-        {viewMode === 'table' && (
-          <TableView rangeData={rangeData} rangeTypes={rangeTypes} />
-        )}
-
-        {viewMode === 'visual' && (
-          <VisualRangeView rangeData={rangeData} />
-        )}
-      </div>
-
-      {/* Add/Edit Range Modal */}
-      {showAddModal && (
-        <AddRangeModal 
-          rangeType={showAddModal}
-          prefillData={prefillData}
-          onClose={() => { setShowAddModal(false); setPrefillData(null); }}
-          onSave={(range) => {
-            // Add range logic would go here
-            setShowAddModal(false);
-            setPrefillData(null);
-          }}
-        />
-      )}
-    </div>
-  );
-};
-
-// ============================================
-// COVERAGE VALIDATION PANEL
-// ============================================
-
-const CoverageValidationPanel = ({ coverage, onFillGap, rangeData, onCopyFromRange }) => {
-  return (
-    <div className="p-4 bg-gray-50 border-b border-gray-200">
-      <h3 className="text-sm font-semibold text-gray-900 mb-4 flex items-center gap-2">
-        <CheckCircle size={16} className="text-gray-500" />
-        Age Coverage Validation
-      </h3>
-      
-      <div className="grid grid-cols-2 gap-6">
-        {/* Male Coverage */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-700">
-                Male
-              </span>
-              {coverage.male.complete ? (
-                <span className="flex items-center gap-1 text-xs text-green-600 font-medium">
-                  <CheckCircle size={14} />
-                  Complete Coverage
-                </span>
-              ) : (
-                <span className="flex items-center gap-1 text-xs text-red-600 font-medium">
-                  <AlertCircle size={14} />
-                  {coverage.male.issues.length} Issue(s) Found
-                </span>
-              )}
-            </div>
-          </div>
-          
-          {coverage.male.issues.length > 0 ? (
-            <div className="space-y-2">
-              {coverage.male.issues.map((issue, idx) => (
-                <div 
-                  key={idx}
-                  className={`p-3 rounded-lg text-sm ${
-                    issue.type === 'gap' ? 'bg-red-50 border border-red-200' : 'bg-amber-50 border border-amber-200'
-                  }`}
-                >
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <span className={`text-xs font-semibold uppercase ${
-                        issue.type === 'gap' ? 'text-red-600' : 'text-amber-600'
-                      }`}>
-                        {issue.type}
-                      </span>
-                      <p className={`mt-1 ${issue.type === 'gap' ? 'text-red-700' : 'text-amber-700'}`}>
-                        {issue.message}
-                      </p>
-                    </div>
-                    {issue.type === 'gap' && (
-                      <button
-                        onClick={() => onFillGap(issue, 'male')}
-                        className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-teal-700 bg-teal-100 hover:bg-teal-200 rounded transition-colors"
-                      >
-                        <Plus size={12} />
-                        Fill Gap
-                      </button>
-                    )}
-                  </div>
-                  {issue.suggestedFill && (
-                    <p className="text-xs text-gray-500 mt-2">
-                      Suggested values from adjacent range: Low={issue.suggestedFill.low}, High={issue.suggestedFill.high}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="p-3 bg-green-50 rounded-lg text-sm text-green-700">
-              All age ranges from birth to maximum age are covered.
-            </div>
-          )}
-        </div>
-
-        {/* Female Coverage */}
-        <div className="bg-white rounded-lg border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-3">
-            <div className="flex items-center gap-2">
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-pink-100 text-pink-700">
-                Female
-              </span>
-              {coverage.female.complete ? (
-                <span className="flex items-center gap-1 text-xs text-green-600 font-medium">
-                  <CheckCircle size={14} />
-                  Complete Coverage
-                </span>
-              ) : (
-                <span className="flex items-center gap-1 text-xs text-red-600 font-medium">
-                  <AlertCircle size={14} />
-                  {coverage.female.issues.length} Issue(s) Found
-                </span>
-              )}
-            </div>
-          </div>
-          
-          {coverage.female.issues.length > 0 ? (
-            <div className="space-y-2">
-              {coverage.female.issues.map((issue, idx) => (
-                <div 
-                  key={idx}
-                  className={`p-3 rounded-lg text-sm ${
-                    issue.type === 'gap' ? 'bg-red-50 border border-red-200' : 'bg-amber-50 border border-amber-200'
-                  }`}
-                >
-                  <div className="flex items-start justify-between">
-                    <div>
-                      <span className={`text-xs font-semibold uppercase ${
-                        issue.type === 'gap' ? 'text-red-600' : 'text-amber-600'
-                      }`}>
-                        {issue.type}
-                      </span>
-                      <p className={`mt-1 ${issue.type === 'gap' ? 'text-red-700' : 'text-amber-700'}`}>
-                        {issue.message}
-                      </p>
-                    </div>
-                    {issue.type === 'gap' && (
-                      <button
-                        onClick={() => onFillGap(issue, 'female')}
-                        className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-teal-700 bg-teal-100 hover:bg-teal-200 rounded transition-colors"
-                      >
-                        <Plus size={12} />
-                        Fill Gap
-                      </button>
-                    )}
-                  </div>
-                  {issue.suggestedFill && (
-                    <p className="text-xs text-gray-500 mt-2">
-                      Suggested values from adjacent range: Low={issue.suggestedFill.low}, High={issue.suggestedFill.high}
-                    </p>
-                  )}
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="p-3 bg-green-50 rounded-lg text-sm text-green-700">
-              All age ranges from birth to maximum age are covered.
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// TABLE VIEW
-// ============================================
-
-const TableView = ({ rangeData, rangeTypes }) => {
-  // Flatten and sort all ranges
-  const allRanges = useMemo(() => {
-    const flat = [];
-    rangeTypes.forEach(type => {
-      (rangeData[type.id] || []).forEach(range => {
-        flat.push({ ...range, rangeType: type.id, rangeLabel: type.label });
-      });
-    });
-    return flat.sort((a, b) => {
-      // Sort by type, then sex, then age
-      if (a.rangeType !== b.rangeType) return a.rangeType.localeCompare(b.rangeType);
-      if (a.sex !== b.sex) return a.sex.localeCompare(b.sex);
-      return normalizeToDays(a.ageFrom, a.ageFromUnit) - normalizeToDays(b.ageFrom, b.ageFromUnit);
-    });
-  }, [rangeData, rangeTypes]);
-
-  return (
-    <div className="overflow-x-auto">
-      <table className="w-full">
-        <thead className="bg-gray-50 border-y border-gray-200">
-          <tr>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Type</th>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Sex</th>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Age From</th>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Age To</th>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">Low</th>
-            <th className="px-3 py-3 text-left text-xs font-semibold text-gray-700 uppercase">High</th>
-            <th className="px-3 py-3 text-right text-xs font-semibold text-gray-700 uppercase">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200">
-          {allRanges.map(range => {
-            const colors = getRangeTypeColor(range.rangeType);
-            return (
-              <tr key={`${range.rangeType}-${range.id}`} className="hover:bg-gray-50">
-                <td className="px-3 py-3">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${colors.badge}`}>
-                    {range.rangeLabel}
-                  </span>
-                </td>
-                <td className="px-3 py-3">
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getSexBadgeColor(range.sex)}`}>
-                    {getSexLabel(range.sex)}
-                  </span>
-                </td>
-                <td className="px-3 py-3 text-sm text-gray-900">
-                  {range.ageFrom} {range.ageFromUnit}
-                </td>
-                <td className="px-3 py-3 text-sm text-gray-900">
-                  {range.ageTo === 999 ? 'âˆž' : `${range.ageTo} ${range.ageToUnit}`}
-                </td>
-                <td className="px-3 py-3 text-sm text-gray-900">
-                  {range.low !== null ? range.low : 'â€”'}
-                </td>
-                <td className="px-3 py-3 text-sm text-gray-900">
-                  {range.high !== null ? range.high : 'â€”'}
-                </td>
-                <td className="px-3 py-3 text-right">
-                  <div className="flex items-center justify-end gap-1">
-                    <button className="p-1 text-gray-400 hover:text-gray-600"><Edit size={14} /></button>
-                    <button className="p-1 text-gray-400 hover:text-blue-600"><Copy size={14} /></button>
-                    <button className="p-1 text-gray-400 hover:text-red-500"><Trash2 size={14} /></button>
-                  </div>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
-    </div>
-  );
-};
-
-// ============================================
-// VISUAL RANGE VIEW
-// ============================================
-
-const VisualRangeView = ({ rangeData }) => {
-  const [selectedSex, setSelectedSex] = useState('M');
-  const [selectedAgeValue, setSelectedAgeValue] = useState(1);
-  const [selectedAgeUnit, setSelectedAgeUnit] = useState('days');
-
-  const selectedAgeDays = normalizeToDays(selectedAgeValue, selectedAgeUnit);
-
-  // Find applicable ranges for selected demographics
-  const getApplicableRange = (ranges) => {
-    return ranges.find(r => {
-      const matchesSex = r.sex === selectedSex || r.sex === 'A';
-      const fromDays = normalizeToDays(r.ageFrom, r.ageFromUnit);
-      const toDays = normalizeToDays(r.ageTo, r.ageToUnit);
-      const matchesAge = selectedAgeDays >= fromDays && selectedAgeDays <= toDays;
-      return matchesSex && matchesAge;
-    });
-  };
-
-  const normalRange = getApplicableRange(rangeData.normal);
-  const validRange = getApplicableRange(rangeData.valid);
-  const criticalRange = getApplicableRange(rangeData.critical);
-  const reportingRange = getApplicableRange(rangeData.reporting);
-
-  const scale = { min: 0, max: 200 };
-  const toPercent = (val) => Math.min(100, Math.max(0, ((val - scale.min) / (scale.max - scale.min)) * 100));
-
-  return (
-    <div className="space-y-6">
-      {/* Demographic Selector */}
-      <div className="flex items-center gap-4 p-4 bg-gray-50 rounded-lg">
-        <span className="text-sm font-medium text-gray-700">View ranges for:</span>
-        <div className="flex items-center gap-2">
-          <select 
-            value={selectedSex}
-            onChange={(e) => setSelectedSex(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 rounded-md text-sm"
-          >
-            <option value="M">Male</option>
-            <option value="F">Female</option>
-          </select>
-        </div>
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-600">Age:</span>
-          <input 
-            type="number"
-            min="0"
-            value={selectedAgeValue}
-            onChange={(e) => setSelectedAgeValue(Number(e.target.value))}
-            className="w-20 px-3 py-1.5 border border-gray-300 rounded-md text-sm"
-          />
-          <select 
-            value={selectedAgeUnit}
-            onChange={(e) => setSelectedAgeUnit(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 rounded-md text-sm"
-          >
-            <option value="hours">hours</option>
-            <option value="days">days</option>
-            <option value="weeks">weeks</option>
-            <option value="months">months</option>
-            <option value="years">years</option>
-          </select>
-        </div>
-      </div>
-
-      {/* Applicable Ranges Display */}
-      <div className="p-4 bg-gray-50 rounded-lg space-y-4">
-        <div className="text-sm text-gray-600 mb-4">
-          Showing ranges applicable to: <strong>{selectedSex === 'M' ? 'Male' : 'Female'}, {selectedAgeValue} {selectedAgeUnit} old</strong>
-        </div>
-
-        {/* Range Bars */}
-        {[
-          { label: 'Valid', range: validRange, color: 'bg-blue-300', textColor: 'text-blue-800' },
-          { label: 'Normal', range: normalRange, color: 'bg-green-400', textColor: 'text-green-800' },
-          { label: 'Critical', range: criticalRange, color: 'bg-red-400', textColor: 'text-red-800' },
-          { label: 'Reporting', range: reportingRange, color: 'bg-purple-300', textColor: 'text-purple-800' },
-        ].map(({ label, range, color, textColor }) => (
-          <div key={label} className="flex items-center gap-3">
-            <div className="w-24 text-sm font-medium text-gray-700">{label}</div>
-            <div className="flex-1 relative h-8 bg-gray-200 rounded">
-              {range ? (
-                <>
-                  {range.low !== null && range.high !== null && (
-                    <div 
-                      className={`absolute h-full ${color} rounded`}
-                      style={{ 
-                        left: `${toPercent(range.low)}%`, 
-                        width: `${toPercent(range.high) - toPercent(range.low)}%` 
-                      }}
-                    />
-                  )}
-                  {range.low === null && range.high !== null && (
-                    <div 
-                      className={`absolute h-full ${color} rounded-l`}
-                      style={{ left: '0%', width: `${toPercent(range.high)}%` }}
-                    />
-                  )}
-                  <span className={`absolute left-2 top-1/2 -translate-y-1/2 text-xs font-medium ${textColor}`}>
-                    {range.low ?? 'â€”'} â€“ {range.high ?? 'â€”'}
-                  </span>
-                </>
-              ) : (
-                <span className="absolute left-2 top-1/2 -translate-y-1/2 text-xs text-gray-500 italic">
-                  Not defined for this demographic
-                </span>
-              )}
-            </div>
-          </div>
-        ))}
-
-        {/* Legend */}
-        <div className="flex items-center gap-6 mt-4 pt-4 border-t border-gray-200">
-          <div className="flex items-center gap-2"><div className="w-4 h-4 bg-blue-300 rounded"></div><span className="text-xs text-gray-600">Valid</span></div>
-          <div className="flex items-center gap-2"><div className="w-4 h-4 bg-green-400 rounded"></div><span className="text-xs text-gray-600">Normal</span></div>
-          <div className="flex items-center gap-2"><div className="w-4 h-4 bg-red-400 rounded"></div><span className="text-xs text-gray-600">Critical</span></div>
-          <div className="flex items-center gap-2"><div className="w-4 h-4 bg-purple-300 rounded"></div><span className="text-xs text-gray-600">Reporting</span></div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// ADD RANGE MODAL
-// ============================================
-
-const AddRangeModal = ({ rangeType, prefillData, onClose, onSave }) => {
-  const [formData, setFormData] = useState({
-    sex: prefillData?.sex || 'A',
-    ageFrom: prefillData?.ageFrom ?? 0,
-    ageFromUnit: prefillData?.ageFromUnit || 'hours',
-    ageTo: prefillData?.ageTo ?? 999,
-    ageToUnit: prefillData?.ageToUnit || 'years',
-    low: prefillData?.low ?? '',
-    high: prefillData?.high ?? '',
-  });
-
-  const rangeTypeLabels = {
-    normal: 'Normal Range',
-    valid: 'Valid Range',
-    critical: 'Critical Range',
-    reporting: 'Reporting Range',
-  };
-
-  return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
-        <div className="flex items-center justify-between p-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Add {rangeTypeLabels[rangeType]}</h2>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-gray-600 rounded">
-            <X size={20} />
-          </button>
-        </div>
-
-        {/* Template Source Banner */}
-        {prefillData?.templateSource && (
-          <div className="px-6 py-3 bg-blue-50 border-b border-blue-200">
-            <div className="flex items-center gap-2 text-sm text-blue-700">
-              <Info size={16} />
-              <span>{prefillData.templateSource}</span>
-            </div>
-          </div>
-        )}
-
-        <div className="p-6 space-y-4">
-          {/* Sex Selection */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Applies To</label>
-            <div className="flex gap-3">
-              {[
-                { value: 'A', label: 'All', color: 'gray' },
-                { value: 'M', label: 'Male Only', color: 'blue' },
-                { value: 'F', label: 'Female Only', color: 'pink' },
-              ].map(option => (
-                <label 
-                  key={option.value}
-                  className={`flex-1 flex items-center justify-center gap-2 p-3 border-2 rounded-lg cursor-pointer transition-colors ${
-                    formData.sex === option.value 
-                      ? 'border-teal-500 bg-teal-50' 
-                      : 'border-gray-200 hover:bg-gray-50'
-                  }`}
-                >
-                  <input
-                    type="radio"
-                    name="sex"
-                    value={option.value}
-                    checked={formData.sex === option.value}
-                    onChange={(e) => setFormData({...formData, sex: e.target.value})}
-                    className="sr-only"
-                  />
-                  <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getSexBadgeColor(option.value)}`}>
-                    {option.label}
-                  </span>
-                </label>
-              ))}
-            </div>
-          </div>
-
-          {/* Age Range */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">Age Range</label>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">From</label>
-                <div className="flex gap-2">
-                  <input
-                    type="number"
-                    min="0"
-                    value={formData.ageFrom}
-                    onChange={(e) => setFormData({...formData, ageFrom: Number(e.target.value)})}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                  />
-                  <select
-                    value={formData.ageFromUnit}
-                    onChange={(e) => setFormData({...formData, ageFromUnit: e.target.value})}
-                    className="px-3 py-2 border border-gray-300 rounded-md"
-                  >
-                    <option value="hours">hours</option>
-                    <option value="days">days</option>
-                    <option value="weeks">weeks</option>
-                    <option value="months">months</option>
-                    <option value="years">years</option>
-                  </select>
-                </div>
-              </div>
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">To</label>
-                <div className="flex gap-2">
-                  <input
-                    type="number"
-                    min="0"
-                    value={formData.ageTo}
-                    onChange={(e) => setFormData({...formData, ageTo: Number(e.target.value)})}
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                  />
-                  <select
-                    value={formData.ageToUnit}
-                    onChange={(e) => setFormData({...formData, ageToUnit: e.target.value})}
-                    className="px-3 py-2 border border-gray-300 rounded-md"
-                  >
-                    <option value="hours">hours</option>
-                    <option value="days">days</option>
-                    <option value="weeks">weeks</option>
-                    <option value="months">months</option>
-                    <option value="years">years</option>
-                  </select>
-                </div>
-              </div>
-            </div>
-            <p className="text-xs text-gray-500 mt-2">
-              Use 999 years for "no upper age limit" (infinity)
-            </p>
-          </div>
-
-          {/* Value Range */}
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-2">
-              {rangeType === 'critical' ? 'Critical Thresholds' : 'Value Range'}
-            </label>
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">
-                  {rangeType === 'critical' ? 'Critical Low (values below this)' : 'Low'}
-                </label>
-                <input
-                  type="number"
-                  step="any"
-                  value={formData.low}
-                  onChange={(e) => setFormData({...formData, low: e.target.value})}
-                  placeholder={rangeType === 'critical' ? 'Leave blank if N/A' : '0'}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                />
-              </div>
-              <div>
-                <label className="block text-xs text-gray-500 mb-1">
-                  {rangeType === 'critical' ? 'Critical High (values above this)' : 'High'}
-                </label>
-                <input
-                  type="number"
-                  step="any"
-                  value={formData.high}
-                  onChange={(e) => setFormData({...formData, high: e.target.value})}
-                  placeholder={rangeType === 'critical' ? 'Leave blank if N/A' : '100'}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center justify-end gap-3 p-4 border-t border-gray-200 bg-gray-50">
-          <button 
-            onClick={onClose}
-            className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 font-medium"
-          >
-            Cancel
-          </button>
-          <button 
-            onClick={() => onSave(formData)}
-            className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md font-medium"
-          >
-            Add Range
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// TEST ORDERING FOR SAMPLE TYPE
-// ============================================
-
-const TestOrderingPanel = () => {
-  const [tests, setTests] = useState([
-    { id: 1, name: 'Glucose, Fasting', order: 1 },
-    { id: 2, name: 'Hemoglobin A1c', order: 2 },
-    { id: 3, name: 'Creatinine', order: 3 },
-    { id: 4, name: 'BUN', order: 4 },
-    { id: 5, name: 'ALT (SGPT)', order: 5 },
-    { id: 6, name: 'AST (SGOT)', order: 6 },
-    { id: 7, name: 'Bilirubin, Total', order: 7 },
-    { id: 8, name: 'Albumin', order: 8 },
-  ]);
-
-  const [draggedItem, setDraggedItem] = useState(null);
-  const [selectedSampleType, setSelectedSampleType] = useState('serum');
-
-  const handleDragStart = (e, index) => {
-    setDraggedItem(index);
-    e.dataTransfer.effectAllowed = 'move';
-  };
-
-  const handleDragOver = (e, index) => {
-    e.preventDefault();
-    if (draggedItem === null || draggedItem === index) return;
-    
-    const newTests = [...tests];
-    const draggedTest = newTests[draggedItem];
-    newTests.splice(draggedItem, 1);
-    newTests.splice(index, 0, draggedTest);
-    
-    // Update order numbers
-    newTests.forEach((test, idx) => test.order = idx + 1);
-    
-    setTests(newTests);
-    setDraggedItem(index);
-  };
-
-  const handleDragEnd = () => {
-    setDraggedItem(null);
-  };
-
-  const moveUp = (index) => {
-    if (index === 0) return;
-    const newTests = [...tests];
-    [newTests[index - 1], newTests[index]] = [newTests[index], newTests[index - 1]];
-    newTests.forEach((test, idx) => test.order = idx + 1);
-    setTests(newTests);
-  };
-
-  const moveDown = (index) => {
-    if (index === tests.length - 1) return;
-    const newTests = [...tests];
-    [newTests[index], newTests[index + 1]] = [newTests[index + 1], newTests[index]];
-    newTests.forEach((test, idx) => test.order = idx + 1);
-    setTests(newTests);
-  };
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Test Display Order</h2>
-          <p className="text-sm text-gray-500 mt-1">Drag and drop to reorder tests for this sample type</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <label className="text-sm text-gray-600">Sample Type:</label>
-          <select 
-            value={selectedSampleType}
-            onChange={(e) => setSelectedSampleType(e.target.value)}
-            className="px-3 py-1.5 border border-gray-300 rounded-md text-sm"
-          >
-            <option value="serum">Serum</option>
-            <option value="plasma">Plasma</option>
-            <option value="whole_blood">Whole Blood</option>
-            <option value="urine">Urine</option>
-          </select>
-        </div>
-      </div>
-
-      <div className="space-y-1">
-        {tests.map((test, index) => (
-          <div
-            key={test.id}
-            draggable
-            onDragStart={(e) => handleDragStart(e, index)}
-            onDragOver={(e) => handleDragOver(e, index)}
-            onDragEnd={handleDragEnd}
-            className={`flex items-center gap-3 p-3 bg-white border rounded-lg cursor-move transition-all ${
-              draggedItem === index ? 'border-teal-500 bg-teal-50 shadow-lg' : 'border-gray-200 hover:border-gray-300'
-            }`}
-          >
-            <div className="flex items-center gap-2 text-gray-400">
-              <GripVertical size={16} />
-              <span className="text-sm font-medium w-6">{test.order}.</span>
-            </div>
-            <span className="flex-1 text-sm font-medium text-gray-900">{test.name}</span>
-            <div className="flex items-center gap-1">
-              <button 
-                onClick={() => moveUp(index)}
-                disabled={index === 0}
-                className="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30"
-              >
-                <ArrowUp size={16} />
-              </button>
-              <button 
-                onClick={() => moveDown(index)}
-                disabled={index === tests.length - 1}
-                className="p-1 text-gray-400 hover:text-gray-600 disabled:opacity-30"
-              >
-                <ArrowDown size={16} />
-              </button>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      <p className="text-xs text-gray-500 mt-4">
-        This order determines how tests appear in order entry and result entry for the selected sample type.
-      </p>
-    </div>
-  );
-};
-
-// ============================================
-// PANEL ASSOCIATION WITH INLINE CREATE AND ORDERING
-// ============================================
-
-const PanelAssociationPanel = () => {
-  const [selectedPanels, setSelectedPanels] = useState({
-    1: { selected: true, order: 3 },  // BMP, position 3
-    3: { selected: true, order: 2 },  // Lipid Panel, position 2
-  });
-  const [showAddPanel, setShowAddPanel] = useState(false);
-  const [newPanelName, setNewPanelName] = useState('');
-  const [expandedPanel, setExpandedPanel] = useState(null);
-
-  const availablePanels = [
-    { id: 1, name: 'Basic Metabolic Panel', testCount: 8, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium'] },
-    { id: 2, name: 'Comprehensive Metabolic Panel', testCount: 14, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium', 'Total Protein', 'Albumin', 'Bilirubin', 'ALP', 'AST', 'ALT'] },
-    { id: 3, name: 'Lipid Panel', testCount: 4, tests: ['Total Cholesterol', 'HDL', 'LDL', 'Triglycerides'] },
-    { id: 4, name: 'Liver Function Panel', testCount: 7, tests: ['Total Protein', 'Albumin', 'Bilirubin Total', 'Bilirubin Direct', 'ALP', 'AST', 'ALT'] },
-    { id: 5, name: 'Renal Function Panel', testCount: 5, tests: ['BUN', 'Creatinine', 'eGFR', 'BUN/Creatinine Ratio', 'Uric Acid'] },
-    { id: 6, name: 'Thyroid Panel', testCount: 3, tests: ['TSH', 'Free T4', 'Free T3'] },
-  ];
-
-  const togglePanel = (panelId, panel) => {
-    setSelectedPanels(prev => {
-      if (prev[panelId]?.selected) {
-        // Deselect - remove from selection
-        const newSelection = { ...prev };
-        delete newSelection[panelId];
-        setExpandedPanel(null);
-        return newSelection;
-      } else {
-        // Select - add with default order at end
-        setExpandedPanel(panelId);
-        return {
-          ...prev,
-          [panelId]: { selected: true, order: panel.testCount + 1 }
-        };
-      }
-    });
-  };
-
-  const updateOrder = (panelId, newOrder) => {
-    setSelectedPanels(prev => ({
-      ...prev,
-      [panelId]: { ...prev[panelId], order: newOrder }
-    }));
-  };
-
-  const handleAddPanel = () => {
-    if (newPanelName.trim()) {
-      // Would add to availablePanels and select it
-      setNewPanelName('');
-      setShowAddPanel(false);
-    }
-  };
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Panel Membership</h2>
-          <p className="text-sm text-gray-500 mt-1">Select which panels should include this test and set display order</p>
-        </div>
-        <button 
-          onClick={() => setShowAddPanel(true)}
-          className="flex items-center gap-2 text-teal-600 hover:text-teal-700 font-medium text-sm"
+        <Button
+          kind="ghost"
+          onClick={() => setShowFilters(!showFilters)}
+          size="sm"
         >
-          <Plus size={16} />
-          Create New Panel
-        </button>
+          {t('admin.testCatalog.list.action.filters', 'Filters')}
+        </Button>
+        <Button kind="primary" onClick={onAdd} size="sm">
+          {t('admin.testCatalog.list.action.addTest', '+ Add Test')}
+        </Button>
       </div>
 
-      {/* Inline Add Panel Form */}
-      {showAddPanel && (
-        <div className="mb-4 p-4 bg-teal-50 border border-teal-200 rounded-lg">
-          <label className="block text-sm font-medium text-gray-700 mb-2">New Panel Name</label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newPanelName}
-              onChange={(e) => setNewPanelName(e.target.value)}
-              placeholder="Enter panel name..."
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              autoFocus
-            />
-            <button 
-              onClick={handleAddPanel}
-              className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md font-medium"
+      {/* Filters panel */}
+      {showFilters && (
+        <div style={{ background: '#f4f4f4', border: '1px solid #d0d0d0', borderRadius: '4px', padding: '16px', marginBottom: '16px', display: 'grid', gridTemplateColumns: 'repeat(6, 1fr)', gap: '12px' }}>
+          <FormGroup legendText={t('admin.testCatalog.list.label.section', 'Section')}>
+            <Select
+              value={filters.section}
+              onChange={(e) => setFilters({ ...filters, section: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.section', 'Section')}
             >
-              Create
-            </button>
-            <button 
-              onClick={() => { setShowAddPanel(false); setNewPanelName(''); }}
-              className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100"
+              <SelectItem text={t('admin.testCatalog.common.option.allSections', 'All Sections')} value="" />
+              <SelectItem text="Chemistry" value="Chemistry" />
+              <SelectItem text="Hematology" value="Hematology" />
+              <SelectItem text="Serology" value="Serology" />
+              <SelectItem text="Microbiology" value="Microbiology" />
+              <SelectItem text="Environmental" value="Environmental" />
+              <SelectItem text="Molecular" value="Molecular" />
+            </Select>
+          </FormGroup>
+
+          <FormGroup legendText={t('admin.testCatalog.list.label.sampleType', 'Sample Type')}>
+            <Select
+              value={filters.sampleType}
+              onChange={(e) => setFilters({ ...filters, sampleType: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.sampleType', 'Sample Type')}
             >
-              Cancel
-            </button>
-          </div>
+              <SelectItem text={t('admin.testCatalog.common.option.allTypes', 'All Types')} value="" />
+              <SelectItem text="Serum" value="Serum" />
+              <SelectItem text="Plasma" value="Plasma" />
+              <SelectItem text="Whole Blood" value="Whole Blood" />
+              <SelectItem text="Water" value="Water" />
+              <SelectItem text="Mosquito Pool" value="Mosquito Pool" />
+            </Select>
+          </FormGroup>
+
+          <FormGroup legendText={t('admin.testCatalog.list.label.resultType', 'Result Type')}>
+            <Select
+              value={filters.resultType}
+              onChange={(e) => setFilters({ ...filters, resultType: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.resultType', 'Result Type')}
+            >
+              <SelectItem text={t('admin.testCatalog.common.option.allTypes', 'All Types')} value="" />
+              <SelectItem text="NUMERIC" value="NUMERIC" />
+              <SelectItem text="SELECT_LIST" value="SELECT_LIST" />
+              <SelectItem text="MULTI_SELECT" value="MULTI_SELECT" />
+              <SelectItem text="FREE_TEXT" value="FREE_TEXT" />
+            </Select>
+          </FormGroup>
+
+          <FormGroup legendText={t('admin.testCatalog.list.label.status', 'Status')}>
+            <Select
+              value={filters.status}
+              onChange={(e) => setFilters({ ...filters, status: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.status', 'Status')}
+            >
+              <SelectItem text={t('admin.testCatalog.common.option.allStatuses', 'All Statuses')} value="" />
+              <SelectItem text="Active" value="Active" />
+              <SelectItem text="Inactive" value="Inactive" />
+            </Select>
+          </FormGroup>
+
+          <FormGroup legendText={t('admin.testCatalog.list.label.domain', 'Domain')}>
+            <Select
+              value={filters.domain}
+              onChange={(e) => setFilters({ ...filters, domain: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.domain', 'Domain')}
+            >
+              <SelectItem text={t('admin.testCatalog.common.option.allDomains', 'All Domains')} value="All Domains" />
+              <SelectItem text="Clinical" value="CLINICAL" />
+              <SelectItem text="Environmental" value="ENVIRONMENTAL" />
+              <SelectItem text="Vector" value="VECTOR" />
+            </Select>
+          </FormGroup>
+
+          <FormGroup legendText={t('admin.testCatalog.list.label.amrStatus', 'AMR Status')}>
+            <Select
+              value={filters.amr}
+              onChange={(e) => setFilters({ ...filters, amr: e.target.value })}
+              labelText={t('admin.testCatalog.list.label.amrStatus', 'AMR Status')}
+            >
+              <SelectItem text={t('admin.testCatalog.common.option.all', 'All')} value="All" />
+              <SelectItem text="AMR Only" value="AMR Only" />
+              <SelectItem text="Non-AMR" value="Non-AMR" />
+            </Select>
+          </FormGroup>
         </div>
       )}
 
-      <div className="space-y-3">
-        {availablePanels.map(panel => {
-          const isSelected = selectedPanels[panel.id]?.selected;
-          const isExpanded = expandedPanel === panel.id;
-          const currentOrder = selectedPanels[panel.id]?.order || panel.testCount + 1;
-          
-          return (
-            <div 
-              key={panel.id}
-              className={`border-2 rounded-lg transition-colors ${
-                isSelected 
-                  ? 'border-teal-500 bg-teal-50' 
-                  : 'border-gray-200 hover:bg-gray-50'
-              }`}
-            >
-              {/* Panel Header */}
-              <div 
-                className="flex items-center gap-3 p-3 cursor-pointer"
-                onClick={() => togglePanel(panel.id, panel)}
-              >
-                <input
-                  type="checkbox"
-                  checked={isSelected}
-                  onChange={() => {}}
-                  className="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                />
-                <div className="flex-1">
-                  <p className="text-sm font-medium text-gray-900">{panel.name}</p>
-                  <p className="text-xs text-gray-500">{panel.testCount} tests</p>
-                </div>
-                {isSelected && (
-                  <div className="flex items-center gap-2">
-                    <span className="text-xs text-teal-700 bg-teal-100 px-2 py-0.5 rounded">
-                      Position: {currentOrder}
-                    </span>
-                    <button
-                      onClick={(e) => { e.stopPropagation(); setExpandedPanel(isExpanded ? null : panel.id); }}
-                      className="p-1 text-teal-600 hover:bg-teal-100 rounded"
-                    >
-                      {isExpanded ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
-                    </button>
-                  </div>
-                )}
-              </div>
+      {/* Data Table */}
+      <DataTable rows={rows} headers={headers}>
+        {({ rows: tableRows, headers: tableHeaders, getRowProps, getTableProps }) => (
+          <TableContainer title="">
+            <Table {...getTableProps()} style={{ cursor: 'pointer' }}>
+              <TableHead>
+                <TableRow>
+                  {tableHeaders.map((header) => (
+                    <TableHeader key={header.key}>{header.header}</TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {tableRows.map((row) => (
+                  <TableRow
+                    key={row.id}
+                    {...getRowProps({ row })}
+                    onClick={() => onEdit(row._test)}
+                    style={{ cursor: 'pointer' }}
+                  >
+                    {row.cells.map((cell) => (
+                      <TableCell key={cell.id}>
+                        {cell.info.header === 'name' ? (
+                          <Button
+                            kind="ghost"
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              onEdit(row._test);
+                            }}
+                            style={{ padding: 0, textAlign: 'left', fontWeight: 600 }}
+                          >
+                            {cell.value}
+                          </Button>
+                        ) : cell.info.header === 'domain' ? (
+                          <DomainTag domain={cell.value} />
+                        ) : cell.info.header === 'status' ? (
+                          <Tag type={cell.value === 'Active' ? 'green' : 'gray'}>{cell.value}</Tag>
+                        ) : (
+                          cell.value
+                        )}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
 
-              {/* Expanded Order Selection */}
-              {isSelected && isExpanded && (
-                <div className="px-3 pb-3 border-t border-teal-200 mt-0 pt-3">
-                  <div className="flex items-start gap-4">
-                    {/* Order Input */}
-                    <div className="w-56">
-                      <label className="block text-xs font-medium text-gray-700 mb-1">
-                        Display Position in Panel
-                      </label>
-                      <div className="flex items-center gap-2">
-                        <input
-                          type="number"
-                          min="1"
-                          max={panel.testCount + 1}
-                          value={currentOrder}
-                          onChange={(e) => updateOrder(panel.id, parseInt(e.target.value) || 1)}
-                          className="w-16 px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                          onClick={(e) => e.stopPropagation()}
-                        />
-                        <span className="text-xs text-gray-500">of {panel.testCount + 1}</span>
-                      </div>
-                      <p className="text-xs text-gray-400 mt-2">
-                        Enter a number or drag the test in the preview list
-                      </p>
-                    </div>
-                    
-                    {/* Preview of tests in panel with drag-drop */}
-                    <div className="flex-1">
-                      <label className="block text-xs font-medium text-gray-700 mb-1">
-                        Panel Test Order Preview <span className="text-gray-400 font-normal">â€” drag to reorder</span>
-                      </label>
-                      <div className="bg-white border border-gray-200 rounded-md p-2 max-h-40 overflow-y-auto">
-                        <ol className="text-xs text-gray-600 space-y-0.5">
-                          {panel.tests.map((test, idx) => {
-                            const position = idx + 1;
-                            const isInsertPoint = position === currentOrder;
-                            
-                            return (
-                              <React.Fragment key={test}>
-                                {isInsertPoint && (
-                                  <li 
-                                    draggable
-                                    onDragStart={(e) => {
-                                      e.dataTransfer.setData('text/plain', 'thisTest');
-                                      e.dataTransfer.effectAllowed = 'move';
-                                    }}
-                                    className="flex items-center gap-2 py-1.5 px-2 bg-teal-100 rounded text-teal-800 font-medium cursor-grab active:cursor-grabbing border-2 border-teal-300 border-dashed"
-                                  >
-                                    <GripVertical size={12} className="text-teal-500 flex-shrink-0" />
-                                    <span className="w-4">{currentOrder}.</span>
-                                    <span className="flex-1">â† THIS TEST (Glucose, Fasting)</span>
-                                  </li>
-                                )}
-                                <li 
-                                  className="flex items-center gap-2 py-1 px-2 hover:bg-gray-50 rounded"
-                                  onDragOver={(e) => {
-                                    e.preventDefault();
-                                    e.currentTarget.classList.add('border-t-2', 'border-teal-400');
-                                  }}
-                                  onDragLeave={(e) => {
-                                    e.currentTarget.classList.remove('border-t-2', 'border-teal-400');
-                                  }}
-                                  onDrop={(e) => {
-                                    e.preventDefault();
-                                    e.currentTarget.classList.remove('border-t-2', 'border-teal-400');
-                                    const newPosition = position >= currentOrder ? position : position;
-                                    updateOrder(panel.id, position >= currentOrder ? position + 1 : position);
-                                  }}
-                                >
-                                  <span className="w-4 ml-4 text-gray-400">
-                                    {position >= currentOrder ? position + 1 : position}.
-                                  </span>
-                                  <span>{test}</span>
-                                </li>
-                              </React.Fragment>
-                            );
-                          })}
-                          {currentOrder > panel.testCount && (
-                            <li 
-                              draggable
-                              onDragStart={(e) => {
-                                e.dataTransfer.setData('text/plain', 'thisTest');
-                                e.dataTransfer.effectAllowed = 'move';
-                              }}
-                              className="flex items-center gap-2 py-1.5 px-2 bg-teal-100 rounded text-teal-800 font-medium cursor-grab active:cursor-grabbing border-2 border-teal-300 border-dashed"
-                            >
-                              <GripVertical size={12} className="text-teal-500 flex-shrink-0" />
-                              <span className="w-4">{currentOrder}.</span>
-                              <span className="flex-1">â† THIS TEST (Glucose, Fasting)</span>
-                            </li>
-                          )}
-                        </ol>
-                      </div>
-                      <p className="text-xs text-gray-400 mt-1 flex items-center gap-1">
-                        <GripVertical size={10} /> Drag the highlighted row to change position
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              )}
-            </div>
-          );
-        })}
-      </div>
-      
-      <p className="text-xs text-gray-500 mt-4">
-        Click on a selected panel to expand and set the display order. Use the number input or drag the test in the preview list.
-      </p>
+      {/* Pagination */}
+      <Pagination
+        totalItems={filteredTests.length}
+        pageSize={pageSize}
+        pageSizes={[10, 25, 50, 100]}
+        page={currentPage}
+        onChange={({ page }) => setCurrentPage(page)}
+        style={{ marginTop: '16px' }}
+      />
     </div>
   );
-};
+}
 
-// ============================================
-// TEST SECTION MULTI-SELECT
-// ============================================
-
-const TestSectionMultiSelect = () => {
-  const [selectedSections, setSelectedSections] = useState(['chemistry']);
-  
-  const sections = [
-    { id: 'chemistry', name: 'Chemistry' },
-    { id: 'hematology', name: 'Hematology' },
-    { id: 'serology', name: 'Serology' },
-    { id: 'immunology', name: 'Immunology' },
-    { id: 'microbiology', name: 'Microbiology' },
-    { id: 'urinalysis', name: 'Urinalysis' },
-    { id: 'parasitology', name: 'Parasitology' },
-    { id: 'molecular', name: 'Molecular Biology' },
-  ];
-
-  const toggleSection = (sectionId) => {
-    setSelectedSections(prev => 
-      prev.includes(sectionId) ? prev.filter(id => id !== sectionId) : [...prev, sectionId]
-    );
-  };
-
+// ==================== EDITOR SECTIONS ====================
+/**
+ * BasicInfoSection — test name, code, section(s), domain, flags (Active/Orderable/Internal QA)
+ */
+function BasicInfoSection({ test, setTest }) {
   return (
     <div>
-      <div className="flex items-center gap-2 mb-2">
-        <label className="text-sm font-medium text-gray-700">Test Section(s)</label>
-        <span className="text-red-500">*</span>
-        <button className="text-gray-400 hover:text-gray-600">
-          <Info size={14} />
-        </button>
-      </div>
-      <div className="border border-gray-300 rounded-md p-3 max-h-48 overflow-y-auto">
-        <div className="space-y-2">
-          {sections.map(section => (
-            <label key={section.id} className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded">
-              <input
-                type="checkbox"
-                checked={selectedSections.includes(section.id)}
-                onChange={() => toggleSection(section.id)}
-                className="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-              />
-              <span className="text-sm text-gray-700">{section.name}</span>
-            </label>
+      <h2>{t('admin.testCatalog.basicInfo.header.title', 'Basic Information')}</h2>
+      <p>{t('admin.testCatalog.basicInfo.header.subtitle', 'Core test identity and classification')}</p>
+
+      <TextInput
+        labelText={t('admin.testCatalog.basicInfo.label.name', 'Test Name') + ' *'}
+        value={test.name || ''}
+        onChange={(e) => setTest({ ...test, name: e.target.value })}
+        placeholder={t('admin.testCatalog.basicInfo.placeholder.name', '')}
+        style={{ marginBottom: '16px' }}
+      />
+
+      <TextInput
+        labelText={t('admin.testCatalog.basicInfo.label.reportingName', 'Reporting Name')}
+        placeholder={t('admin.testCatalog.basicInfo.placeholder.reportingName', '')}
+        style={{ marginBottom: '16px' }}
+      />
+
+      <TextInput
+        labelText={t('admin.testCatalog.basicInfo.label.testCode', 'Test Code')}
+        placeholder={t('admin.testCatalog.basicInfo.placeholder.testCode', 'e.g., GLU')}
+        style={{ marginBottom: '16px' }}
+      />
+
+      <TextArea
+        labelText={t('admin.testCatalog.basicInfo.label.description', 'Description')}
+        placeholder={t('admin.testCatalog.basicInfo.placeholder.description', 'Enter test description...')}
+        style={{ marginBottom: '16px' }}
+      />
+
+      <div style={{ marginBottom: '16px' }}>
+        <label>{t('admin.testCatalog.basicInfo.label.testSections', 'Test Section(s)') + ' *'}</label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '8px', marginTop: '8px' }}>
+          {['Chemistry', 'Hematology', 'Serology', 'Immunology', 'Microbiology', 'Urinalysis', 'Parasitology', 'Molecular'].map((s) => (
+            <Checkbox key={s} labelText={s} id={`sec-${s}`} />
           ))}
         </div>
       </div>
-      <p className="text-xs text-gray-500 mt-1">
-        Select one or more laboratory units that can perform this test
-      </p>
+
+      <div style={{ marginBottom: '24px' }}>
+        <label>{t('admin.testCatalog.basicInfo.label.domain', 'Domain') + ' *'}</label>
+        <RadioButtonGroup
+          legendText={t('admin.testCatalog.basicInfo.label.domain', 'Domain')}
+          name="domain"
+          valueSelected={test.domain || 'CLINICAL'}
+          onChange={(val) => setTest({ ...test, domain: val })}
+          style={{ marginTop: '8px' }}
+        >
+          <RadioButton labelText={t('admin.testCatalog.basicInfo.option.clinical', 'Clinical')} value="CLINICAL" id="domain-clinical" />
+          <RadioButton labelText={t('admin.testCatalog.basicInfo.option.environmental', 'Environmental')} value="ENVIRONMENTAL" id="domain-env" />
+          <RadioButton labelText={t('admin.testCatalog.basicInfo.option.vector', 'Vector')} value="VECTOR" id="domain-vec" />
+        </RadioButtonGroup>
+      </div>
+
+      <div style={{ borderTop: '1px solid #e0e0e0', paddingTop: '16px', marginBottom: '16px' }}>
+        <Checkbox labelText={t('admin.testCatalog.basicInfo.label.active', 'Active Test')} id="active-test" />
+        <Checkbox labelText={t('admin.testCatalog.basicInfo.label.orderable', 'Orderable')} id="orderable-test" style={{ marginTop: '8px' }} />
+        <Checkbox labelText={t('admin.testCatalog.basicInfo.label.internalQA', 'Internal QA — No Results Release')} id="qa-test" style={{ marginTop: '8px' }} />
+        <Checkbox labelText={t('admin.testCatalog.basicInfo.label.amrTest', 'AMR Test')} id="amr-test" style={{ marginTop: '8px' }} />
+      </div>
     </div>
   );
-};
+}
 
-// ============================================
-// METHOD MANAGEMENT WITH INLINE CREATE
-// ============================================
-
-const MethodLinkingWithCreate = () => {
-  const [linkedMethods, setLinkedMethods] = useState([
-    { id: 1, code: 'HEX', name: 'Hexokinase', isDefault: true, effectiveDate: '2024-01-01' },
-    { id: 2, code: 'GOX', name: 'Glucose Oxidase', isDefault: false, effectiveDate: '2020-01-01' },
+/**
+ * SampleResultsSection — sample types, result type (NUMERIC/SELECT_LIST/MULTI_SELECT/FREE_TEXT), units, interpretations
+ */
+function SampleResultsSection({ test, setTest }) {
+  const [resultType, setResultType] = useState('NUMERIC');
+  const [selectOptions, setSelectOptions] = useState([
+    { id: 1, value: 'Positive', display: 'Positive', active: true },
+    { id: 2, value: 'Negative', display: 'Negative', active: true },
+    { id: 3, value: 'Indeterminate', display: 'Indeterminate', active: true },
   ]);
-  const [showAddMethod, setShowAddMethod] = useState(false);
-  const [showCreateMethod, setShowCreateMethod] = useState(false);
-  const [showCopyMethodsModal, setShowCopyMethodsModal] = useState(false);
-  const [newMethodName, setNewMethodName] = useState('');
-  const [newMethodCode, setNewMethodCode] = useState('');
-
-  const availableMethods = [
-    { id: 3, code: 'GOD-PAP', name: 'Enzymatic (GOD-PAP)' },
-    { id: 4, code: 'CLR', name: 'Colorimetric' },
-    { id: 5, code: 'ISE', name: 'Ion-Selective Electrode' },
-  ];
-
-  const handleCreateMethod = () => {
-    if (newMethodName.trim()) {
-      // Would create method and add to linked
-      setNewMethodName('');
-      setShowCreateMethod(false);
-    }
-  };
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-4">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Associated Methods</h2>
-          <p className="text-sm text-gray-500 mt-1">Link analytical methods used to perform this test</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <button 
-            onClick={() => setShowCopyMethodsModal(true)}
-            className="flex items-center gap-2 px-3 py-1.5 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
-          >
-            <Copy size={16} />
-            Copy from Test...
-          </button>
-          <button 
-            onClick={() => setShowAddMethod(!showAddMethod)}
-            className="flex items-center gap-2 px-3 py-1.5 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium"
-          >
-            <Plus size={16} />
-            Link Method
-          </button>
-        </div>
-      </div>
-
-      {/* Add Method Panel */}
-      {showAddMethod && (
-        <div className="mb-4 p-4 bg-gray-50 border border-gray-200 rounded-lg">
-          <div className="flex items-center justify-between mb-3">
-            <label className="text-sm font-medium text-gray-700">Select Method to Link</label>
-            <button 
-              onClick={() => { setShowAddMethod(false); setShowCreateMethod(true); }}
-              className="text-sm text-teal-600 hover:text-teal-700 font-medium"
-            >
-              + Create New Method
-            </button>
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            {availableMethods.map(method => (
-              <button
-                key={method.id}
-                className="p-2 text-left text-sm border border-gray-200 rounded-md hover:bg-white hover:border-teal-500 flex items-center gap-2"
-              >
-                <code className="px-1.5 py-0.5 bg-gray-200 text-gray-600 rounded text-xs font-mono">{method.code}</code>
-                <span>{method.name}</span>
-              </button>
-            ))}
-          </div>
-          <button 
-            onClick={() => setShowAddMethod(false)}
-            className="mt-3 text-sm text-gray-500 hover:text-gray-700"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-
-      {/* Create New Method Panel */}
-      {showCreateMethod && (
-        <div className="mb-4 p-4 bg-teal-50 border border-teal-200 rounded-lg">
-          <label className="block text-sm font-medium text-gray-700 mb-2">Create New Method</label>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={newMethodCode}
-              onChange={(e) => setNewMethodCode(e.target.value.toUpperCase())}
-              placeholder="Code (e.g., HEX)"
-              className="w-28 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500 font-mono uppercase"
-            />
-            <input
-              type="text"
-              value={newMethodName}
-              onChange={(e) => setNewMethodName(e.target.value)}
-              placeholder="Method name (e.g., Hexokinase Method)"
-              className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              autoFocus
-            />
-            <button 
-              onClick={handleCreateMethod}
-              className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md font-medium"
-            >
-              Create & Link
-            </button>
-            <button 
-              onClick={() => { setShowCreateMethod(false); setNewMethodName(''); setNewMethodCode(''); }}
-              className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100"
-            >
-              Cancel
-            </button>
-          </div>
-          <p className="mt-2 text-xs text-gray-500">Code is used for quick macro-style entry in result screens</p>
-        </div>
-      )}
-
-      {/* Linked Methods List */}
-      <div className="space-y-3">
-        {linkedMethods.map((method) => (
-          <div key={method.id} className={`p-4 border rounded-lg ${method.isDefault ? 'border-teal-300 bg-teal-50' : 'border-gray-200'}`}>
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <div className={`w-10 h-10 rounded-lg flex items-center justify-center ${method.isDefault ? 'bg-teal-200' : 'bg-gray-100'}`}>
-                  <Settings className={method.isDefault ? 'text-teal-700' : 'text-gray-500'} size={20} />
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <code className="px-2 py-0.5 bg-gray-100 text-gray-700 rounded text-xs font-mono">{method.code}</code>
-                    <span className="font-medium text-gray-900">{method.name}</span>
-                    {method.isDefault && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded bg-teal-200 text-teal-800 text-xs font-medium">
-                        Default
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-sm text-gray-500">Effective: {method.effectiveDate}</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                {!method.isDefault && (
-                  <button className="px-2 py-1 text-xs text-teal-600 hover:bg-teal-100 rounded font-medium">
-                    Set Default
-                  </button>
-                )}
-                <button className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded">
-                  <Edit size={16} />
-                </button>
-                <button className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded">
-                  <X size={16} />
-                </button>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Copy Methods from Test Modal */}
-      {showCopyMethodsModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-xl">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Copy Methods from Another Test</h3>
-              <button onClick={() => setShowCopyMethodsModal(false)} className="text-gray-400 hover:text-gray-600">
-                <X size={20} />
-              </button>
-            </div>
-            <div className="p-6">
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Search for test</label>
-                <div className="flex gap-2">
-                  <input 
-                    type="text" 
-                    placeholder="Enter test name..."
-                    className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500"
-                  />
-                  <button className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-md text-sm font-medium">
-                    Search
-                  </button>
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-2 block">Select test:</label>
-                <div className="space-y-2 max-h-40 overflow-y-auto border border-gray-200 rounded-md p-2">
-                  {['Fasting Glucose', 'Random Glucose', '2-Hour Glucose', 'HbA1c'].map((test, i) => (
-                    <label key={i} className="flex items-center gap-2 p-2 hover:bg-gray-50 rounded cursor-pointer">
-                      <input type="radio" name="sourceTestMethod" className="text-teal-600 focus:ring-teal-500" />
-                      <span className="text-sm text-gray-700">{test}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-2 block">Methods to copy:</label>
-                <div className="space-y-2 border border-gray-200 rounded-md p-3 bg-gray-50">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" defaultChecked className="rounded border-gray-300 text-teal-600" />
-                    <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">HEX</code>
-                    <span className="text-sm text-gray-700">Hexokinase Method</span>
-                    <span className="text-xs bg-teal-100 text-teal-700 px-2 py-0.5 rounded">Default</span>
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" defaultChecked className="rounded border-gray-300 text-teal-600" />
-                    <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">GOX</code>
-                    <span className="text-sm text-gray-700">Glucose Oxidase Method</span>
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600" />
-                    <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">ELEC</code>
-                    <span className="text-sm text-gray-700">Electrode Method</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-              <button 
-                onClick={() => setShowCopyMethodsModal(false)}
-                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-              >
-                Cancel
-              </button>
-              <button className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium">
-                Copy Selected
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ============================================
-// TEST LIST VIEW
-// ============================================
-
-const mockTests = [
-  { id: 1, name: 'Glucose, Fasting', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '1558-6', active: true, isAmr: false },
-  { id: 2, name: 'Hemoglobin', section: 'Hematology', sampleType: 'Whole Blood', resultType: 'Numeric', loinc: '718-7', active: true, isAmr: false },
-  { id: 3, name: 'HIV Rapid Test', section: 'Serology', sampleType: 'Serum', resultType: 'Select List', loinc: 'â€”', active: true, isAmr: false },
-  { id: 4, name: 'Creatinine', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '2160-0', active: true, isAmr: false },
-  { id: 5, name: 'ALT (SGPT)', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '1742-6', active: false, isAmr: false },
-  { id: 6, name: 'CD4 Count', section: 'Immunology', sampleType: 'Whole Blood', resultType: 'Numeric', loinc: '24467-3', active: true, isAmr: false },
-  { id: 7, name: 'Malaria RDT', section: 'Parasitology', sampleType: 'Whole Blood', resultType: 'Select List', loinc: 'â€”', active: true, isAmr: false },
-  { id: 8, name: 'Bilirubin, Total', section: 'Chemistry', sampleType: 'Serum', resultType: 'Numeric', loinc: '1975-2', active: true, isAmr: false },
-  { id: 9, name: 'Ampicillin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'Select List', loinc: '18864-9', active: true, isAmr: true, whonetCode: 'AMP' },
-  { id: 10, name: 'Ciprofloxacin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'Select List', loinc: '18906-8', active: true, isAmr: true, whonetCode: 'CIP' },
-  { id: 11, name: 'Gentamicin Susceptibility', section: 'Microbiology', sampleType: 'Culture', resultType: 'Select List', loinc: '18928-2', active: true, isAmr: true, whonetCode: 'GEN' },
-];
-
-const TestListView = ({ onEditTest, onAddTest }) => {
-  const [selectedTests, setSelectedTests] = useState([]);
-  const [searchTerm, setSearchTerm] = useState('');
-  const [showFilters, setShowFilters] = useState(false);
-
-  const toggleSelect = (id) => {
-    setSelectedTests(prev => 
-      prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id]
-    );
-  };
-
-  const toggleSelectAll = () => {
-    setSelectedTests(prev => 
-      prev.length === mockTests.length ? [] : mockTests.map(t => t.id)
-    );
-  };
-
-  return (
-    <div className="bg-gray-50 min-h-screen">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 px-6 py-4">
-        <div className="flex items-center justify-between">
-          <div>
-            <h1 className="text-2xl font-semibold text-gray-900">Test Catalog Management</h1>
-            <p className="text-sm text-gray-500 mt-1">Manage laboratory tests, panels, and configurations</p>
-          </div>
-          <button 
-            onClick={onAddTest}
-            className="flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded-md font-medium transition-colors"
-          >
-            <Plus size={18} />
-            Add Test
-          </button>
-        </div>
-      </div>
-
-      {/* Search and Filters Bar */}
-      <div className="bg-white border-b border-gray-200 px-6 py-3">
-        <div className="flex items-center gap-4">
-          <div className="relative flex-1 max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={18} />
-            <input
-              type="text"
-              placeholder="Search tests..."
-              value={searchTerm}
-              onChange={(e) => setSearchTerm(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-            />
-          </div>
-          
-          <button 
-            onClick={() => setShowFilters(!showFilters)}
-            className={`flex items-center gap-2 px-3 py-2 border rounded-md transition-colors ${showFilters ? 'bg-teal-50 border-teal-500 text-teal-700' : 'border-gray-300 text-gray-700 hover:bg-gray-50'}`}
-          >
-            <Filter size={18} />
-            Filters
-            <ChevronDown size={16} className={`transition-transform ${showFilters ? 'rotate-180' : ''}`} />
-          </button>
-
-          <div className="flex items-center gap-2 ml-auto">
-            <button className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50">
-              <Download size={18} />
-              Export
-            </button>
-            <button className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50">
-              <Upload size={18} />
-              Import
-            </button>
-            <button className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50">
-              <Cloud size={18} />
-              Fetch from Hub
-            </button>
-          </div>
-        </div>
-
-        {/* Expanded Filters */}
-        {showFilters && (
-          <div className="flex items-center gap-4 mt-3 pt-3 border-t border-gray-200">
-            <select className="px-3 py-2 border border-gray-300 rounded-md text-gray-700">
-              <option>All Sections</option>
-              <option>Chemistry</option>
-              <option>Hematology</option>
-              <option>Serology</option>
-              <option>Immunology</option>
-            </select>
-            <select className="px-3 py-2 border border-gray-300 rounded-md text-gray-700">
-              <option>All Sample Types</option>
-              <option>Serum</option>
-              <option>Whole Blood</option>
-              <option>Urine</option>
-            </select>
-            <select className="px-3 py-2 border border-gray-300 rounded-md text-gray-700">
-              <option>All Result Types</option>
-              <option>Numeric</option>
-              <option>Select List</option>
-              <option>Text</option>
-            </select>
-            <select className="px-3 py-2 border border-gray-300 rounded-md text-gray-700">
-              <option>All Statuses</option>
-              <option>Active</option>
-              <option>Inactive</option>
-            </select>
-            <select className="px-3 py-2 border border-gray-300 rounded-md text-gray-700">
-              <option>All Tests</option>
-              <option>AMR Tests Only</option>
-              <option>Non-AMR Tests</option>
-            </select>
-            <button className="text-teal-600 hover:text-teal-700 text-sm font-medium">Clear All</button>
-          </div>
-        )}
-      </div>
-
-      {/* Bulk Actions Bar */}
-      {selectedTests.length > 0 && (
-        <div className="bg-teal-50 border-b border-teal-200 px-6 py-2">
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-teal-800 font-medium">{selectedTests.length} test(s) selected</span>
-            <button className="text-sm text-teal-700 hover:text-teal-900 font-medium">Activate</button>
-            <button className="text-sm text-teal-700 hover:text-teal-900 font-medium">Deactivate</button>
-            <button className="text-sm text-teal-700 hover:text-teal-900 font-medium">Add to Panel</button>
-            <button className="text-sm text-teal-700 hover:text-teal-900 font-medium">Export Selected</button>
-            <button className="text-sm text-gray-500 hover:text-gray-700 ml-auto" onClick={() => setSelectedTests([])}>Clear Selection</button>
-          </div>
-        </div>
-      )}
-
-      {/* Table */}
-      <div className="px-6 py-4">
-        <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
-          <table className="w-full">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="w-12 px-4 py-3">
-                  <input 
-                    type="checkbox" 
-                    checked={selectedTests.length === mockTests.length}
-                    onChange={toggleSelectAll}
-                    className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                  />
-                </th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">Test Name</th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">Section</th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">Sample Type</th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">Result Type</th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">LOINC</th>
-                <th className="px-4 py-3 text-left text-sm font-semibold text-gray-700">Status</th>
-                <th className="w-24 px-4 py-3 text-right text-sm font-semibold text-gray-700">Actions</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-200">
-              {mockTests.map((test) => (
-                <tr key={test.id} className={`hover:bg-gray-50 ${selectedTests.includes(test.id) ? 'bg-teal-50' : ''}`}>
-                  <td className="px-4 py-3">
-                    <input 
-                      type="checkbox" 
-                      checked={selectedTests.includes(test.id)}
-                      onChange={() => toggleSelect(test.id)}
-                      className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                    />
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-2">
-                      <button 
-                        onClick={() => onEditTest(test)}
-                        className="text-teal-600 hover:text-teal-800 font-medium"
-                      >
-                        {test.name}
-                      </button>
-                      {test.isAmr && (
-                        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700" title={`WHONET: ${test.whonetCode}`}>
-                          AMR
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600">{test.section}</td>
-                  <td className="px-4 py-3 text-sm text-gray-600">{test.sampleType}</td>
-                  <td className="px-4 py-3">
-                    <span className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
-                      {test.resultType}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 text-sm text-gray-600 font-mono">{test.loinc}</td>
-                  <td className="px-4 py-3">
-                    <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${test.active ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-500'}`}>
-                      {test.active ? 'Active' : 'Inactive'}
-                    </span>
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center justify-end gap-1">
-                      <button 
-                        onClick={() => onEditTest(test)}
-                        className="p-1.5 text-gray-500 hover:text-teal-600 hover:bg-teal-50 rounded"
-                        title="Edit"
-                      >
-                        <Edit size={16} />
-                      </button>
-                      <button className="p-1.5 text-gray-500 hover:text-blue-600 hover:bg-blue-50 rounded" title="Duplicate">
-                        <Copy size={16} />
-                      </button>
-                      <button className="p-1.5 text-gray-500 hover:text-red-600 hover:bg-red-50 rounded" title="Deactivate">
-                        <Trash2 size={16} />
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        {/* Pagination */}
-        <div className="flex items-center justify-between mt-4">
-          <span className="text-sm text-gray-500">Showing 1-8 of 347 tests</span>
-          <div className="flex items-center gap-2">
-            <button className="px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50" disabled>Previous</button>
-            <button className="px-3 py-1.5 bg-teal-600 text-white rounded-md text-sm">1</button>
-            <button className="px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">2</button>
-            <button className="px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">3</button>
-            <span className="text-gray-500">...</span>
-            <button className="px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">44</button>
-            <button className="px-3 py-1.5 border border-gray-300 rounded-md text-sm text-gray-700 hover:bg-gray-50">Next</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// COMPLIANCE TAB (S-01 Integration)
-// See: S01-compliance-standards-admin-frs-v1.0.md
-// ============================================
-
-const ComplianceTab = () => {
-  const [groupBy, setGroupBy] = useState('standard');
-
-  // Placeholder thresholds — in production, loaded via API per test
-  const thresholds = [
-    { id: 't1', std: 'PP No. 22/2021 — Baku Mutu Air', grp: 'Parameter Fisika', type: 'MAX', value: '≤ 25 NTU', date: '2021-02-02' },
-    { id: 't2', std: 'WHO Drinking Water Guidelines', grp: 'Chemical Contaminants', type: 'MAX', value: '≤ 5 NTU', date: '2022-03-21' },
-  ];
-
-  const typeColors = { MAX: 'bg-red-100 text-red-700', MIN: 'bg-blue-100 text-blue-700', RANGE: 'bg-teal-100 text-teal-700', DESCRIPTIVE: 'bg-purple-100 text-purple-700' };
+  const [showInterpModal, setShowInterpModal] = useState(false);
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold">Compliance Thresholds</h2>
-        <div className="flex items-center gap-3">
-          <div className="flex items-center gap-2 text-sm">
-            <span className="text-gray-500">Group by:</span>
-            <select value={groupBy} onChange={e => setGroupBy(e.target.value)} className="border border-gray-300 rounded px-2 py-1 text-sm">
-              <option value="standard">Standard</option>
-              <option value="group">Parameter Group</option>
-            </select>
-          </div>
-          <button className="px-3 py-1.5 bg-teal-600 hover:bg-teal-700 text-white rounded text-sm font-medium flex items-center gap-1">
-            <Plus size={14} /> Add Threshold
-          </button>
+      <h2>{t('admin.testCatalog.sampleResults.header.title', 'Sample & Results Configuration')}</h2>
+      <p>{t('admin.testCatalog.sampleResults.header.subtitle', 'Define sample types and result format')}</p>
+
+      <div style={{ marginBottom: '16px' }}>
+        <label>{t('admin.testCatalog.sampleResults.label.sampleTypes', 'Sample Type(s)') + ' *'}</label>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: '8px', marginTop: '8px' }}>
+          {['Serum', 'Plasma', 'Whole Blood', 'Urine', 'CSF', 'Water', 'Mosquito Pool'].map((s) => (
+            <Checkbox key={s} labelText={s} id={`st-${s}`} />
+          ))}
         </div>
       </div>
-      <p className="text-sm text-gray-500 mb-4">
-        Regulatory compliance thresholds for this test. Environmental tests use these instead of (or alongside) clinical reference ranges.
-        Full compliance standards are managed at Admin → Test Management → Compliance Standards.
-      </p>
-      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-        <table className="w-full text-sm">
+
+      <Select
+        labelText={t('admin.testCatalog.sampleResults.label.defaultSampleType', 'Default Sample Type')}
+        style={{ marginBottom: '16px' }}
+      >
+        <SelectItem text={t('admin.testCatalog.common.option.select', 'Select...')} value="" />
+      </Select>
+
+      <Select
+        labelText={t('admin.testCatalog.sampleResults.label.resultType', 'Result Type') + ' *'}
+        value={resultType}
+        onChange={(e) => setResultType(e.target.value)}
+        style={{ marginBottom: '16px' }}
+      >
+        <SelectItem text="NUMERIC" value="NUMERIC" />
+        <SelectItem text="SELECT_LIST" value="SELECT_LIST" />
+        <SelectItem text="MULTI_SELECT" value="MULTI_SELECT" />
+        <SelectItem text="FREE_TEXT" value="FREE_TEXT" />
+      </Select>
+
+      {resultType === 'NUMERIC' && (
+        <>
+          <Select labelText={t('admin.testCatalog.sampleResults.label.unitOfMeasure', 'Unit of Measure')} style={{ marginBottom: '16px' }}>
+            <SelectItem text="mg/dL" value="mg/dL" />
+            <SelectItem text="mmol/L" value="mmol/L" />
+            <SelectItem text="g/dL" value="g/dL" />
+          </Select>
+
+          <NumberInput
+            labelText={t('admin.testCatalog.sampleResults.label.significantDigits', 'Significant Digits')}
+            min={0}
+            max={6}
+            style={{ marginBottom: '16px' }}
+          />
+        </>
+      )}
+
+      <TextInput
+        labelText={t('admin.testCatalog.sampleResults.label.defaultResultValue', 'Default Result Value')}
+        style={{ marginBottom: '16px' }}
+      />
+
+      {(resultType === 'SELECT_LIST' || resultType === 'MULTI_SELECT') && (
+        <Tile style={{ marginBottom: '16px', padding: '16px' }}>
+          <h4 style={{ marginTop: 0 }}>{t('admin.testCatalog.sampleResults.header.selectListOptions', 'Select List Options')}</h4>
+          <div style={{ fontSize: '12px', marginBottom: '12px' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr style={{ background: '#f4f4f4', borderBottom: '1px solid #d0d0d0' }}>
+                  <th style={{ padding: '8px', textAlign: 'left' }}>≡</th>
+                  <th style={{ padding: '8px', textAlign: 'left' }}>Value</th>
+                  <th style={{ padding: '8px', textAlign: 'left' }}>Display Order</th>
+                  <th style={{ padding: '8px', textAlign: 'left' }}>Active</th>
+                  <th style={{ padding: '8px', textAlign: 'left' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {selectOptions.map((opt) => (
+                  <tr key={opt.id} style={{ borderBottom: '1px solid #e0e0e0' }}>
+                    <td style={{ padding: '8px' }}>≡</td>
+                    <td style={{ padding: '8px', fontFamily: 'monospace' }}>{opt.value}</td>
+                    <td style={{ padding: '8px' }}>1</td>
+                    <td style={{ padding: '8px' }}>
+                      <Checkbox checked={opt.active} id={`opt-${opt.id}`} />
+                    </td>
+                    <td style={{ padding: '8px' }}>
+                      <Button kind="ghost" size="sm">Edit</Button>
+                      <Button kind="ghost" size="sm" style={{ marginLeft: '4px' }}>Delete</Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Tile>
+      )}
+
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '16px' }}>
+        <h4 style={{ margin: 0 }}>{t('admin.testCatalog.sampleResults.header.resultInterpretations', 'Result Interpretations')}</h4>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <Button kind="secondary" size="sm">{t('admin.testCatalog.sampleResults.action.copyFromTest', '📋 Copy from Test...')}</Button>
+          <Button kind="primary" size="sm" onClick={() => setShowInterpModal(true)}>
+            {t('admin.testCatalog.common.button.add', '+ Add Interpretation')}
+          </Button>
+        </div>
+      </div>
+
+      <div style={{ fontSize: '12px', marginBottom: '16px' }}>
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
           <thead>
-            <tr className="bg-gray-50 border-b">
-              <th className="px-4 py-3 text-left font-semibold text-gray-700">Standard</th>
-              <th className="px-4 py-3 text-left font-semibold text-gray-700">Parameter Group</th>
-              <th className="px-4 py-3 text-left font-semibold text-gray-700">Type</th>
-              <th className="px-4 py-3 text-left font-semibold text-gray-700">Value</th>
-              <th className="px-4 py-3 text-left font-semibold text-gray-700">Effective Date</th>
-              <th className="px-4 py-3 w-16"></th>
+            <tr style={{ background: '#f4f4f4', borderBottom: '2px solid #d0d0d0' }}>
+              <th style={{ padding: '8px', textAlign: 'left' }}>≡</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Code</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Label</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Value/Range</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Text</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Active</th>
+              <th style={{ padding: '8px', textAlign: 'left' }}>Actions</th>
             </tr>
           </thead>
           <tbody>
-            {thresholds.map(th => (
-              <tr key={th.id} className="border-b hover:bg-gray-50">
-                <td className="px-4 py-3">{th.std}</td>
-                <td className="px-4 py-3">{th.grp}</td>
-                <td className="px-4 py-3"><span className={`px-2 py-0.5 rounded-full text-xs font-medium ${typeColors[th.type]}`}>{th.type}</span></td>
-                <td className="px-4 py-3 font-medium">{th.value}</td>
-                <td className="px-4 py-3 text-gray-500">{th.date}</td>
-                <td className="px-4 py-3"><button className="text-gray-400 hover:text-gray-600"><Edit size={16} /></button></td>
+            {[
+              { code: 'GLU-CRIT-H', label: 'Critical High', type: 'red', value: '> 500', text: 'Critical hyperglycemia...' },
+              { code: 'GLU-HI', label: 'High', type: 'warm-gray', value: '140-500', text: 'Elevated glucose...' },
+              { code: 'GLU-NL', label: 'Normal', type: 'green', value: '70-100', text: 'Within normal range...' },
+            ].map((int, idx) => (
+              <tr key={idx} style={{ borderBottom: '1px solid #e0e0e0' }}>
+                <td style={{ padding: '8px' }}>≡</td>
+                <td style={{ padding: '8px', fontFamily: 'monospace' }}>{int.code}</td>
+                <td style={{ padding: '8px' }}>
+                  <Tag type={int.type}>{int.label}</Tag>
+                </td>
+                <td style={{ padding: '8px' }}>{int.value}</td>
+                <td style={{ padding: '8px', fontSize: '11px', maxWidth: '200px' }}>{int.text}</td>
+                <td style={{ padding: '8px' }}>
+                  <Checkbox checked id={`int-${idx}`} />
+                </td>
+                <td style={{ padding: '8px' }}>
+                  <Button kind="ghost" size="sm">Edit</Button>
+                  <Button kind="ghost" size="sm" style={{ marginLeft: '4px' }}>Delete</Button>
+                </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
-    </div>
-  );
-};
 
-// ============================================
-// TEST EDITOR (TABBED INTERFACE)
-// ============================================
-
-const TestEditor = ({ test, onBack }) => {
-  const [activeTab, setActiveTab] = useState('basic');
-
-  // Tab groups: Configuration | Organization | Resources | Automation | Compliance
-  // Compliance tab added in v2.1 — see S01-compliance-standards-admin-frs-v1.0.md
-  const tabs = [
-    { id: 'basic', label: 'Basic Info', icon: FileText },
-    { id: 'sample', label: 'Sample & Results', icon: Beaker },
-    { id: 'ranges', label: 'Ranges', icon: Activity },
-    { id: 'storage', label: 'Sample Storage', icon: Thermometer },
-    { id: 'ordering', label: 'Display Order', icon: Layers },
-    { id: 'panels', label: 'Panels', icon: Layers },
-    { id: 'labels', label: 'Labels', icon: Printer },
-    { id: 'terminology', label: 'Terminology', icon: Tag },
-    { id: 'reagents', label: 'Reagents', icon: FlaskConical },
-    { id: 'analyzers', label: 'Analyzers', icon: Cpu },
-    { id: 'methods', label: 'Methods', icon: Settings },
-    { id: 'alerts', label: 'Alerts', icon: Bell },
-    { id: 'reflex', label: 'Reflex & Calc', icon: GitBranch },
-    { id: 'compliance', label: 'Compliance', icon: CheckCircle },
-  ];
-
-  return (
-    <div className="bg-gray-50 h-screen flex flex-col">
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200 px-6 py-4 flex-shrink-0">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <button onClick={onBack} className="p-2 text-gray-500 hover:text-gray-700 hover:bg-gray-100 rounded-md">
-              <ChevronLeft size={20} />
-            </button>
-            <div>
-              <h1 className="text-xl font-semibold text-gray-900">
-                {test ? `Edit Test: ${test.name}` : 'Add New Test'}
-              </h1>
-              <p className="text-sm text-gray-500">Configure all test properties in one place</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-3">
-            <button onClick={onBack} className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 font-medium">
-              Cancel
-            </button>
-            <button className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md font-medium">
-              Save Test
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content with Vertical Tabs */}
-      <div className="flex flex-1 overflow-hidden">
-        {/* Vertical Tab Sidebar */}
-        <div className="w-56 bg-white border-r border-gray-200 flex-shrink-0 overflow-y-auto">
-          <nav className="p-2">
-            <div className="mb-2">
-              <p className="px-3 py-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider">Configuration</p>
-            </div>
-            {tabs.slice(0, 4).map((tab) => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors mb-0.5 ${
-                    activeTab === tab.id 
-                      ? 'bg-teal-50 text-teal-700 border-l-3 border-teal-600' 
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  <Icon size={18} className={activeTab === tab.id ? 'text-teal-600' : 'text-gray-400'} />
-                  {tab.label}
-                </button>
-              );
-            })}
-            
-            <div className="mt-4 mb-2">
-              <p className="px-3 py-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider">Organization</p>
-            </div>
-            {tabs.slice(4, 7).map((tab) => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors mb-0.5 ${
-                    activeTab === tab.id 
-                      ? 'bg-teal-50 text-teal-700 border-l-3 border-teal-600' 
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  <Icon size={18} className={activeTab === tab.id ? 'text-teal-600' : 'text-gray-400'} />
-                  {tab.label}
-                </button>
-              );
-            })}
-            
-            <div className="mt-4 mb-2">
-              <p className="px-3 py-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider">Resources</p>
-            </div>
-            {tabs.slice(7, 9).map((tab) => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors mb-0.5 ${
-                    activeTab === tab.id 
-                      ? 'bg-teal-50 text-teal-700 border-l-3 border-teal-600' 
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  <Icon size={18} className={activeTab === tab.id ? 'text-teal-600' : 'text-gray-400'} />
-                  {tab.label}
-                </button>
-              );
-            })}
-            
-            <div className="mt-4 mb-2">
-              <p className="px-3 py-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider">Automation</p>
-            </div>
-            {tabs.slice(9, 13).map((tab) => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors mb-0.5 ${
-                    activeTab === tab.id
-                      ? 'bg-teal-50 text-teal-700 border-l-3 border-teal-600'
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  <Icon size={18} className={activeTab === tab.id ? 'text-teal-600' : 'text-gray-400'} />
-                  {tab.label}
-                </button>
-              );
-            })}
-
-            <div className="mt-4 mb-2">
-              <p className="px-3 py-1.5 text-xs font-semibold text-gray-400 uppercase tracking-wider">Compliance</p>
-            </div>
-            {tabs.slice(13).map((tab) => {
-              const Icon = tab.icon;
-              return (
-                <button
-                  key={tab.id}
-                  onClick={() => setActiveTab(tab.id)}
-                  className={`w-full flex items-center gap-3 px-3 py-2 text-sm font-medium rounded-md transition-colors mb-0.5 ${
-                    activeTab === tab.id
-                      ? 'bg-teal-50 text-teal-700 border-l-3 border-teal-600'
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'
-                  }`}
-                >
-                  <Icon size={18} className={activeTab === tab.id ? 'text-teal-600' : 'text-gray-400'} />
-                  {tab.label}
-                </button>
-              );
-            })}
-          </nav>
-        </div>
-
-        {/* Tab Content */}
-        <div className="flex-1 overflow-y-auto px-6 py-6">
-          <div className="max-w-5xl">
-            {activeTab === 'basic' && <BasicInfoTab test={test} />}
-            {activeTab === 'sample' && <SampleResultsTab test={test} />}
-            {activeTab === 'ranges' && <RangeEditorV3 />}
-            {activeTab === 'storage' && <SampleStorageTab />}
-            {activeTab === 'ordering' && <TestOrderingPanel />}
-            {activeTab === 'panels' && <PanelAssociationPanel />}
-            {activeTab === 'labels' && <LabelsTab />}
-            {activeTab === 'terminology' && <TerminologyMappingsTab />}
-            {activeTab === 'reagents' && <ReagentLinkingTab />}
-            {activeTab === 'analyzers' && <AnalyzerLinkingTab />}
-            {activeTab === 'methods' && <MethodLinkingWithCreate />}
-            {activeTab === 'alerts' && <AlertRulesTab />}
-            {activeTab === 'reflex' && <ReflexCalculatedTab />}
-            {activeTab === 'compliance' && <ComplianceTab />}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// BASIC INFO TAB
-// ============================================
-
-const BasicInfoTab = ({ test }) => {
-  const [isAmrTest, setIsAmrTest] = useState(false);
-
-  return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">Basic Information</h2>
-        
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <div className="flex items-center gap-1 mb-1">
-              <label className="text-sm font-medium text-gray-700">Test Name</label>
-              <span className="text-red-500">*</span>
-              <button className="text-gray-400 hover:text-gray-600"><Info size={14} /></button>
-            </div>
-            <input 
-              type="text" 
-              defaultValue={test?.name || ''}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              placeholder="Enter test name"
-            />
-          </div>
-
-          <div>
-            <div className="flex items-center gap-1 mb-1">
-              <label className="text-sm font-medium text-gray-700">Reporting Name</label>
-              <button className="text-gray-400 hover:text-gray-600"><Info size={14} /></button>
-            </div>
-            <input 
-              type="text" 
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              placeholder="Name for patient reports"
-            />
-          </div>
-
-          <div>
-            <div className="flex items-center gap-1 mb-1">
-              <label className="text-sm font-medium text-gray-700">Test Code</label>
-              <button className="text-gray-400 hover:text-gray-600"><Info size={14} /></button>
-            </div>
-            <input 
-              type="text" 
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              placeholder="e.g., GLU-F"
-            />
-          </div>
-
-          <div>
-            <TestSectionMultiSelect />
-          </div>
-
-          <div className="col-span-2">
-            <div className="flex items-center gap-1 mb-1">
-              <label className="text-sm font-medium text-gray-700">Description</label>
-              <button className="text-gray-400 hover:text-gray-600"><Info size={14} /></button>
-            </div>
-            <textarea 
-              rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              placeholder="Enter test description..."
-            />
-          </div>
-
-          <div className="col-span-2 border-t border-gray-200 pt-6">
-            <h3 className="text-sm font-semibold text-gray-700 mb-4">Status & Visibility</h3>
-            <div className="flex items-center gap-8">
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input type="checkbox" defaultChecked className="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                <span className="text-sm text-gray-700">Active</span>
-              </label>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input type="checkbox" defaultChecked className="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                <span className="text-sm text-gray-700">Orderable</span>
-              </label>
-              <label className="flex items-center gap-3 cursor-pointer">
-                <input type="checkbox" className="w-4 h-4 rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                <div>
-                  <span className="text-sm text-gray-700">Internal QA - No Results Release</span>
-                  <p className="text-xs text-gray-500">Test results will not appear on patient reports</p>
-                </div>
-              </label>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* AMR Test Configuration */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-start gap-4">
-          <input 
-            type="checkbox" 
-            checked={isAmrTest}
-            onChange={(e) => setIsAmrTest(e.target.checked)}
-            className="w-5 h-5 mt-0.5 rounded border-gray-300 text-teal-600 focus:ring-teal-500" 
-          />
-          <div className="flex-1">
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-semibold text-gray-900">Antimicrobial Resistance (AMR) Test</h3>
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-700">
-                WHONET
-              </span>
-            </div>
-            <p className="text-sm text-gray-500 mt-1">
-              Enable for WHONET export and antimicrobial resistance surveillance
-            </p>
-
-            {/* AMR Configuration - shown when checked */}
-            {isAmrTest && (
-              <div className="mt-4 p-4 bg-purple-50 border border-purple-200 rounded-lg">
-                <h4 className="text-sm font-medium text-purple-900 mb-4">WHONET Configuration</h4>
-                <div className="grid grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">WHONET Antibiotic Code</label>
-                    <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
-                      <option value="">Select antibiotic...</option>
-                      <option value="AMP">AMP - Ampicillin</option>
-                      <option value="AMC">AMC - Amoxicillin/Clavulanic acid</option>
-                      <option value="CIP">CIP - Ciprofloxacin</option>
-                      <option value="GEN">GEN - Gentamicin</option>
-                      <option value="MEM">MEM - Meropenem</option>
-                      <option value="VAN">VAN - Vancomycin</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Antibiotic Class</label>
-                    <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
-                      <option value="">Select class...</option>
-                      <option value="penicillins">Penicillins</option>
-                      <option value="cephalosporins">Cephalosporins</option>
-                      <option value="carbapenems">Carbapenems</option>
-                      <option value="fluoroquinolones">Fluoroquinolones</option>
-                      <option value="aminoglycosides">Aminoglycosides</option>
-                      <option value="glycopeptides">Glycopeptides</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Test Method</label>
-                    <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
-                      <option value="disk">Disk Diffusion</option>
-                      <option value="mic">MIC</option>
-                      <option value="etest">E-test</option>
-                      <option value="vitek">VITEK</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Breakpoint Standard</label>
-                    <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500">
-                      <option value="clsi2024">CLSI 2024</option>
-                      <option value="clsi2023">CLSI 2023</option>
-                      <option value="eucast2024">EUCAST 2024</option>
-                      <option value="eucast2023">EUCAST 2023</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 mb-1">Disk Potency</label>
-                    <div className="flex gap-2">
-                      <input 
-                        type="number" 
-                        placeholder="e.g., 10"
-                        className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                      />
-                      <span className="flex items-center px-3 py-2 bg-gray-100 border border-gray-300 rounded-md text-sm text-gray-600">Âµg</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="mt-4 flex items-center gap-2 text-sm text-purple-700">
-                  <Info size={14} />
-                  <span>This test will be included in WHONET exports</span>
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// SAMPLE & RESULTS TAB
-// ============================================
-
-const SampleResultsTab = ({ test }) => {
-  const [showCopyInterpretationsModal, setShowCopyInterpretationsModal] = useState(false);
-  const [showAddInterpretationModal, setShowAddInterpretationModal] = useState(false);
-  const [editingInterpretation, setEditingInterpretation] = useState(null);
-  const [resultType, setResultType] = useState('numeric'); // 'numeric' or 'select'
-  
-  // Sample select list options (would come from test configuration)
-  const selectListOptions = [
-    { id: 1, value: 'Positive', displayOrder: 1 },
-    { id: 2, value: 'Negative', displayOrder: 2 },
-    { id: 3, value: 'Indeterminate', displayOrder: 3 },
-    { id: 4, value: 'Reactive', displayOrder: 4 },
-    { id: 5, value: 'Non-Reactive', displayOrder: 5 },
-  ];
-
-  // Available label colors
-  const labelColors = [
-    { id: 'red', name: 'Red', bg: 'bg-red-100', text: 'text-red-700', preview: 'bg-red-500' },
-    { id: 'orange', name: 'Orange', bg: 'bg-orange-100', text: 'text-orange-700', preview: 'bg-orange-500' },
-    { id: 'yellow', name: 'Yellow', bg: 'bg-yellow-100', text: 'text-yellow-700', preview: 'bg-yellow-500' },
-    { id: 'green', name: 'Green', bg: 'bg-green-100', text: 'text-green-700', preview: 'bg-green-500' },
-    { id: 'teal', name: 'Teal', bg: 'bg-teal-100', text: 'text-teal-700', preview: 'bg-teal-500' },
-    { id: 'blue', name: 'Blue', bg: 'bg-blue-100', text: 'text-blue-700', preview: 'bg-blue-500' },
-    { id: 'purple', name: 'Purple', bg: 'bg-purple-100', text: 'text-purple-700', preview: 'bg-purple-500' },
-    { id: 'pink', name: 'Pink', bg: 'bg-pink-100', text: 'text-pink-700', preview: 'bg-pink-500' },
-    { id: 'gray', name: 'Gray', bg: 'bg-gray-100', text: 'text-gray-700', preview: 'bg-gray-500' },
-  ];
-  
-  // Sample interpretations data with macro codes
-  const [interpretations, setInterpretations] = useState([
-    { id: 1, code: 'GLU-CRIT-H', resultType: 'numeric', label: 'Critical High', color: 'red', value: '>400', text: 'CRITICAL: Glucose severely elevated. Immediate clinical attention required.', isActive: true },
-    { id: 2, code: 'GLU-HI', resultType: 'numeric', label: 'High', color: 'orange', value: '>126', text: 'Elevated fasting glucose. Consider diabetes screening and lifestyle modifications.', isActive: true },
-    { id: 3, code: 'GLU-NL', resultType: 'numeric', label: 'Normal', color: 'green', value: '70-99', text: 'Fasting glucose within normal limits.', isActive: true },
-    { id: 4, code: 'GLU-LO', resultType: 'numeric', label: 'Low', color: 'yellow', value: '<70', text: 'Hypoglycemia. Evaluate for symptoms and underlying cause.', isActive: true },
-    { id: 5, code: 'GLU-CRIT-L', resultType: 'numeric', label: 'Critical Low', color: 'red', value: '<50', text: 'CRITICAL: Severe hypoglycemia. Immediate intervention required.', isActive: true },
-  ]);
-
-  // New interpretation form state
-  const [newInterpretation, setNewInterpretation] = useState({
-    code: '',
-    label: '',
-    color: 'gray',
-    value: '',
-    selectedValues: [], // Array for multi-select
-    text: '',
-    isActive: true
-  });
-
-  const handleAddInterpretation = () => {
-    setEditingInterpretation(null);
-    setNewInterpretation({
-      code: '',
-      label: '',
-      color: 'gray',
-      value: '',
-      selectedValues: [],
-      text: '',
-      isActive: true
-    });
-    setShowAddInterpretationModal(true);
-  };
-
-  const handleEditInterpretation = (interp) => {
-    setEditingInterpretation(interp);
-    // Parse value back to array if it's a select list type
-    const selectedVals = interp.resultType === 'select' 
-      ? (interp.value.includes(',') ? interp.value.split(', ') : [interp.value])
-      : [];
-    setNewInterpretation({
-      code: interp.code,
-      label: interp.label,
-      color: interp.color || 'gray',
-      value: interp.resultType === 'select' ? '' : interp.value,
-      selectedValues: selectedVals,
-      text: interp.text,
-      isActive: interp.isActive
-    });
-    setShowAddInterpretationModal(true);
-  };
-
-  const handleSaveInterpretation = () => {
-    const isSelectList = resultType === 'select' || resultType === 'multiselect';
-    const interpData = {
-      id: editingInterpretation ? editingInterpretation.id : Math.max(...interpretations.map(i => i.id), 0) + 1,
-      code: newInterpretation.code,
-      resultType: isSelectList ? 'select' : 'numeric',
-      label: newInterpretation.label,
-      color: newInterpretation.color,
-      value: isSelectList ? newInterpretation.selectedValues.join(', ') : newInterpretation.value,
-      text: newInterpretation.text,
-      isActive: newInterpretation.isActive
-    };
-
-    if (editingInterpretation) {
-      setInterpretations(interpretations.map(i => i.id === editingInterpretation.id ? interpData : i));
-    } else {
-      setInterpretations([...interpretations, interpData]);
-    }
-    setShowAddInterpretationModal(false);
-  };
-
-  const handleDeleteInterpretation = (id) => {
-    if (confirm('Are you sure you want to delete this interpretation?')) {
-      setInterpretations(interpretations.filter(i => i.id !== id));
-    }
-  };
-
-  const handleToggleActive = (id) => {
-    setInterpretations(interpretations.map(i => 
-      i.id === id ? { ...i, isActive: !i.isActive } : i
-    ));
-  };
-
-  const getLabelStyle = (color) => {
-    const colorDef = labelColors.find(c => c.id === color) || labelColors.find(c => c.id === 'gray');
-    return `${colorDef.bg} ${colorDef.text}`;
-  };
-
-  return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">Sample & Result Configuration</h2>
-        
-        <div className="space-y-6">
-          <div className="grid grid-cols-2 gap-6">
-            <div>
-              <div className="flex items-center gap-1 mb-1">
-                <label className="text-sm font-medium text-gray-700">Sample Type(s)</label>
-                <span className="text-red-500">*</span>
-              </div>
-              <div className="border border-gray-300 rounded-md p-3 space-y-2 max-h-40 overflow-y-auto">
-                {['Serum', 'Plasma', 'Whole Blood', 'Urine', 'CSF'].map(type => (
-                  <label key={type} className="flex items-center gap-2 cursor-pointer">
-                    <input 
-                      type="checkbox" 
-                      defaultChecked={type === 'Serum'}
-                      className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" 
-                    />
-                    <span className="text-sm text-gray-700">{type}</span>
-                  </label>
-                ))}
-              </div>
-            </div>
-
-            <div>
-              <div className="flex items-center gap-1 mb-1">
-                <label className="text-sm font-medium text-gray-700">Default Sample Type</label>
-              </div>
-              <select className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
-                <option value="">No default</option>
-                <option value="serum" selected>Serum</option>
-                <option value="plasma">Plasma</option>
-              </select>
-            </div>
-          </div>
-
-          <div className="border-t border-gray-200 pt-6">
-            <h3 className="text-sm font-semibold text-gray-700 mb-4">Result Configuration</h3>
-            
-            <div className="grid grid-cols-2 gap-6">
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Result Type <span className="text-red-500">*</span></label>
-                <select 
-                  value={resultType}
-                  onChange={(e) => setResultType(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                >
-                  <option value="numeric">Numeric</option>
-                  <option value="select">Select List</option>
-                  <option value="multiselect">Multi-select</option>
-                  <option value="text">Free Text</option>
-                  <option value="remark">Remark Only</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Unit of Measure {resultType === 'numeric' && <span className="text-red-500">*</span>}</label>
-                <select 
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                  disabled={resultType !== 'numeric'}
-                >
-                  <option value="">Select unit...</option>
-                  <option value="mgdl" selected>mg/dL</option>
-                  <option value="mmoll">mmol/L</option>
-                  <option value="gdl">g/dL</option>
-                  <option value="ul">ÂµL</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Significant Digits</label>
-                <input 
-                  type="number" 
-                  min="0" 
-                  max="6"
-                  defaultValue="0"
-                  disabled={resultType !== 'numeric'}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500 disabled:bg-gray-100"
-                />
-              </div>
-
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Default Result</label>
-                <input 
-                  type="text" 
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                  placeholder="Optional default value"
-                />
-              </div>
-            </div>
-
-            {/* Select List Options Preview */}
-            {(resultType === 'select' || resultType === 'multiselect') && (
-              <div className="mt-4 p-4 bg-gray-50 rounded-lg border border-gray-200">
-                <div className="flex items-center justify-between mb-2">
-                  <label className="text-sm font-medium text-gray-700">Select List Options</label>
-                  <button className="text-sm text-teal-600 hover:text-teal-700 font-medium">
-                    Configure Options...
-                  </button>
-                </div>
-                <div className="flex flex-wrap gap-2">
-                  {selectListOptions.map(opt => (
-                    <span key={opt.id} className="px-2 py-1 bg-white border border-gray-300 rounded text-sm text-gray-700">
-                      {opt.value}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Result Interpretations Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Result Interpretations</h2>
-            <p className="text-sm text-gray-500 mt-1">
-              Define interpretive labels and clinical guidance that are added as external notes based on result values.
-            </p>
-          </div>
-          <div className="flex items-center gap-2">
-            <button 
-              onClick={() => setShowCopyInterpretationsModal(true)}
-              className="flex items-center gap-2 px-3 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50"
-            >
-              <Copy size={16} />
-              Copy from Test...
-            </button>
-            <button 
-              onClick={handleAddInterpretation}
-              className="flex items-center gap-2 px-3 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium"
-            >
-              <Plus size={16} />
-              Add Interpretation
-            </button>
-          </div>
-        </div>
-
-        {interpretations.length > 0 ? (
-          <div className="border border-gray-200 rounded-lg overflow-hidden">
-            <table className="w-full">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="w-10 px-4 py-3"></th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase w-28">Code</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Label</th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase w-32">
-                    {resultType === 'select' ? 'Selected Value' : 'Value/Range'}
-                  </th>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Interpretation Text</th>
-                  <th className="px-4 py-3 text-center text-xs font-semibold text-gray-500 uppercase w-20">Active</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase w-24">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {interpretations.map((interp, index) => (
-                  <tr key={interp.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 text-center">
-                      <GripVertical size={16} className="text-gray-400 cursor-grab" />
-                    </td>
-                    <td className="px-4 py-3">
-                      <code className="px-2 py-1 bg-gray-100 text-gray-700 rounded text-xs font-mono">{interp.code}</code>
-                    </td>
-                    <td className="px-4 py-3">
-                      <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getLabelStyle(interp.color)}`}>
-                        {interp.label}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-sm font-mono text-gray-600">{interp.value}</td>
-                    <td className="px-4 py-3 text-sm text-gray-700 max-w-md truncate">{interp.text}</td>
-                    <td className="px-4 py-3 text-center">
-                      <input 
-                        type="checkbox" 
-                        checked={interp.isActive} 
-                        className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                        onChange={() => handleToggleActive(interp.id)}
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <div className="flex items-center justify-end gap-1">
-                        <button 
-                          onClick={() => handleEditInterpretation(interp)}
-                          className="p-1 text-gray-400 hover:text-teal-600"
-                        >
-                          <Edit size={16} />
-                        </button>
-                        <button 
-                          onClick={() => handleDeleteInterpretation(interp.id)}
-                          className="p-1 text-gray-400 hover:text-red-600"
-                        >
-                          <Trash2 size={16} />
-                        </button>
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <div className="border border-dashed border-gray-300 rounded-lg p-8 text-center">
-            <FileText size={32} className="mx-auto text-gray-400 mb-2" />
-            <p className="text-gray-500">No interpretations configured</p>
-            <p className="text-sm text-gray-400 mt-1">Add interpretations to provide automatic clinical notes based on result values</p>
-          </div>
-        )}
-      </div>
-
-      {/* Add/Edit Interpretation Modal */}
-      {showAddInterpretationModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-lg">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">
-                {editingInterpretation ? 'Edit Interpretation' : 'Add Interpretation'}
-              </h3>
-              <button onClick={() => setShowAddInterpretationModal(false)} className="text-gray-400 hover:text-gray-600">
-                <X size={20} />
-              </button>
-            </div>
-            <div className="p-6 space-y-4">
-              {/* Code Field */}
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">
-                  Code <span className="text-red-500">*</span>
-                </label>
-                <input 
-                  type="text"
-                  value={newInterpretation.code}
-                  onChange={(e) => setNewInterpretation({...newInterpretation, code: e.target.value.toUpperCase()})}
-                  placeholder="e.g., GLU-HI, HIV-POS, STAGE-2"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 font-mono uppercase"
-                />
-                <p className="text-xs text-gray-500 mt-1">Shortcode for quick entry in result screens</p>
-              </div>
-
-              {/* Label and Color */}
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="text-sm font-medium text-gray-700 mb-1 block">
-                    Label <span className="text-red-500">*</span>
-                  </label>
-                  <input 
-                    type="text"
-                    value={newInterpretation.label}
-                    onChange={(e) => setNewInterpretation({...newInterpretation, label: e.target.value})}
-                    placeholder="e.g., Critical High, Stage II, Treatment Failure"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500"
-                  />
-                </div>
-                <div>
-                  <label className="text-sm font-medium text-gray-700 mb-1 block">
-                    Color (optional)
-                  </label>
-                  <div className="flex items-center gap-2">
-                    <select
-                      value={newInterpretation.color}
-                      onChange={(e) => setNewInterpretation({...newInterpretation, color: e.target.value})}
-                      className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500"
-                    >
-                      {labelColors.map(color => (
-                        <option key={color.id} value={color.id}>{color.name}</option>
-                      ))}
-                    </select>
-                    <div className={`w-8 h-8 rounded-md ${labelColors.find(c => c.id === newInterpretation.color)?.preview || 'bg-gray-500'}`}></div>
-                  </div>
-                </div>
-              </div>
-
-              {/* Preview */}
-              {newInterpretation.label && (
-                <div className="flex items-center gap-2">
-                  <span className="text-sm text-gray-500">Preview:</span>
-                  <span className={`inline-flex items-center px-2 py-1 rounded-full text-xs font-medium ${getLabelStyle(newInterpretation.color)}`}>
-                    {newInterpretation.label}
-                  </span>
-                </div>
-              )}
-
-              {/* Value - different UI for numeric vs select list */}
-              {resultType === 'select' || resultType === 'multiselect' ? (
-                /* Select List Value - Multi-select checkboxes */
-                <div>
-                  <label className="text-sm font-medium text-gray-700 mb-1 block">
-                    When Value(s) Selected <span className="text-red-500">*</span>
-                  </label>
-                  <div className="border border-gray-300 rounded-md p-3 space-y-2 max-h-40 overflow-y-auto bg-white">
-                    {selectListOptions.map(opt => (
-                      <label key={opt.id} className="flex items-center gap-2 cursor-pointer hover:bg-gray-50 p-1 rounded">
-                        <input 
-                          type="checkbox"
-                          checked={newInterpretation.selectedValues?.includes(opt.value) || false}
-                          onChange={(e) => {
-                            const currentValues = newInterpretation.selectedValues || [];
-                            const newValues = e.target.checked 
-                              ? [...currentValues, opt.value]
-                              : currentValues.filter(v => v !== opt.value);
-                            setNewInterpretation({...newInterpretation, selectedValues: newValues});
-                          }}
-                          className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                        />
-                        <span className="text-sm text-gray-700">{opt.value}</span>
-                      </label>
-                    ))}
-                  </div>
-                  {newInterpretation.selectedValues?.length > 0 && (
-                    <div className="mt-2 flex flex-wrap gap-1">
-                      {newInterpretation.selectedValues.map(val => (
-                        <span key={val} className="inline-flex items-center px-2 py-0.5 rounded bg-teal-100 text-teal-700 text-xs">
-                          {val}
-                          <button 
-                            type="button"
-                            onClick={() => setNewInterpretation({
-                              ...newInterpretation, 
-                              selectedValues: newInterpretation.selectedValues.filter(v => v !== val)
-                            })}
-                            className="ml-1 text-teal-500 hover:text-teal-700"
-                          >
-                            Ã—
-                          </button>
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  <p className="text-xs text-gray-500 mt-1">Select one or more values that will trigger this interpretation</p>
-                </div>
-              ) : (
-                /* Numeric/Text Value */
-                <div>
-                  <label className="text-sm font-medium text-gray-700 mb-1 block">
-                    Value or Range <span className="text-red-500">*</span>
-                  </label>
-                  <input 
-                    type="text"
-                    value={newInterpretation.value}
-                    onChange={(e) => setNewInterpretation({...newInterpretation, value: e.target.value})}
-                    placeholder="e.g., >126, <70, 70-99"
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 font-mono"
-                  />
-                  <p className="text-xs text-gray-500 mt-1">
-                    Use comparison operators (&gt;, &lt;, &ge;, &le;), ranges (70-99), or exact values
-                  </p>
-                </div>
-              )}
-
-              {/* Interpretation Text */}
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-1 block">
-                  Interpretation Text <span className="text-red-500">*</span>
-                </label>
-                <textarea
-                  value={newInterpretation.text}
-                  onChange={(e) => setNewInterpretation({...newInterpretation, text: e.target.value})}
-                  rows={3}
-                  placeholder="Clinical interpretation, guidance, or action items..."
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">This text will be added as an external note on the result</p>
-              </div>
-
-              {/* Active Toggle */}
-              <div className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="interpActive"
-                  checked={newInterpretation.isActive}
-                  onChange={(e) => setNewInterpretation({...newInterpretation, isActive: e.target.checked})}
-                  className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                />
-                <label htmlFor="interpActive" className="text-sm text-gray-700">Active</label>
-              </div>
-            </div>
-            <div className="flex items-center justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-              <button 
-                onClick={() => setShowAddInterpretationModal(false)}
-                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-              >
-                Cancel
-              </button>
-              <button 
-                onClick={handleSaveInterpretation}
-                disabled={!newInterpretation.code || !newInterpretation.label || !newInterpretation.text || 
-                  (resultType === 'select' || resultType === 'multiselect' ? newInterpretation.selectedValues?.length === 0 : !newInterpretation.value)}
-                className="px-4 py-2 bg-teal-600 hover:bg-teal-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white rounded-md text-sm font-medium"
-              >
-                {editingInterpretation ? 'Save Changes' : 'Add Interpretation'}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Copy Interpretations Modal */}
-      {showCopyInterpretationsModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-xl">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Copy Interpretations from Another Test</h3>
-              <button onClick={() => setShowCopyInterpretationsModal(false)} className="text-gray-400 hover:text-gray-600">
-                <X size={20} />
-              </button>
-            </div>
-            <div className="p-6">
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-1 block">Search for test</label>
-                <div className="flex gap-2">
-                  <input 
-                    type="text" 
-                    placeholder="Enter test name..."
-                    className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500"
-                  />
-                  <button className="px-4 py-2 bg-gray-100 hover:bg-gray-200 rounded-md text-sm font-medium">
-                    Search
-                  </button>
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-2 block">Select test:</label>
-                <div className="space-y-2 max-h-40 overflow-y-auto border border-gray-200 rounded-md p-2">
-                  {[
-                    { name: 'HbA1c (Hemoglobin A1c)', type: 'Numeric' },
-                    { name: 'Breast Cancer Panel', type: 'Select List' },
-                    { name: 'HIV Rapid Test', type: 'Select List' },
-                    { name: 'PSA (Prostate Specific Antigen)', type: 'Numeric' },
-                  ].map((test, i) => (
-                    <label key={i} className="flex items-center gap-2 p-2 hover:bg-gray-50 rounded cursor-pointer">
-                      <input type="radio" name="sourceTest" className="text-teal-600 focus:ring-teal-500" />
-                      <span className="text-sm text-gray-700">{test.name}</span>
-                      <span className={`text-xs px-1.5 py-0.5 rounded ${test.type === 'Select List' ? 'bg-purple-100 text-purple-700' : 'bg-blue-100 text-blue-700'}`}>
-                        {test.type}
-                      </span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-2 block">Interpretations to copy:</label>
-                <div className="space-y-2 border border-gray-200 rounded-md p-3 bg-gray-50 max-h-48 overflow-y-auto">
-                  <label className="flex items-start gap-2 cursor-pointer">
-                    <input type="checkbox" defaultChecked className="mt-1 rounded border-gray-300 text-teal-600" />
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">A1C-NL</code>
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-700">Normal</span>
-                        <span className="text-xs text-gray-500">&lt;5.7%</span>
-                      </div>
-                      <p className="text-xs text-gray-500 mt-0.5">HbA1c within normal range. Continue current management.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-start gap-2 cursor-pointer">
-                    <input type="checkbox" defaultChecked className="mt-1 rounded border-gray-300 text-teal-600" />
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">A1C-PRE</code>
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-700">Prediabetes</span>
-                        <span className="text-xs text-gray-500">5.7-6.4%</span>
-                      </div>
-                      <p className="text-xs text-gray-500 mt-0.5">Consider lifestyle modifications and monitoring.</p>
-                    </div>
-                  </label>
-                  <label className="flex items-start gap-2 cursor-pointer">
-                    <input type="checkbox" defaultChecked className="mt-1 rounded border-gray-300 text-teal-600" />
-                    <div className="flex-1">
-                      <div className="flex items-center gap-2">
-                        <code className="px-1.5 py-0.5 bg-gray-200 text-gray-700 rounded text-xs font-mono">A1C-DM</code>
-                        <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-700">Diabetes</span>
-                        <span className="text-xs text-gray-500">â‰¥6.5%</span>
-                      </div>
-                      <p className="text-xs text-gray-500 mt-0.5">Consistent with diabetes mellitus diagnosis.</p>
-                    </div>
-                  </label>
-                </div>
-              </div>
-
-              <div className="mb-4">
-                <label className="text-sm font-medium text-gray-700 mb-2 block">Import mode:</label>
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="radio" name="importMode" className="text-teal-600 focus:ring-teal-500" />
-                    <span className="text-sm text-gray-700">Replace existing interpretations</span>
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="radio" name="importMode" defaultChecked className="text-teal-600 focus:ring-teal-500" />
-                    <span className="text-sm text-gray-700">Append to existing interpretations</span>
-                  </label>
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-              <button 
-                onClick={() => setShowCopyInterpretationsModal(false)}
-                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-              >
-                Cancel
-              </button>
-              <button className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium">
-                Copy Selected
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ============================================
-// SAMPLE STORAGE TAB
-// ============================================
-
-const SampleStorageTab = () => {
-  const [overrideRestricted, setOverrideRestricted] = useState(false);
-
-  const storageConditions = [
-    { value: 'ultra-low', label: 'Ultra-low freezer (-80Â°C to -60Â°C)', icon: 'ðŸ§Š', temp: '-80Â°C to -60Â°C' },
-    { value: 'freezer', label: 'Freezer (-30Â°C to -15Â°C)', icon: 'â„ï¸', temp: '-30Â°C to -15Â°C' },
-    { value: 'refrigerator', label: 'Refrigerator (2Â°C to 8Â°C)', icon: 'ðŸŒ¡ï¸', temp: '2Â°C to 8Â°C' },
-    { value: 'cold-room', label: 'Cold room (4Â°C to 8Â°C)', icon: 'ðŸŒ¡ï¸', temp: '4Â°C to 8Â°C' },
-    { value: 'cool-room', label: 'Cool room (15Â°C to 18Â°C)', icon: 'ðŸŒ¡ï¸', temp: '15Â°C to 18Â°C' },
-    { value: 'room-temp', label: 'Room temperature (18Â°C to 25Â°C)', icon: 'ðŸ ', temp: '18Â°C to 25Â°C' },
-    { value: 'controlled-room', label: 'Controlled room temp (20Â°C to 25Â°C)', icon: 'ðŸ ', temp: '20Â°C to 25Â°C' },
-    { value: 'warm-incubator', label: 'Warm incubator (35Â°C to 37Â°C)', icon: 'ðŸ”¥', temp: '35Â°C to 37Â°C' },
-    { value: 'ambient', label: 'Ambient (uncontrolled)', icon: 'ðŸŒ¡ï¸', temp: 'Uncontrolled' },
-  ];
-
-  const disposalMethods = [
-    'Biohazard/Infectious waste bin',
-    'Sharps container',
-    'Chemical deactivation',
-    'Incineration',
-    'Autoclave then general waste',
-    'Pharmaceutical waste',
-    'Radioactive waste',
-    'General waste (non-hazardous only)',
-    'Return to manufacturer',
-  ];
-
-  return (
-    <div className="space-y-6">
-      {/* Storage Requirements */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center gap-3 mb-6">
-          <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-            <Thermometer className="text-blue-600" size={20} />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Storage Requirements</h2>
-            <p className="text-sm text-gray-500">Define how samples for this test should be stored</p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Storage Conditions <span className="text-red-500">*</span>
-            </label>
-            <select className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
-              <option value="">Select storage conditions...</option>
-              {storageConditions.map(cond => (
-                <option key={cond.value} value={cond.value}>
-                  {cond.icon} {cond.label}
-                </option>
-              ))}
-              <option value="custom">Custom (specify below)</option>
-            </select>
-            <p className="text-xs text-gray-500 mt-1">Temperature range for sample preservation</p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Custom Storage Conditions
-            </label>
-            <input 
-              type="text"
-              placeholder="e.g., 2-8Â°C, protected from light"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-            />
-            <p className="text-xs text-gray-500 mt-1">Override or add details to selected condition</p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Maximum Storage Duration <span className="text-red-500">*</span>
-            </label>
-            <div className="flex gap-2">
-              <input 
-                type="number"
-                min="1"
-                defaultValue="72"
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              />
-              <select className="w-32 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
-                <option value="hours">Hours</option>
-                <option value="days">Days</option>
-                <option value="weeks">Weeks</option>
-                <option value="months">Months</option>
-              </select>
-            </div>
-            <p className="text-xs text-gray-500 mt-1">Maximum time sample can be stored before testing</p>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Stability Notes
-            </label>
-            <input 
-              type="text"
-              placeholder="e.g., Stable for 7 days refrigerated, 1 month frozen"
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-            />
-          </div>
-        </div>
-
-        {/* Special Handling Requirements */}
-        <div className="mt-6 pt-6 border-t border-gray-200">
-          <label className="block text-sm font-medium text-gray-700 mb-3">Special Handling Requirements</label>
-          <div className="flex flex-wrap gap-4">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">ðŸ”† Protect from light</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">â„ï¸ Do not freeze</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">ðŸ”¥ Do not refrigerate</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">â¬†ï¸ Keep upright</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">ðŸ§ª Centrifuge before storage</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-              <span className="text-sm text-gray-700">âš—ï¸ Aliquot before storage</span>
-            </label>
-          </div>
-        </div>
-      </div>
-
-      {/* Disposal Requirements */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center gap-3 mb-6">
-          <div className="w-10 h-10 bg-red-100 rounded-lg flex items-center justify-center">
-            <Trash2 className="text-red-600" size={20} />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Disposal Requirements</h2>
-            <p className="text-sm text-gray-500">Define how samples should be disposed after testing</p>
-          </div>
-        </div>
-
-        <div className="grid grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Disposal Method <span className="text-red-500">*</span>
-            </label>
-            <select className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
-              <option value="">Select disposal method...</option>
-              {disposalMethods.map(method => (
-                <option key={method} value={method}>{method}</option>
-              ))}
-            </select>
-          </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Disposal Timeframe
-            </label>
-            <div className="flex gap-2">
-              <input 
-                type="number"
-                min="1"
-                placeholder="e.g., 7"
-                className="flex-1 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-              />
-              <select className="w-32 px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500">
-                <option value="days">Days</option>
-                <option value="weeks">Weeks</option>
-                <option value="months">Months</option>
-              </select>
-            </div>
-            <p className="text-xs text-gray-500 mt-1">Maximum time after test completion before disposal</p>
-          </div>
-        </div>
-      </div>
-
-      {/* Special Instructions */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center gap-3 mb-6">
-          <div className="w-10 h-10 bg-yellow-100 rounded-lg flex items-center justify-center">
-            <AlertTriangle className="text-yellow-600" size={20} />
-          </div>
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Special Instructions</h2>
-            <p className="text-sm text-gray-500">Additional guidance for sample handling</p>
-          </div>
-        </div>
-
-        <textarea
-          rows={4}
-          placeholder="Enter any special instructions for sample handling, storage, or disposal that don't fit in the fields above..."
-          className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-        />
-      </div>
-
-      {/* Override Settings */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-start gap-4">
-          <input 
-            type="checkbox"
-            checked={overrideRestricted}
-            onChange={(e) => setOverrideRestricted(e.target.checked)}
-            className="w-5 h-5 mt-0.5 rounded border-gray-300 text-red-600 focus:ring-red-500"
-          />
-          <div>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-semibold text-gray-900">Override Restricted</h3>
-              <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-700">
-                Locked
-              </span>
-            </div>
-            <p className="text-sm text-gray-500 mt-1">
-              When enabled, order entry staff cannot modify storage or disposal requirements for this test. 
-              Use for critical tests where sample handling must be strictly controlled (e.g., HIV, controlled substances).
-            </p>
-            
-            {overrideRestricted && (
-              <div className="mt-3 p-3 bg-red-50 border border-red-200 rounded-lg">
-                <div className="flex items-center gap-2 text-red-700 text-sm">
-                  <AlertCircle size={16} />
-                  <span className="font-medium">Storage and disposal settings are locked</span>
-                </div>
-                <p className="text-xs text-red-600 mt-1">
-                  Only Lab Managers can modify these requirements. Order entry staff will see these as read-only.
-                </p>
-              </div>
-            )}
-          </div>
-        </div>
-      </div>
-
-      {/* Quick Reference Card */}
-      <div className="bg-gradient-to-r from-blue-50 to-teal-50 rounded-lg border border-blue-200 p-6">
-        <h3 className="text-sm font-semibold text-gray-900 mb-3">ðŸ“‹ Storage Condition Quick Reference</h3>
-        <div className="grid grid-cols-3 gap-4 text-sm">
-          <div>
-            <p className="font-medium text-gray-700">Ultra-low Freezer</p>
-            <p className="text-gray-600">-80Â°C to -60Â°C</p>
-          </div>
-          <div>
-            <p className="font-medium text-gray-700">Freezer</p>
-            <p className="text-gray-600">-30Â°C to -15Â°C</p>
-          </div>
-          <div>
-            <p className="font-medium text-gray-700">Refrigerator</p>
-            <p className="text-gray-600">2Â°C to 8Â°C</p>
-          </div>
-          <div>
-            <p className="font-medium text-gray-700">Cool Room</p>
-            <p className="text-gray-600">15Â°C to 18Â°C</p>
-          </div>
-          <div>
-            <p className="font-medium text-gray-700">Room Temperature</p>
-            <p className="text-gray-600">18Â°C to 25Â°C</p>
-          </div>
-          <div>
-            <p className="font-medium text-gray-700">Warm Incubator</p>
-            <p className="text-gray-600">35Â°C to 37Â°C</p>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// LABELS TAB
-// ============================================
-
-const LabelsTab = () => {
-  const [labelConfigs, setLabelConfigs] = useState([
-    { id: 1, presetId: 'specimen', presetName: 'Specimen Label', defaultQty: 1, maxQty: 5, allowOverride: true },
-    { id: 2, presetId: 'block', presetName: 'Block Label', defaultQty: 4, maxQty: 20, allowOverride: true },
-    { id: 3, presetId: 'slide', presetName: 'Slide Label', defaultQty: 12, maxQty: 50, allowOverride: true },
-    { id: 4, presetId: 'freezer', presetName: 'Freezer Label', defaultQty: 2, maxQty: 10, allowOverride: false },
-  ]);
-  const [allowCountOverride, setAllowCountOverride] = useState(true);
-
-  const availablePresets = [
-    { id: 'order', name: 'Order Label', category: 'Order', size: '50 Ã— 25 mm' },
-    { id: 'specimen', name: 'Specimen Label', category: 'Specimen', size: '50 Ã— 25 mm' },
-    { id: 'block', name: 'Block Label', category: 'Pathology', size: '26 Ã— 12 mm' },
-    { id: 'slide', name: 'Slide Label', category: 'Pathology', size: '76 Ã— 26 mm' },
-    { id: 'freezer', name: 'Freezer Label', category: 'Storage', size: '38 Ã— 19 mm' },
-    { id: 'cryo', name: 'Cryo Vial Label', category: 'Storage', size: '32 Ã— 13 mm' },
-  ];
-
-  const handleRemoveLabel = (id) => {
-    setLabelConfigs(labelConfigs.filter(c => c.id !== id));
-  };
-
-  const handleAddLabel = () => {
-    const nextId = Math.max(...labelConfigs.map(c => c.id), 0) + 1;
-    setLabelConfigs([...labelConfigs, {
-      id: nextId,
-      presetId: '',
-      presetName: '',
-      defaultQty: 1,
-      maxQty: 10,
-      allowOverride: true
-    }]);
-  };
-
-  return (
-    <div className="space-y-6">
-      {/* Default Labels Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Default Labels for This Test</h2>
-            <p className="text-sm text-gray-500 mt-1">When this test is ordered, automatically suggest these labels</p>
-          </div>
-          <button 
-            onClick={handleAddLabel}
-            className="flex items-center gap-2 px-3 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium"
-          >
-            <Plus size={16} />
-            Add Label Type
-          </button>
-        </div>
-
-        {labelConfigs.length > 0 ? (
-          <div className="border border-gray-200 rounded-lg overflow-hidden">
-            <table className="w-full">
-              <thead className="bg-gray-50">
-                <tr>
-                  <th className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase">Label Preset</th>
-                  <th className="px-4 py-3 text-center text-xs font-semibold text-gray-500 uppercase w-28">Default Qty</th>
-                  <th className="px-4 py-3 text-center text-xs font-semibold text-gray-500 uppercase w-28">Max Qty</th>
-                  <th className="px-4 py-3 text-center text-xs font-semibold text-gray-500 uppercase w-32">Allow Override</th>
-                  <th className="px-4 py-3 text-right text-xs font-semibold text-gray-500 uppercase w-20">Actions</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-gray-100">
-                {labelConfigs.map((config) => (
-                  <tr key={config.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3">
-                      <select 
-                        value={config.presetId}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500 text-sm"
-                      >
-                        <option value="">Select preset...</option>
-                        {availablePresets.map(preset => (
-                          <option key={preset.id} value={preset.id}>
-                            {preset.name} ({preset.category} - {preset.size})
-                          </option>
-                        ))}
-                      </select>
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <input 
-                        type="number" 
-                        min="1" 
-                        value={config.defaultQty}
-                        className="w-20 px-3 py-2 border border-gray-300 rounded-md text-center focus:ring-2 focus:ring-teal-500 text-sm"
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <input 
-                        type="number" 
-                        min="1" 
-                        value={config.maxQty}
-                        className="w-20 px-3 py-2 border border-gray-300 rounded-md text-center focus:ring-2 focus:ring-teal-500 text-sm"
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-center">
-                      <input 
-                        type="checkbox" 
-                        checked={config.allowOverride}
-                        className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                      />
-                    </td>
-                    <td className="px-4 py-3 text-right">
-                      <button 
-                        onClick={() => handleRemoveLabel(config.id)}
-                        className="p-1 text-gray-400 hover:text-red-600"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        ) : (
-          <div className="border border-dashed border-gray-300 rounded-lg p-8 text-center">
-            <Printer size={32} className="mx-auto text-gray-400 mb-2" />
-            <p className="text-gray-500">No label types configured</p>
-            <p className="text-sm text-gray-400 mt-1">Add label presets to automatically suggest labels when this test is ordered</p>
-          </div>
-        )}
-      </div>
-
-      {/* Label Generation Settings */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h3 className="text-sm font-semibold text-gray-700 mb-4">Label Generation Settings</h3>
-        <label className="flex items-center gap-2 cursor-pointer">
-          <input 
-            type="checkbox" 
-            checked={allowCountOverride}
-            onChange={(e) => setAllowCountOverride(e.target.checked)}
-            className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-          />
-          <span className="text-sm text-gray-700">Allow label count override at order entry</span>
-        </label>
-        <p className="text-xs text-gray-500 mt-2 ml-6">
-          When enabled, users can modify label quantities during order entry. Individual label types can still be locked via the "Allow Override" column above.
-        </p>
-      </div>
-
-      {/* Order Entry Preview */}
-      <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
-        <h3 className="text-sm font-semibold text-blue-900 mb-3 flex items-center gap-2">
-          <Info size={16} />
-          Order Entry Preview
-        </h3>
-        <p className="text-sm text-blue-800 mb-4">
-          When this test is ordered, the Labels section will be pre-populated as follows:
-        </p>
-        <div className="bg-white rounded-lg border border-blue-200 p-4">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-gray-200">
-                <th className="pb-2 text-left font-medium text-gray-700">Label Type</th>
-                <th className="pb-2 text-center font-medium text-gray-700 w-20">Qty</th>
-                <th className="pb-2 text-left font-medium text-gray-700">Source</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {labelConfigs.filter(c => c.presetId).map(config => (
-                <tr key={config.id}>
-                  <td className="py-2 text-gray-900">{config.presetName || 'Label'}</td>
-                  <td className="py-2 text-center">
-                    {config.allowOverride ? (
-                      <span className="text-gray-900">{config.defaultQty}</span>
-                    ) : (
-                      <span className="text-gray-500 bg-gray-100 px-2 py-0.5 rounded">{config.defaultQty}</span>
-                    )}
-                  </td>
-                  <td className="py-2 text-gray-500 text-xs">This test</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          {labelConfigs.some(c => !c.allowOverride) && (
-            <p className="text-xs text-gray-500 mt-3 flex items-center gap-1">
-              <AlertCircle size={12} />
-              Gray quantities are locked and cannot be modified at order entry
-            </p>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// TERMINOLOGY MAPPINGS TAB
-// ============================================
-
-const TerminologyMappingsTab = () => {
-  const [mappings] = useState([
-    { id: 1, source: 'LOINC', code: '1558-6', relationship: 'SAME_AS', displayName: 'Fasting glucose [Mass/volume] in Serum or Plasma' },
-    { id: 2, source: 'SNOMED', code: '271062006', relationship: 'SAME_AS', displayName: 'Fasting blood glucose measurement' },
-  ]);
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Terminology Mappings</h2>
-          <p className="text-sm text-gray-500 mt-1">Link this test to standard terminology codes for interoperability</p>
-        </div>
-        <button className="flex items-center gap-2 text-teal-600 hover:text-teal-700 font-medium text-sm">
-          <Plus size={16} />
-          Add Mapping
-        </button>
-      </div>
-
-      <div className="space-y-4">
-        {mappings.map((mapping) => (
-          <div key={mapping.id} className="p-4 border border-gray-200 rounded-lg hover:border-gray-300">
-            <div className="flex items-start justify-between">
-              <div className="flex items-start gap-4">
-                <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold ${
-                  mapping.source === 'LOINC' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700'
-                }`}>
-                  {mapping.source}
-                </span>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm font-medium text-gray-900">{mapping.code}</span>
-                    <span className="inline-flex items-center px-2 py-0.5 rounded text-xs bg-teal-100 text-teal-700">
-                      {mapping.relationship.replace('_', ' ')}
-                    </span>
-                  </div>
-                  <p className="text-sm text-gray-600 mt-1">{mapping.displayName}</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2">
-                <button className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded"><Edit size={16} /></button>
-                <button className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"><Trash2 size={16} /></button>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Add Mapping Form */}
-      <div className="mt-6 p-4 border-2 border-dashed border-gray-300 rounded-lg">
-        <h3 className="text-sm font-semibold text-gray-700 mb-4">Add New Mapping</h3>
-        <div className="grid grid-cols-4 gap-4">
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Terminology Source</label>
-            <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
-              <option value="">Select...</option>
-              <option value="LOINC">LOINC</option>
-              <option value="SNOMED">SNOMED CT</option>
-              <option value="CIEL">CIEL</option>
-              <option value="OCL">Open Concept Lab</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Code</label>
-            <input type="text" placeholder="Enter code" className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm" />
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">Relationship</label>
-            <select className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm">
-              <option value="SAME_AS">Same As</option>
-              <option value="BROADER_THAN">Broader Than</option>
-              <option value="NARROWER_THAN">Narrower Than</option>
-            </select>
-          </div>
-          <div className="flex items-end">
-            <button className="w-full px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md text-sm font-medium">Add</button>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// REAGENT LINKING TAB
-// ============================================
-
-const ReagentLinkingTab = () => {
-  const [linkedReagents] = useState([
-    { id: 1, name: 'Glucose Reagent R1', manufacturer: 'Roche', usageType: 'PRIMARY', quantityPerTest: 100, unit: 'ÂµL', stockLevel: 2500 },
-    { id: 2, name: 'Glucose Reagent R2', manufacturer: 'Roche', usageType: 'SECONDARY', quantityPerTest: 50, unit: 'ÂµL', stockLevel: 1200 },
-  ]);
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Associated Reagents</h2>
-          <p className="text-sm text-gray-500 mt-1">Link reagents from inventory to track consumption</p>
-        </div>
-        <button className="flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-3 py-2 rounded-md text-sm font-medium">
-          <Plus size={16} />
-          Link Reagent
-        </button>
-      </div>
-
-      <div className="space-y-3">
-        {linkedReagents.map((reagent) => (
-          <div key={reagent.id} className="p-4 border border-gray-200 rounded-lg">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-4">
-                <div className="w-10 h-10 bg-teal-100 rounded-lg flex items-center justify-center">
-                  <FlaskConical className="text-teal-600" size={20} />
-                </div>
-                <div>
-                  <div className="flex items-center gap-2">
-                    <span className="font-medium text-gray-900">{reagent.name}</span>
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                      reagent.usageType === 'PRIMARY' ? 'bg-blue-100 text-blue-700' : 'bg-green-100 text-green-700'
-                    }`}>
-                      {reagent.usageType}
-                    </span>
-                  </div>
-                  <p className="text-sm text-gray-500">{reagent.manufacturer} â€¢ {reagent.quantityPerTest} {reagent.unit} per test</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-4">
-                <div className="text-right">
-                  <span className="text-sm font-medium text-gray-900">{reagent.stockLevel.toLocaleString()} {reagent.unit}</span>
-                  <p className="text-xs text-gray-500">Current Stock</p>
-                </div>
-                <button className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"><X size={16} /></button>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// ANALYZER LINKING TAB
-// ============================================
-
-const AnalyzerLinkingTab = () => {
-  const [showLinkModal, setShowLinkModal] = useState(false);
-  const [linkedAnalyzers, setLinkedAnalyzers] = useState([
-    { id: 1, name: 'Cobas c 501', manufacturer: 'Roche', serialNumber: 'SN-2024-0142', location: 'Chemistry Lab A', status: 'Online' },
-    { id: 2, name: 'Cobas c 502', manufacturer: 'Roche', serialNumber: 'SN-2024-0143', location: 'Chemistry Lab B', status: 'Online' },
-  ]);
-
-  // Available analyzers from Master Lists (not yet linked)
-  const availableAnalyzers = [
-    { id: 3, name: 'AU680', manufacturer: 'Beckman Coulter', serialNumber: 'SN-2023-0098', location: 'Chemistry Lab A', status: 'Online' },
-    { id: 4, name: 'Architect c8000', manufacturer: 'Abbott', serialNumber: 'SN-2022-0456', location: 'Chemistry Lab C', status: 'Maintenance' },
-    { id: 5, name: 'Vitros 5600', manufacturer: 'Ortho Clinical', serialNumber: 'SN-2024-0201', location: 'STAT Lab', status: 'Online' },
-  ];
-
-  const [selectedAnalyzers, setSelectedAnalyzers] = useState([]);
-
-  const handleToggleAnalyzer = (id) => {
-    setSelectedAnalyzers(prev => 
-      prev.includes(id) ? prev.filter(a => a !== id) : [...prev, id]
-    );
-  };
-
-  const handleLinkAnalyzers = () => {
-    const newAnalyzers = availableAnalyzers.filter(a => selectedAnalyzers.includes(a.id));
-    setLinkedAnalyzers([...linkedAnalyzers, ...newAnalyzers]);
-    setShowLinkModal(false);
-    setSelectedAnalyzers([]);
-  };
-
-  const handleUnlinkAnalyzer = (id) => {
-    if (confirm('Are you sure you want to unlink this analyzer?')) {
-      setLinkedAnalyzers(linkedAnalyzers.filter(a => a.id !== id));
-    }
-  };
-
-  return (
-    <div className="space-y-6">
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Linked Analyzers</h2>
-            <p className="text-sm text-gray-500 mt-1">Select which analyzers can perform this test</p>
-          </div>
-          <button 
-            onClick={() => setShowLinkModal(true)}
-            className="flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-3 py-2 rounded-md text-sm font-medium"
-          >
-            <Plus size={16} />
-            Link Analyzer
-          </button>
-        </div>
-
-        {linkedAnalyzers.length > 0 ? (
-          <div className="space-y-3">
-            {linkedAnalyzers.map((analyzer) => (
-              <div key={analyzer.id} className="p-4 border border-gray-200 rounded-lg hover:border-gray-300">
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
-                      <Cpu className="text-gray-600" size={20} />
-                    </div>
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <span className="font-medium text-gray-900">{analyzer.name}</span>
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                          analyzer.status === 'Online' ? 'bg-green-100 text-green-700' : 
-                          analyzer.status === 'Maintenance' ? 'bg-yellow-100 text-yellow-700' : 
-                          'bg-red-100 text-red-700'
-                        }`}>
-                          {analyzer.status}
-                        </span>
-                      </div>
-                      <p className="text-sm text-gray-500">{analyzer.manufacturer} â€¢ {analyzer.location}</p>
-                      <p className="text-xs text-gray-400 mt-0.5">S/N: {analyzer.serialNumber}</p>
-                    </div>
-                  </div>
-                  <button 
-                    onClick={() => handleUnlinkAnalyzer(analyzer.id)}
-                    className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded"
-                    title="Unlink analyzer"
-                  >
-                    <X size={16} />
-                  </button>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="border border-dashed border-gray-300 rounded-lg p-8 text-center">
-            <Cpu size={32} className="mx-auto text-gray-400 mb-2" />
-            <p className="text-gray-500">No analyzers linked</p>
-            <p className="text-sm text-gray-400 mt-1">Link analyzers that can perform this test</p>
-          </div>
-        )}
-      </div>
-
-      {/* Info Card */}
-      <div className="bg-blue-50 rounded-lg border border-blue-200 p-4">
-        <div className="flex gap-3">
-          <Info className="text-blue-600 flex-shrink-0 mt-0.5" size={18} />
-          <div className="text-sm text-blue-800">
-            <p className="font-medium mb-1">About Analyzer Linking</p>
-            <ul className="space-y-1 text-blue-700">
-              <li>â€¢ Analyzers are configured in <span className="font-medium">Administration â†’ Master Lists â†’ Analyzers</span></li>
-              <li>â€¢ Test code mapping is configured separately in the analyzer interface setup</li>
-              <li>â€¢ Linking an analyzer indicates this test can be performed on that instrument</li>
-            </ul>
-          </div>
-        </div>
-      </div>
-
-      {/* Link Analyzer Modal */}
-      {showLinkModal && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-lg">
-            <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Link Analyzers</h3>
-              <button onClick={() => setShowLinkModal(false)} className="text-gray-400 hover:text-gray-600">
-                <X size={20} />
-              </button>
-            </div>
-            <div className="p-6">
-              {/* Analyzer Selection */}
-              <div>
-                <label className="text-sm font-medium text-gray-700 mb-2 block">
-                  Select Analyzers
-                </label>
-                <div className="border border-gray-300 rounded-md max-h-64 overflow-y-auto">
-                  {availableAnalyzers.filter(a => !linkedAnalyzers.find(la => la.id === a.id)).map(analyzer => (
-                    <label 
-                      key={analyzer.id} 
-                      className={`flex items-center gap-3 p-3 cursor-pointer hover:bg-gray-50 border-b border-gray-100 last:border-b-0 ${
-                        selectedAnalyzers.includes(analyzer.id) ? 'bg-teal-50' : ''
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={selectedAnalyzers.includes(analyzer.id)}
-                        onChange={() => handleToggleAnalyzer(analyzer.id)}
-                        className="rounded border-gray-300 text-teal-600 focus:ring-teal-500"
-                      />
-                      <div className="flex-1">
-                        <div className="flex items-center gap-2">
-                          <span className="font-medium text-gray-900">{analyzer.name}</span>
-                          <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${
-                            analyzer.status === 'Online' ? 'bg-green-100 text-green-700' : 
-                            analyzer.status === 'Maintenance' ? 'bg-yellow-100 text-yellow-700' : 
-                            'bg-red-100 text-red-700'
-                          }`}>
-                            {analyzer.status}
-                          </span>
-                        </div>
-                        <p className="text-sm text-gray-500">{analyzer.manufacturer} â€¢ {analyzer.location}</p>
-                      </div>
-                    </label>
-                  ))}
-                  {availableAnalyzers.filter(a => !linkedAnalyzers.find(la => la.id === a.id)).length === 0 && (
-                    <div className="p-4 text-center text-gray-500 text-sm">
-                      All available analyzers are already linked
-                    </div>
-                  )}
-                </div>
-              </div>
-
-              {selectedAnalyzers.length > 0 && (
-                <p className="text-sm text-gray-600 mt-3">
-                  {selectedAnalyzers.length} analyzer{selectedAnalyzers.length !== 1 ? 's' : ''} selected
-                </p>
-              )}
-            </div>
-            <div className="flex items-center justify-end gap-3 px-6 py-4 bg-gray-50 border-t border-gray-200 rounded-b-lg">
-              <button 
-                onClick={() => setShowLinkModal(false)}
-                className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800"
-              >
-                Cancel
-              </button>
-              <button 
-                onClick={handleLinkAnalyzers}
-                disabled={selectedAnalyzers.length === 0}
-                className="px-4 py-2 bg-teal-600 hover:bg-teal-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white rounded-md text-sm font-medium"
-              >
-                Link Selected
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ============================================
-// ALERT RULES TAB
-// ============================================
-
-const AlertRulesTab = () => {
-  const [showAddRule, setShowAddRule] = useState(false);
-  const [alertRules, setAlertRules] = useState([
-    {
-      id: 1,
-      name: 'Critical Value Alert',
-      enabled: true,
-      triggerType: 'critical',
-      channels: ['sms', 'email'],
-      recipients: { orderingPhysician: true, patient: false, custom: null },
-      smsTemplate: 'CRITICAL: {{test_name}} result {{result}} {{unit}} for {{patient_name}}. Please review immediately.'
-    },
-    {
-      id: 2,
-      name: 'Abnormal Result Notification',
-      enabled: true,
-      triggerType: 'abnormal',
-      channels: ['email'],
-      recipients: { orderingPhysician: true, patient: false, custom: null },
-      smsTemplate: ''
-    },
-    {
-      id: 3,
-      name: 'Positive Result Alert',
-      enabled: false,
-      triggerType: 'specific',
-      triggerValue: 'Positive',
-      channels: ['sms'],
-      recipients: { orderingPhysician: false, patient: true, custom: null },
-      smsTemplate: 'Lab result ready for {{patient_name}}. Please contact your healthcare provider.'
-    }
-  ]);
-
-  const getTriggerLabel = (type, value) => {
-    switch(type) {
-      case 'all': return 'All Results';
-      case 'abnormal': return 'Abnormal (High or Low)';
-      case 'critical': return 'Critical Value';
-      case 'specific': return `Equals "${value}"`;
-      default: return type;
-    }
-  };
-
-  const toggleRule = (id) => {
-    setAlertRules(prev => prev.map(rule => 
-      rule.id === id ? { ...rule, enabled: !rule.enabled } : rule
-    ));
-  };
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h2 className="text-lg font-semibold text-gray-900">Alert Rules</h2>
-          <p className="text-sm text-gray-500 mt-1">Configure automated notifications when specific result conditions are met</p>
-        </div>
-        <button 
-          onClick={() => setShowAddRule(true)}
-          className="flex items-center gap-2 bg-teal-600 hover:bg-teal-700 text-white px-4 py-2 rounded-md font-medium text-sm"
+      {showInterpModal && (
+        <Modal
+          open={showInterpModal}
+          onRequestClose={() => setShowInterpModal(false)}
+          modalHeading={t('admin.testCatalog.sampleResults.modal.addInterpretation', 'Add Interpretation')}
+          primaryButtonText={t('admin.testCatalog.common.button.add', 'Add')}
+          secondaryButtonText={t('admin.testCatalog.common.button.cancel', 'Cancel')}
         >
-          <Plus size={16} />
-          Add Rule
-        </button>
-      </div>
-
-      {/* Alert Rules List */}
-      <div className="space-y-4">
-        {alertRules.map((rule) => (
-          <div 
-            key={rule.id} 
-            className={`border rounded-lg overflow-hidden ${rule.enabled ? 'border-gray-200' : 'border-gray-200 bg-gray-50'}`}
-          >
-            {/* Rule Header */}
-            <div className="flex items-center justify-between p-4 bg-gray-50 border-b border-gray-200">
-              <div className="flex items-center gap-3">
-                <div className={`w-2 h-2 rounded-full ${rule.enabled ? 'bg-green-500' : 'bg-gray-300'}`} />
-                <span className="font-medium text-gray-900">{rule.name}</span>
-                <span className={`text-xs px-2 py-0.5 rounded ${rule.enabled ? 'bg-green-100 text-green-700' : 'bg-gray-200 text-gray-500'}`}>
-                  {rule.enabled ? 'Enabled' : 'Disabled'}
-                </span>
-              </div>
-              <div className="flex items-center gap-2">
-                <button 
-                  onClick={() => toggleRule(rule.id)}
-                  className="text-sm text-gray-600 hover:text-gray-900"
-                >
-                  {rule.enabled ? 'Disable' : 'Enable'}
-                </button>
-                <button className="p-1.5 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded">
-                  <Edit size={16} />
-                </button>
-                <button className="p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded">
-                  <Trash2 size={16} />
-                </button>
-              </div>
-            </div>
-            
-            {/* Rule Details */}
-            <div className="p-4 space-y-3">
-              <div className="flex items-center gap-8">
-                <div>
-                  <span className="text-xs text-gray-500 uppercase tracking-wider">When</span>
-                  <p className="text-sm text-gray-900 mt-1">
-                    Result is <span className="font-medium text-teal-700">{getTriggerLabel(rule.triggerType, rule.triggerValue)}</span>
-                  </p>
-                </div>
-                <div>
-                  <span className="text-xs text-gray-500 uppercase tracking-wider">Notify Via</span>
-                  <div className="flex items-center gap-2 mt-1">
-                    {rule.channels.includes('sms') && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-blue-100 text-blue-700 text-xs">
-                        <Phone size={12} /> SMS
-                      </span>
-                    )}
-                    {rule.channels.includes('email') && (
-                      <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded bg-purple-100 text-purple-700 text-xs">
-                        <Mail size={12} /> Email
-                      </span>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <span className="text-xs text-gray-500 uppercase tracking-wider">Recipients</span>
-                  <div className="flex items-center gap-2 mt-1">
-                    {rule.recipients.orderingPhysician && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded bg-gray-100 text-gray-700 text-xs">
-                        Ordering Physician
-                      </span>
-                    )}
-                    {rule.recipients.patient && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded bg-gray-100 text-gray-700 text-xs">
-                        Patient
-                      </span>
-                    )}
-                    {rule.recipients.custom && (
-                      <span className="inline-flex items-center px-2 py-0.5 rounded bg-gray-100 text-gray-700 text-xs">
-                        {rule.recipients.custom}
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-              
-              {rule.smsTemplate && (
-                <div className="pt-3 border-t border-gray-100">
-                  <span className="text-xs text-gray-500 uppercase tracking-wider">SMS Template</span>
-                  <p className="text-sm text-gray-600 mt-1 font-mono bg-gray-50 p-2 rounded">
-                    {rule.smsTemplate}
-                  </p>
-                </div>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {alertRules.length === 0 && (
-        <div className="p-8 border-2 border-dashed border-gray-300 rounded-lg text-center">
-          <Bell className="mx-auto text-gray-400 mb-3" size={32} />
-          <p className="text-gray-600">No alert rules configured</p>
-          <button 
-            onClick={() => setShowAddRule(true)}
-            className="mt-2 text-teal-600 hover:text-teal-700 font-medium text-sm"
-          >
-            + Add your first alert rule
-          </button>
-        </div>
-      )}
-
-      {/* Add Rule Modal */}
-      {showAddRule && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <div className="flex items-center justify-between p-4 border-b border-gray-200">
-              <h3 className="text-lg font-semibold text-gray-900">Add Alert Rule</h3>
-              <button onClick={() => setShowAddRule(false)} className="text-gray-400 hover:text-gray-600">
-                <X size={20} />
-              </button>
-            </div>
-            
-            <div className="p-6 space-y-6">
-              {/* Rule Name */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Rule Name</label>
-                <input 
-                  type="text" 
-                  placeholder="e.g., Critical Value SMS Alert"
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                />
-              </div>
-
-              {/* Trigger Condition */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-3">Alert when result is:</label>
-                <div className="space-y-2">
-                  {[
-                    { value: 'all', label: 'All Results' },
-                    { value: 'abnormal', label: 'Abnormal (outside normal range)' },
-                    { value: 'critical', label: 'Critical (panic value)' },
-                    { value: 'specific', label: 'Specific Value' },
-                  ].map(option => (
-                    <label key={option.value} className="flex items-center gap-3 cursor-pointer">
-                      <input type="radio" name="trigger" value={option.value} className="text-teal-600 focus:ring-teal-500" />
-                      <span className="text-sm text-gray-700">{option.label}</span>
-                    </label>
-                  ))}
-                </div>
-              </div>
-
-              {/* Notification Channels */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-3">Send via:</label>
-                <div className="flex items-center gap-6">
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                    <Phone size={16} className="text-gray-500" />
-                    <span className="text-sm text-gray-700">SMS</span>
-                  </label>
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                    <Mail size={16} className="text-gray-500" />
-                    <span className="text-sm text-gray-700">Email</span>
-                  </label>
-                </div>
-              </div>
-
-              {/* Recipients */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-3">Recipients:</label>
-                <div className="space-y-3">
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                    <span className="text-sm text-gray-700">Ordering Physician (from order)</span>
-                  </label>
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                    <span className="text-sm text-gray-700">Patient (from patient record)</span>
-                  </label>
-                  <label className="flex items-center gap-3 cursor-pointer">
-                    <input type="checkbox" className="rounded border-gray-300 text-teal-600 focus:ring-teal-500" />
-                    <span className="text-sm text-gray-700">Custom recipient:</span>
-                  </label>
-                  <div className="ml-7 grid grid-cols-2 gap-3">
-                    <input 
-                      type="text" 
-                      placeholder="Phone: +1 555-123-4567"
-                      className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                    />
-                    <input 
-                      type="email" 
-                      placeholder="Email: user@example.com"
-                      className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                    />
-                  </div>
-                </div>
-              </div>
-
-              {/* SMS Template */}
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">SMS Template (160 char recommended)</label>
-                <textarea 
-                  rows={3}
-                  placeholder="CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}. Review immediately."
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm font-mono focus:ring-2 focus:ring-teal-500 focus:border-teal-500"
-                />
-                <p className="text-xs text-gray-500 mt-1">
-                  Variables: {"{{patient_name}}, {{patient_id}}, {{test_name}}, {{result}}, {{unit}}, {{reference_range}}"}
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center justify-end gap-3 p-4 border-t border-gray-200 bg-gray-50">
-              <button 
-                onClick={() => setShowAddRule(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-100 font-medium"
-              >
-                Cancel
-              </button>
-              <button className="px-4 py-2 bg-teal-600 hover:bg-teal-700 text-white rounded-md font-medium">
-                Save Alert Rule
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-    </div>
-  );
-};
-
-// ============================================
-// REFLEX & CALCULATED RESULTS TAB
-// ============================================
-
-const ReflexCalculatedTab = () => {
-  const reflexRules = [
-    {
-      id: 1,
-      condition: '> 200 mg/dL',
-      targetTests: ['Hemoglobin A1c'],
-      mode: 'suggest'
-    },
-    {
-      id: 2,
-      condition: '= "Abnormal"',
-      targetTests: ['Glucose Tolerance Test'],
-      mode: 'auto'
-    }
-  ];
-
-  const incomingReflex = [
-    {
-      id: 101,
-      sourceTest: 'Glucose Tolerance Test',
-      condition: '2-hour result > 140',
-    }
-  ];
-
-  const calculationsUsingThis = [
-    {
-      id: 201,
-      name: 'LDL Cholesterol (Calculated)',
-      formula: 'Total_Chol - HDL - (Triglycerides / 5)',
-      variableUsed: 'Not used - this test is Glucose'
-    }
-  ];
-
-  const isCalculatedResult = false; // This test is not a calculated result
-
-  return (
-    <div className="space-y-6">
-      {/* Reflex Tests Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Reflex Tests</h2>
-            <p className="text-sm text-gray-500 mt-1">Automatic test ordering based on results</p>
-          </div>
-        </div>
-
-        {/* Rules triggered BY this test */}
-        <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-3">Rules triggered BY this test:</h3>
-          {reflexRules.length > 0 ? (
-            <div className="space-y-3">
-              {reflexRules.map((rule) => (
-                <div key={rule.id} className="p-4 border border-gray-200 rounded-lg bg-gray-50">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-4">
-                      <div className="text-sm">
-                        <span className="text-gray-500">IF result</span>{' '}
-                        <span className="font-medium text-gray-900">{rule.condition}</span>{' '}
-                        <span className="text-gray-500">â†’ ORDER</span>{' '}
-                        <span className="font-medium text-teal-700">{rule.targetTests.join(', ')}</span>
-                      </div>
-                      <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                        rule.mode === 'auto' ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
-                      }`}>
-                        {rule.mode === 'auto' ? 'Auto-order' : 'Suggest'}
-                      </span>
-                    </div>
-                    <a 
-                      href={`/MasterListsPage#reflex?ruleId=${rule.id}`}
-                      className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
-                    >
-                      Edit in Master Lists
-                      <ChevronRight size={14} />
-                    </a>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-gray-500 italic p-4 bg-gray-50 rounded-lg">
-              No reflex rules configured for this test
-            </p>
-          )}
-        </div>
-
-        {/* Rules that ORDER this test */}
-        <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-3">Rules that ORDER this test:</h3>
-          {incomingReflex.length > 0 ? (
-            <div className="space-y-3">
-              {incomingReflex.map((rule) => (
-                <div key={rule.id} className="p-4 border border-blue-200 rounded-lg bg-blue-50">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      <span className="text-blue-400">â†³</span>
-                      <span className="text-sm text-gray-700">
-                        <span className="font-medium text-gray-900">{rule.sourceTest}</span>
-                        <span className="text-gray-500"> when {rule.condition}</span>
-                      </span>
-                    </div>
-                    <a 
-                      href={`/MasterListsPage#reflex?ruleId=${rule.id}`}
-                      className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
-                    >
-                      Edit in Master Lists
-                      <ChevronRight size={14} />
-                    </a>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-gray-500 italic p-4 bg-gray-50 rounded-lg">
-              No other tests trigger this test as a reflex
-            </p>
-          )}
-        </div>
-
-        {/* Add new link */}
-        <a 
-          href="/MasterListsPage#reflex?action=add&triggerTestId=123"
-          className="inline-flex items-center gap-2 text-sm text-teal-600 hover:text-teal-700 font-medium"
-        >
-          <Plus size={16} />
-          Add New Reflex Rule in Master Lists
-          <ChevronRight size={14} />
-        </a>
-      </div>
-
-      {/* Calculated Results Section */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <div className="flex items-center justify-between mb-4">
-          <div>
-            <h2 className="text-lg font-semibold text-gray-900">Calculated Results</h2>
-            <p className="text-sm text-gray-500 mt-1">Formulas that compute results from other test values</p>
-          </div>
-        </div>
-
-        {/* Calculations that USE this test as input */}
-        <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-700 mb-3">Calculations that USE this test as input:</h3>
-          {calculationsUsingThis.length > 0 ? (
-            <div className="space-y-3">
-              {calculationsUsingThis.map((calc) => (
-                <div key={calc.id} className="p-4 border border-purple-200 rounded-lg bg-purple-50">
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <div className="w-8 h-8 bg-purple-100 rounded-lg flex items-center justify-center">
-                        <Zap className="text-purple-600" size={16} />
-                      </div>
-                      <div>
-                        <p className="text-sm font-medium text-gray-900">{calc.name}</p>
-                        <p className="text-xs text-gray-600 font-mono mt-0.5">{calc.formula}</p>
-                      </div>
-                    </div>
-                    <a 
-                      href={`/MasterListsPage#calculatedValue?calcId=${calc.id}`}
-                      className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
-                    >
-                      Edit in Master Lists
-                      <ChevronRight size={14} />
-                    </a>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-gray-500 italic p-4 bg-gray-50 rounded-lg">
-              This test is not used as input for any calculated results
-            </p>
-          )}
-        </div>
-
-        {/* This test IS a calculated result */}
-        <div>
-          <h3 className="text-sm font-medium text-gray-700 mb-3">This test IS a calculated result:</h3>
-          {isCalculatedResult ? (
-            <div className="p-4 border border-green-200 rounded-lg bg-green-50">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <div className="w-8 h-8 bg-green-100 rounded-lg flex items-center justify-center">
-                    <Zap className="text-green-600" size={16} />
-                  </div>
-                  <div>
-                    <p className="text-sm font-medium text-gray-900">Formula configured</p>
-                    <p className="text-xs text-gray-600 font-mono mt-0.5">[formula would show here]</p>
-                  </div>
-                </div>
-                <a 
-                  href="/MasterListsPage#calculatedValue?resultTestId=123"
-                  className="text-sm text-teal-600 hover:text-teal-700 font-medium flex items-center gap-1"
-                >
-                  Edit in Master Lists
-                  <ChevronRight size={14} />
-                </a>
-              </div>
-            </div>
-          ) : (
-            <div className="p-6 border-2 border-dashed border-gray-300 rounded-lg text-center">
-              <Zap className="mx-auto text-gray-400 mb-2" size={24} />
-              <p className="text-sm text-gray-600 mb-3">This test's result is not calculated from other values</p>
-              <a 
-                href="/MasterListsPage#calculatedValue?action=add&resultTestId=123"
-                className="inline-flex items-center gap-2 text-sm text-teal-600 hover:text-teal-700 font-medium"
-              >
-                <Plus size={16} />
-                Configure in Master Lists
-                <ChevronRight size={14} />
-              </a>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-};
-
-// ============================================
-// MAIN DEMO EXPORT
-// ============================================
-
-export default function TestCatalogMockupsV3() {
-  const [currentScreen, setCurrentScreen] = useState('list');
-  const [selectedTest, setSelectedTest] = useState(null);
-  const [activeDemo, setActiveDemo] = useState('full'); // 'full' or individual component demos
-
-  const handleEditTest = (test) => {
-    setSelectedTest(test);
-    setCurrentScreen('editor');
-  };
-
-  const handleAddTest = () => {
-    setSelectedTest(null);
-    setCurrentScreen('editor');
-  };
-
-  const handleBack = () => {
-    setCurrentScreen('list');
-    setSelectedTest(null);
-  };
-
-  const demos = [
-    { id: 'full', label: 'Full Application' },
-    { id: 'ranges', label: 'Range Editor Only' },
-    { id: 'ordering', label: 'Test Ordering Only' },
-    { id: 'panels', label: 'Panel Association Only' },
-    { id: 'methods', label: 'Method Linking Only' },
-    { id: 'sections', label: 'Test Sections Only' },
-  ];
-
-  return (
-    <div className="min-h-screen bg-gray-100">
-      {/* Demo Mode Selector */}
-      <div className="bg-gray-800 text-white px-6 py-2">
-        <div className="flex items-center gap-4">
-          <span className="text-sm font-medium">Demo Mode:</span>
-          <div className="flex gap-1">
-            {demos.map(demo => (
-              <button
-                key={demo.id}
-                onClick={() => { setActiveDemo(demo.id); setCurrentScreen('list'); }}
-                className={`px-3 py-1 rounded text-xs font-medium transition-colors ${
-                  activeDemo === demo.id 
-                    ? 'bg-teal-600 text-white' 
-                    : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
-                }`}
-              >
-                {demo.label}
-              </button>
-            ))}
-          </div>
-        </div>
-      </div>
-
-      {/* Main Content */}
-      {activeDemo === 'full' ? (
-        <>
-          {currentScreen === 'list' && (
-            <TestListView 
-              onEditTest={handleEditTest} 
-              onAddTest={handleAddTest}
-            />
-          )}
-          {currentScreen === 'editor' && (
-            <TestEditor test={selectedTest} onBack={handleBack} />
-          )}
-        </>
-      ) : (
-        <div className="p-6 max-w-6xl mx-auto">
-          <div className="mb-4">
-            <h2 className="text-lg font-semibold text-gray-900">Component Demo: {demos.find(d => d.id === activeDemo)?.label}</h2>
-          </div>
-          {activeDemo === 'ranges' && <RangeEditorV3 />}
-          {activeDemo === 'ordering' && <TestOrderingPanel />}
-          {activeDemo === 'panels' && <PanelAssociationPanel />}
-          {activeDemo === 'methods' && <MethodLinkingWithCreate />}
-          {activeDemo === 'sections' && (
-            <div className="bg-white rounded-lg border border-gray-200 p-6 max-w-md">
-              <TestSectionMultiSelect />
-            </div>
-          )}
-        </div>
+          <TextInput labelText={t('admin.testCatalog.sampleResults.label.code', 'Code') + ' *'} placeholder="e.g., GLU-HI" />
+          <TextInput labelText={t('admin.testCatalog.sampleResults.label.label', 'Label') + ' *'} placeholder="e.g., High" style={{ marginTop: '16px' }} />
+          <TextInput labelText={t('admin.testCatalog.sampleResults.label.valueRange', 'Value / Range') + ' *'} style={{ marginTop: '16px' }} />
+          <TextArea labelText={t('admin.testCatalog.sampleResults.label.text', 'Interpretation Text')} style={{ marginTop: '16px' }} />
+        </Modal>
       )}
     </div>
   );
 }
+
+/**
+ * MethodsSection — link analytical methods, create inline methods
+ */
+function MethodsSection() {
+  const [showLinkPanel, setShowLinkPanel] = useState(false);
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [showCopyModal, setShowCopyModal] = useState(false);
+  const [newCode, setNewCode] = useState('');
+  const [newName, setNewName] = useState('');
+
+  const linkedMethods = [
+    { code: 'HEX', name: 'Hexokinase', isDefault: true, date: '2024-01-01' },
+    { code: 'GOX', name: 'Glucose Oxidase', isDefault: false, date: '2020-01-01' },
+  ];
+
+  const availableMethods = [
+    { code: 'GOD-PAP', name: 'Enzymatic (GOD-PAP)' },
+    { code: 'CLR', name: 'Colorimetric' },
+    { code: 'ISE', name: 'Ion-Selective Electrode' },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.methods.header.title', 'Associated Methods')}</h2>
+          <p>{t('admin.testCatalog.methods.header.subtitle', 'Link analytical methods used to perform this test')}</p>
+        </div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <Button kind="secondary" size="sm" onClick={() => setShowCopyModal(true)}>
+            {t('admin.testCatalog.methods.action.copyFromTest', '📋 Copy from Test...')}
+          </Button>
+          <Button kind="primary" size="sm" onClick={() => { setShowLinkPanel(true); setShowCreateForm(false); }}>
+            {t('admin.testCatalog.methods.action.linkMethod', '+ Link Method')}
+          </Button>
+        </div>
+      </div>
+
+      {showLinkPanel && (
+        <Tile style={{ marginBottom: '16px', background: '#f9f9f9', borderStyle: 'dashed' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+            <strong>{t('admin.testCatalog.methods.label.selectMethod', 'Select Method to Link')}</strong>
+            <Button kind="ghost" size="sm" onClick={() => { setShowLinkPanel(false); setShowCreateForm(true); }}>
+              {t('admin.testCatalog.methods.action.createNewMethod', '+ Create New Method')}
+            </Button>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
+            {availableMethods.map((m) => (
+              <Button key={m.code} kind="secondary" size="sm" style={{ justifyContent: 'flex-start' }}>
+                <code style={{ background: '#e8e8e8', padding: '2px 4px', borderRadius: '2px', marginRight: '8px' }}>{m.code}</code>
+                {m.name}
+              </Button>
+            ))}
+          </div>
+        </Tile>
+      )}
+
+      {showCreateForm && (
+        <Tile style={{ marginBottom: '16px', background: '#e3f2fd', borderColor: '#0f62fe', borderStyle: 'solid' }}>
+          <label style={{ fontSize: '13px', fontWeight: 600, display: 'block', marginBottom: '8px' }}>
+            {t('admin.testCatalog.methods.label.createNewMethod', 'Create New Method')}
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <TextInput
+              value={newCode}
+              onChange={(e) => setNewCode(e.target.value.toUpperCase())}
+              placeholder={t('admin.testCatalog.methods.placeholder.code', 'Code (e.g., HEX)')}
+              style={{ width: '120px' }}
+            />
+            <TextInput
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              placeholder={t('admin.testCatalog.methods.placeholder.methodName', 'Method name')}
+              style={{ flex: 1 }}
+            />
+            <Button kind="primary" size="sm" onClick={() => { setShowCreateForm(false); setNewCode(''); setNewName(''); }}>
+              {t('admin.testCatalog.methods.action.createLink', 'Create & Link')}
+            </Button>
+            <Button kind="secondary" size="sm" onClick={() => { setShowCreateForm(false); setNewCode(''); setNewName(''); }}>
+              {t('admin.testCatalog.common.button.cancel', 'Cancel')}
+            </Button>
+          </div>
+        </Tile>
+      )}
+
+      {linkedMethods.map((m) => (
+        <Tile
+          key={m.code}
+          style={{
+            marginBottom: '12px',
+            borderColor: m.isDefault ? '#0f62fe' : '#e0e0e0',
+            background: m.isDefault ? '#e3f2fd' : '#fff',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <div
+              style={{
+                width: '40px',
+                height: '40px',
+                background: m.isDefault ? '#bce5fe' : '#e8e8e8',
+                borderRadius: '4px',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: '18px',
+              }}
+            >
+              ⚙
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                <code style={{ background: '#e8e8e8', padding: '2px 6px', borderRadius: '2px', fontWeight: 500 }}>
+                  {m.code}
+                </code>
+                <strong style={{ fontSize: '14px' }}>{m.name}</strong>
+                {m.isDefault && <Tag type="blue">{t('admin.testCatalog.methods.label.default', 'Default')}</Tag>}
+              </div>
+              <div style={{ fontSize: '12px', color: '#525252', marginTop: '4px' }}>
+                {t('admin.testCatalog.methods.label.effective', 'Effective')}: {m.date}
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              {!m.isDefault && <Button kind="ghost" size="sm">{t('admin.testCatalog.methods.action.setDefault', 'Set Default')}</Button>}
+              <Button kind="ghost" size="sm">Edit</Button>
+              <Button kind="ghost" size="sm" style={{ color: '#da1e28' }}>Delete</Button>
+            </div>
+          </div>
+        </Tile>
+      ))}
+
+      {showCopyModal && (
+        <Modal
+          open={showCopyModal}
+          onRequestClose={() => setShowCopyModal(false)}
+          modalHeading={t('admin.testCatalog.methods.modal.copyMethods', 'Copy Methods from Another Test')}
+          primaryButtonText={t('admin.testCatalog.methods.action.copySelected', 'Copy Selected')}
+          secondaryButtonText={t('admin.testCatalog.common.button.cancel', 'Cancel')}
+        >
+          <TextInput
+            labelText={t('admin.testCatalog.methods.label.searchForTest', 'Search for test')}
+            placeholder={t('admin.testCatalog.methods.placeholder.enterTestName', 'Enter test name...')}
+            style={{ marginBottom: '16px' }}
+          />
+          <div style={{ marginBottom: '16px' }}>
+            <label>{t('admin.testCatalog.methods.label.selectTest', 'Select test:')}</label>
+            {['Fasting Glucose', 'Random Glucose', '2-Hour Glucose', 'HbA1c'].map((t, i) => (
+              <div key={i} style={{ padding: '8px', display: 'flex', gap: '8px', alignItems: 'center' }}>
+                <RadioButton id={`srctest-${i}`} name="sourceTest" value={t} />
+                <label htmlFor={`srctest-${i}`}>{t}</label>
+              </div>
+            ))}
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * RangesSection — critical values, normal ranges, reference intervals with structured/table/visual views
+ */
+function RangesSection({ test }) {
+  const [viewMode, setViewMode] = useState('structured');
+  const [showAddModal, setShowAddModal] = useState(null); // null or { rangeType, prefill? }
+  const [showCoveragePanel, setShowCoveragePanel] = useState(true);
+  const [visualSex, setVisualSex] = useState('M');
+  const [visualAge, setVisualAge] = useState(3);
+  const [visualUnit, setVisualUnit] = useState('days');
+
+  // Mock range data — neonatal-aware bilirubin-style ranges with intentional gap in Female
+  const ranges = {
+    normal: {
+      M: [
+        { age: '0 – 24 hours', low: 1, high: 100 },
+        { age: '24 – 48 hours', low: 1, high: 120 },
+        { age: '48 – 72 hours', low: 1, high: 140 },
+        { age: '3 days – 5 days', low: 1, high: 155 },
+        { age: '14 days – 1 month', low: 1, high: 130 },
+        { age: '1 month – 1 year', low: 1, high: 115 },
+        { age: '1 year – ∞', low: 5, high: 40 },
+      ],
+      F: [
+        { age: '0 – 24 hours', low: 1, high: 105 },
+        { age: '24 – 48 hours', low: 1, high: 130 },
+        { age: '48 – 72 hours', low: 1, high: 155 },
+        { age: '3 days – 55 days', low: 1, high: 175 },
+        // intentional gap: 55 days – 1 year missing
+        { age: '1 year – ∞', low: 5, high: 35 },
+      ],
+    },
+    critical: {
+      A: [
+        { age: '0 – 23 hours', low: null, high: 7.9 },
+        { age: '24 – 35 hours', low: null, high: 10.9 },
+        { age: '36 – 47 hours', low: null, high: 13.9 },
+        { age: '48 – 71 hours', low: null, high: 14.9 },
+        { age: '72 hours – 13 days', low: null, high: 17.9 },
+        { age: '14 days – ∞', low: null, high: 15.0 },
+      ],
+    },
+    valid: { A: [{ age: '0 hours – ∞', low: 0, high: 600 }] },
+    reporting: { A: [{ age: '0 hours – ∞', low: 0.1, high: 30 }] },
+  };
+
+  const rangeTypes = [
+    { id: 'normal', label: t('admin.testCatalog.ranges.label.normal', 'Normal Range'), desc: 'Clinical reference values. Results outside flagged H/L on reports.', kind: 'green', barColor: '#a7f0ba' },
+    { id: 'valid', label: t('admin.testCatalog.ranges.label.valid', 'Valid Range'), desc: 'Expected possible values. Entry outside prompts verification.', kind: 'blue', barColor: '#bce5fe' },
+    { id: 'critical', label: t('admin.testCatalog.ranges.label.critical', 'Critical Range'), desc: 'Panic values requiring immediate clinical action.', kind: 'red', barColor: '#f8b8b8' },
+    { id: 'reporting', label: t('admin.testCatalog.ranges.label.reporting', 'Reporting Range'), desc: 'Instrument limits. Results outside may need dilution/rerun.', kind: 'purple', barColor: '#e0c3fc' },
+  ];
+
+  const sexLabels = { M: t('admin.testCatalog.ranges.label.male', 'Male'), F: t('admin.testCatalog.ranges.label.female', 'Female'), A: t('admin.testCatalog.ranges.label.allSexes', 'All') };
+  const sexKinds = { M: 'blue', F: 'purple', A: 'gray' };
+
+  // Visual view: get applicable range for selected demographic (matches by sex preference, fallback to 'A')
+  const getApplicableRange = (typeId) => {
+    const byType = ranges[typeId];
+    return (byType[visualSex] && byType[visualSex][0]) || (byType.A && byType.A[0]) || null;
+  };
+
+  // Flat list for table view
+  const allRangesFlat = [];
+  rangeTypes.forEach(type => {
+    const byType = ranges[type.id];
+    Object.keys(byType).forEach(sex => {
+      byType[sex].forEach(r => allRangesFlat.push({ ...r, type: type.id, typeLabel: type.label, typeKind: type.kind, sex }));
+    });
+  });
+
+  return (
+    <div>
+      <h2>{t('admin.testCatalog.ranges.header.title', 'Ranges & Reference Intervals')}</h2>
+      <p>{t('admin.testCatalog.ranges.header.subtitle', 'Configure normal, critical, and reporting ranges by age and sex')}</p>
+
+      {test && (test.domain === 'ENVIRONMENTAL' || test.domain === 'VECTOR') && (
+        <InlineNotification
+          kind="info"
+          title={t('admin.testCatalog.ranges.notification.domainInfo', 'Domain Note')}
+          subtitle={t('admin.testCatalog.ranges.notification.compliancePrimary', 'This is an Environmental/Vector test. Compliance thresholds are typically the primary evaluation surface for this domain.')}
+          style={{ marginBottom: '16px' }}
+        />
+      )}
+
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+        <Button
+          kind={viewMode === 'structured' ? 'primary' : 'ghost'}
+          onClick={() => setViewMode('structured')}
+          size="sm"
+        >
+          {t('admin.testCatalog.ranges.action.structuredView', 'Structured')}
+        </Button>
+        <Button
+          kind={viewMode === 'table' ? 'primary' : 'ghost'}
+          onClick={() => setViewMode('table')}
+          size="sm"
+        >
+          {t('admin.testCatalog.ranges.action.tableView', 'Table')}
+        </Button>
+        <Button
+          kind={viewMode === 'visual' ? 'primary' : 'ghost'}
+          onClick={() => setViewMode('visual')}
+          size="sm"
+        >
+          {t('admin.testCatalog.ranges.action.visualView', 'Visual')}
+        </Button>
+        <Button kind="ghost" onClick={() => setShowCoveragePanel(!showCoveragePanel)} size="sm">
+          {t('admin.testCatalog.ranges.action.toggleCoverage', 'Coverage Validation')}
+        </Button>
+      </div>
+
+      {showCoveragePanel && (
+        <Tile style={{ background: '#f4f4f4', marginBottom: '16px', padding: '16px' }}>
+          <h4 style={{ marginTop: 0 }}>{t('admin.testCatalog.ranges.header.ageCoverageValidation', 'Age Coverage Validation')}</h4>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
+            <Tile style={{ background: '#fff' }}>
+              <div style={{ marginBottom: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Tag type="blue">{t('admin.testCatalog.ranges.label.male', 'Male')}</Tag>
+                <span style={{ fontSize: '12px', color: '#0d6f1f', fontWeight: 600 }}>✓ Complete Coverage</span>
+              </div>
+              <div style={{ padding: '8px', background: '#d1fce0', borderRadius: '3px', fontSize: '12px', color: '#0d6f1f' }}>
+                {t('admin.testCatalog.ranges.notification.allAgesCompleteCoverage', 'All age ranges from birth to maximum age are covered.')}
+              </div>
+            </Tile>
+            <Tile style={{ background: '#fff' }}>
+              <div style={{ marginBottom: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                <Tag type="purple">{t('admin.testCatalog.ranges.label.female', 'Female')}</Tag>
+                <span style={{ fontSize: '12px', color: '#ae1a1a', fontWeight: 600 }}>⚠ 1 Issue Found</span>
+              </div>
+              <div style={{ background: '#fee5e5', border: '1px solid #f8b8b8', padding: '8px', borderRadius: '3px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                  <div>
+                    <div style={{ fontSize: '11px', fontWeight: 700, color: '#ae1a1a', marginBottom: '2px' }}>GAP</div>
+                    <div style={{ fontSize: '13px', color: '#ae1a1a' }}>{t('admin.testCatalog.ranges.gap.boundary', 'Gap: 55 days to 1 year')}</div>
+                  </div>
+                  <Button
+                    kind="tertiary"
+                    size="sm"
+                    onClick={() => setShowAddModal({ rangeType: 'normal', prefill: { sex: 'F', ageFrom: 55, ageFromUnit: 'days', ageTo: 1, ageToUnit: 'years', low: 1, high: 130, source: '3 days – 55 days range' } })}
+                  >
+                    {t('admin.testCatalog.ranges.action.fillGap', '+ Fill Gap')}
+                  </Button>
+                </div>
+                <div style={{ fontSize: '11px', color: '#525252', marginTop: '6px' }}>
+                  {t('admin.testCatalog.ranges.gap.suggestedValues', 'Suggested values from adjacent range: Low=1, High=130')}
+                </div>
+              </div>
+            </Tile>
+          </div>
+        </Tile>
+      )}
+
+      {viewMode === 'structured' && (
+        <Accordion>
+          {rangeTypes.map(type => {
+            const byType = ranges[type.id];
+            const totalCount = Object.values(byType).reduce((sum, arr) => sum + arr.length, 0);
+            return (
+              <AccordionItem
+                key={type.id}
+                title={
+                  <span style={{ display: 'inline-flex', gap: '12px', alignItems: 'center' }}>
+                    <Tag type={type.kind}>{type.label}</Tag>
+                    <span style={{ fontSize: '12px', color: '#525252', fontWeight: 'normal' }}>{type.desc}</span>
+                    <span style={{ marginLeft: 'auto', fontSize: '12px', color: '#525252' }}>{totalCount} range(s)</span>
+                  </span>
+                }
+              >
+                {Object.keys(byType).map(sex => {
+                  const sexRanges = byType[sex];
+                  if (sexRanges.length === 0) return null;
+                  return (
+                    <div key={sex} style={{ marginBottom: '12px' }}>
+                      <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '6px' }}>
+                        <Tag type={sexKinds[sex]}>{sexLabels[sex]}</Tag>
+                        <span style={{ fontSize: '11px', color: '#525252' }}>({sexRanges.length} ranges)</span>
+                        <div style={{ flex: 1, height: '1px', background: '#e0e0e0' }} />
+                      </div>
+                      {sexRanges.map((r, idx) => {
+                        const lowPct = r.low !== null ? Math.max(0, Math.min(100, (r.low / 200) * 100)) : 0;
+                        const highPct = r.high !== null ? Math.max(0, Math.min(100, (r.high / 200) * 100)) : 100;
+                        return (
+                          <div key={idx} style={{ padding: '8px', background: '#f9f9f9', border: '1px solid #e8e8e8', borderRadius: '3px', marginBottom: '4px', display: 'flex', alignItems: 'center', gap: '16px', fontSize: '12px' }}>
+                            <span style={{ width: '16px', color: '#a8a8a8' }}>{idx + 1}.</span>
+                            <div style={{ width: '160px' }}>
+                              <div style={{ fontSize: '10px', color: '#525252' }}>Age Range</div>
+                              <div style={{ fontWeight: 500 }}>{r.age}</div>
+                            </div>
+                            <div style={{ width: '60px' }}>
+                              <div style={{ fontSize: '10px', color: '#525252' }}>Low</div>
+                              <div style={{ fontWeight: 500 }}>{r.low !== null ? r.low : '—'}</div>
+                            </div>
+                            <div style={{ width: '60px' }}>
+                              <div style={{ fontSize: '10px', color: '#525252' }}>High</div>
+                              <div style={{ fontWeight: 500 }}>{r.high !== null ? r.high : '—'}</div>
+                            </div>
+                            <div style={{ flex: 1, height: '18px', background: '#e8e8e8', borderRadius: '3px', position: 'relative' }}>
+                              {r.low !== null && r.high !== null && (
+                                <div style={{ position: 'absolute', left: `${lowPct}%`, width: `${highPct - lowPct}%`, height: '100%', background: type.barColor, borderRadius: '3px' }} />
+                              )}
+                            </div>
+                            <div style={{ display: 'flex', gap: '2px' }}>
+                              <Button kind="ghost" size="sm" hasIconOnly iconDescription="Edit" renderIcon={Edit}><Edit /></Button>
+                              <Button kind="ghost" size="sm" hasIconOnly iconDescription="Copy to other sex" renderIcon={Copy} onClick={() => setShowAddModal({ rangeType: type.id, prefill: { sex: sex === 'M' ? 'F' : 'M', age: r.age, low: r.low, high: r.high, source: `Copied from ${sexLabels[sex]}: ${r.age}` } })}><Copy /></Button>
+                              <Button kind="ghost" size="sm" hasIconOnly iconDescription="Delete" renderIcon={TrashCan}><TrashCan /></Button>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  );
+                })}
+                <Button kind="ghost" size="sm" renderIcon={Add} onClick={() => setShowAddModal({ rangeType: type.id })}>
+                  {t('admin.testCatalog.ranges.action.addToType', `Add ${type.label}`)}
+                </Button>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
+      )}
+
+      {viewMode === 'table' && (
+        <DataTable
+          headers={[
+            { key: 'type', header: t('admin.testCatalog.ranges.column.type', 'Type') },
+            { key: 'sex', header: t('admin.testCatalog.ranges.column.sex', 'Sex') },
+            { key: 'age', header: t('admin.testCatalog.ranges.column.ageRange', 'Age Range') },
+            { key: 'low', header: t('admin.testCatalog.ranges.column.low', 'Low') },
+            { key: 'high', header: t('admin.testCatalog.ranges.column.high', 'High') },
+            { key: 'actions', header: t('admin.testCatalog.ranges.column.actions', 'Actions') },
+          ]}
+          rows={allRangesFlat.map((r, i) => ({ id: String(i), ...r }))}
+        >
+          {({ headers, rows, getTableProps, getHeaderProps, getRowProps }) => (
+            <TableContainer>
+              <Table {...getTableProps()}>
+                <TableHead>
+                  <TableRow>
+                    {headers.map(h => (
+                      <TableHeader key={h.key} {...getHeaderProps({ header: h })}>{h.header}</TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {rows.map((row, idx) => {
+                    const orig = allRangesFlat[idx];
+                    return (
+                      <TableRow key={row.id} {...getRowProps({ row })}>
+                        <TableCell><Tag type={rangeTypes.find(t => t.id === orig.type).kind}>{orig.typeLabel}</Tag></TableCell>
+                        <TableCell><Tag type={sexKinds[orig.sex]}>{sexLabels[orig.sex]}</Tag></TableCell>
+                        <TableCell>{orig.age}</TableCell>
+                        <TableCell>{orig.low !== null ? orig.low : '—'}</TableCell>
+                        <TableCell>{orig.high !== null ? orig.high : '—'}</TableCell>
+                        <TableCell>
+                          <Button kind="ghost" size="sm">{t('admin.testCatalog.common.button.edit', 'Edit')}</Button>
+                          <Button kind="ghost" size="sm" style={{ color: '#da1e28' }}>{t('admin.testCatalog.common.button.delete', 'Del')}</Button>
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
+      )}
+
+      {viewMode === 'visual' && (
+        <div>
+          <Tile style={{ background: '#f4f4f4', marginBottom: '16px', display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <span style={{ fontSize: '13px', fontWeight: 600 }}>{t('admin.testCatalog.ranges.label.viewRangesFor', 'View ranges for:')}</span>
+            <Select id="visualSex" labelText="" hideLabel value={visualSex} onChange={e => setVisualSex(e.target.value)} size="sm">
+              <SelectItem value="M" text={t('admin.testCatalog.ranges.label.male', 'Male')} />
+              <SelectItem value="F" text={t('admin.testCatalog.ranges.label.female', 'Female')} />
+            </Select>
+            <span style={{ fontSize: '13px' }}>{t('admin.testCatalog.ranges.label.age', 'Age:')}</span>
+            <NumberInput id="visualAge" hideLabel label="" value={visualAge} onChange={(_, { value }) => setVisualAge(value)} min={0} size="sm" style={{ width: '80px' }} />
+            <Select id="visualUnit" labelText="" hideLabel value={visualUnit} onChange={e => setVisualUnit(e.target.value)} size="sm">
+              <SelectItem value="hours" text="hours" />
+              <SelectItem value="days" text="days" />
+              <SelectItem value="weeks" text="weeks" />
+              <SelectItem value="months" text="months" />
+              <SelectItem value="years" text="years" />
+            </Select>
+          </Tile>
+
+          <Tile style={{ background: '#f9f9f9', marginBottom: '16px' }}>
+            <div style={{ fontSize: '13px', marginBottom: '16px' }}>
+              {t('admin.testCatalog.ranges.label.showingRangesFor', 'Showing ranges applicable to:')} <strong>{sexLabels[visualSex]}, {visualAge} {visualUnit} old</strong>
+            </div>
+            {[
+              { id: 'valid', label: t('admin.testCatalog.ranges.label.valid', 'Valid'), barColor: '#bce5fe', textColor: '#003da5' },
+              { id: 'normal', label: t('admin.testCatalog.ranges.label.normal', 'Normal'), barColor: '#a7f0ba', textColor: '#0d6f1f' },
+              { id: 'critical', label: t('admin.testCatalog.ranges.label.critical', 'Critical'), barColor: '#f8b8b8', textColor: '#ae1a1a' },
+              { id: 'reporting', label: t('admin.testCatalog.ranges.label.reporting', 'Reporting'), barColor: '#e0c3fc', textColor: '#6e008d' },
+            ].map(({ id, label, barColor, textColor }) => {
+              const r = getApplicableRange(id);
+              const lowPct = r && r.low !== null ? Math.max(0, Math.min(100, (r.low / 200) * 100)) : 0;
+              const highPct = r && r.high !== null ? Math.max(0, Math.min(100, (r.high / 200) * 100)) : 100;
+              return (
+                <div key={id} style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '8px' }}>
+                  <div style={{ width: '90px', fontSize: '13px', fontWeight: 500 }}>{label}</div>
+                  <div style={{ flex: 1, height: '32px', background: '#e8e8e8', borderRadius: '3px', position: 'relative' }}>
+                    {r ? (
+                      <>
+                        {r.low !== null && r.high !== null && (
+                          <div style={{ position: 'absolute', left: `${lowPct}%`, width: `${highPct - lowPct}%`, height: '100%', background: barColor, borderRadius: '3px' }} />
+                        )}
+                        {r.low === null && r.high !== null && (
+                          <div style={{ position: 'absolute', left: 0, width: `${highPct}%`, height: '100%', background: barColor, borderTopLeftRadius: '3px', borderBottomLeftRadius: '3px' }} />
+                        )}
+                        <span style={{ position: 'absolute', left: '8px', top: '50%', transform: 'translateY(-50%)', fontSize: '12px', fontWeight: 500, color: textColor }}>
+                          {r.low ?? '—'} – {r.high ?? '—'}
+                        </span>
+                      </>
+                    ) : (
+                      <span style={{ position: 'absolute', left: '8px', top: '50%', transform: 'translateY(-50%)', fontSize: '12px', fontStyle: 'italic', color: '#a8a8a8' }}>
+                        {t('admin.testCatalog.ranges.label.notDefinedForDemographic', 'Not defined for this demographic')}
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+            <div style={{ display: 'flex', gap: '16px', paddingTop: '12px', borderTop: '1px solid #e0e0e0', marginTop: '12px' }}>
+              {[{ c: '#bce5fe', l: 'Valid' }, { c: '#a7f0ba', l: 'Normal' }, { c: '#f8b8b8', l: 'Critical' }, { c: '#e0c3fc', l: 'Reporting' }].map(x => (
+                <div key={x.l} style={{ display: 'flex', gap: '6px', alignItems: 'center' }}>
+                  <div style={{ width: '14px', height: '14px', background: x.c, borderRadius: '2px' }} />
+                  <span style={{ fontSize: '11px', color: '#525252' }}>{x.l}</span>
+                </div>
+              ))}
+            </div>
+          </Tile>
+        </div>
+      )}
+
+      <Button kind="primary" renderIcon={Add} onClick={() => setShowAddModal({ rangeType: 'normal' })} style={{ marginTop: '16px' }}>
+        {t('admin.testCatalog.ranges.action.addRange', 'Add Range')}
+      </Button>
+
+      {showAddModal && (
+        <Modal
+          open={!!showAddModal}
+          onRequestClose={() => setShowAddModal(null)}
+          modalHeading={t('admin.testCatalog.ranges.modal.addRange', `Add ${rangeTypes.find(t => t.id === showAddModal.rangeType)?.label || 'Range'}`)}
+          primaryButtonText={t('admin.testCatalog.common.button.add', 'Add Range')}
+          secondaryButtonText={t('admin.testCatalog.common.button.cancel', 'Cancel')}
+        >
+          {showAddModal.prefill?.source && (
+            <InlineNotification kind="info" lowContrast title="" subtitle={`Values from: ${showAddModal.prefill.source}`} hideCloseButton style={{ marginBottom: '16px' }} />
+          )}
+          <FormGroup legendText={t('admin.testCatalog.ranges.label.appliesTo', 'Applies To')} style={{ marginBottom: '16px' }}>
+            <RadioButtonGroup name="sex" valueSelected={showAddModal.prefill?.sex || 'A'} orientation="horizontal">
+              <RadioButton labelText={t('admin.testCatalog.ranges.label.allSexes', 'All')} value="A" />
+              <RadioButton labelText={t('admin.testCatalog.ranges.label.maleOnly', 'Male Only')} value="M" />
+              <RadioButton labelText={t('admin.testCatalog.ranges.label.femaleOnly', 'Female Only')} value="F" />
+            </RadioButtonGroup>
+          </FormGroup>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '16px' }}>
+            <NumberInput id="ageFrom" label={t('admin.testCatalog.ranges.label.ageFrom', 'Age From')} value={showAddModal.prefill?.ageFrom ?? 0} min={0} />
+            <NumberInput id="ageTo" label={t('admin.testCatalog.ranges.label.ageTo', 'Age To')} value={showAddModal.prefill?.ageTo ?? 999} min={0} />
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+            <NumberInput id="low" label={showAddModal.rangeType === 'critical' ? t('admin.testCatalog.ranges.label.criticalLow', 'Critical Low') : t('admin.testCatalog.ranges.label.low', 'Low')} value={showAddModal.prefill?.low ?? ''} placeholder={showAddModal.rangeType === 'critical' ? 'Leave blank if N/A' : '0'} />
+            <NumberInput id="high" label={showAddModal.rangeType === 'critical' ? t('admin.testCatalog.ranges.label.criticalHigh', 'Critical High') : t('admin.testCatalog.ranges.label.high', 'High')} value={showAddModal.prefill?.high ?? ''} placeholder={showAddModal.rangeType === 'critical' ? 'Leave blank if N/A' : '100'} />
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * SampleStorageSection — storage conditions, duration, disposal, special handling, override restricted, quick reference
+ */
+function SampleStorageSection() {
+  const [overrideRestricted, setOverrideRestricted] = useState(false);
+  const handlingOptions = [
+    'Protect from light', 'Do not freeze', 'Do not refrigerate',
+    'Keep upright', 'Centrifuge before storage', 'Aliquot before storage',
+  ];
+
+  return (
+    <div>
+      <h2>{t('admin.testCatalog.sampleStorage.header.title', 'Sample Storage')}</h2>
+      <p>{t('admin.testCatalog.sampleStorage.header.subtitle', 'Define recommended storage conditions, duration, disposal, and special handling')}</p>
+
+      <Tile style={{ marginBottom: '16px' }}>
+        <h4 style={{ marginTop: 0 }}>{t('admin.testCatalog.sampleStorage.header.storageRequirements', 'Storage Requirements')}</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px', marginBottom: '16px' }}>
+          <Select id="storage-conditions" labelText={t('admin.testCatalog.sampleStorage.label.storageConditions', 'Storage Conditions') + ' *'} defaultValue="refrigerator">
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.ultraLowFreezer', 'Ultra-low freezer (-80°C to -60°C)')} value="ultra-low" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.freezer', 'Freezer (-30°C to -15°C)')} value="freezer" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.refrigerator', 'Refrigerator (2°C to 8°C)')} value="refrigerator" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.coldRoom', 'Cold room (4°C to 8°C)')} value="cold-room" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.coolRoom', 'Cool room (15°C to 18°C)')} value="cool-room" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.roomTemp', 'Room temperature (18°C to 25°C)')} value="room-temp" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.controlledRoomTemp', 'Controlled room temp (20°C to 25°C)')} value="controlled-room" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.warmIncubator', 'Warm incubator (35°C to 37°C)')} value="warm-incubator" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.ambient', 'Ambient (uncontrolled)')} value="ambient" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.custom', 'Custom (specify below)')} value="custom" />
+          </Select>
+          <TextInput id="custom-storage" labelText={t('admin.testCatalog.sampleStorage.label.customStorage', 'Custom Storage Conditions')} placeholder="e.g., 2-8°C, protected from light" />
+          <div>
+            <label style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'block' }}>{t('admin.testCatalog.sampleStorage.label.maximumStorageDuration', 'Maximum Storage Duration *')}</label>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <NumberInput id="duration" hideLabel label="" defaultValue={72} min={1} style={{ flex: 1 }} />
+              <Select id="duration-unit" labelText="" hideLabel defaultValue="hours" style={{ width: '120px' }}>
+                <SelectItem text="Hours" value="hours" />
+                <SelectItem text="Days" value="days" />
+                <SelectItem text="Weeks" value="weeks" />
+                <SelectItem text="Months" value="months" />
+              </Select>
+            </div>
+          </div>
+          <TextInput id="stability" labelText={t('admin.testCatalog.sampleStorage.label.stabilityNotes', 'Stability Notes')} placeholder="e.g., Stable for 7 days refrigerated" />
+        </div>
+
+        <FormGroup legendText={t('admin.testCatalog.sampleStorage.label.specialHandling', 'Special Handling Requirements')}>
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '8px' }}>
+            {handlingOptions.map(opt => (
+              <Checkbox key={opt} id={`handling-${opt.replace(/\s+/g, '-')}`} labelText={opt} />
+            ))}
+          </div>
+        </FormGroup>
+      </Tile>
+
+      <Tile style={{ marginBottom: '16px' }}>
+        <h4 style={{ marginTop: 0, color: '#da1e28' }}>{t('admin.testCatalog.sampleStorage.header.disposalRequirements', 'Disposal Requirements')}</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '16px' }}>
+          <Select id="disposal-method" labelText={t('admin.testCatalog.sampleStorage.label.disposalMethod', 'Disposal Method *')}>
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.biohazardWaste', 'Biohazard/Infectious waste bin')} value="biohazard" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.sharps', 'Sharps container')} value="sharps" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.chemicalDeactivation', 'Chemical deactivation')} value="chemical" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.incineration', 'Incineration')} value="incineration" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.autoclave', 'Autoclave then general waste')} value="autoclave" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.pharmaceutical', 'Pharmaceutical waste')} value="pharma" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.radioactive', 'Radioactive waste')} value="radioactive" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.generalWaste', 'General waste (non-hazardous only)')} value="general" />
+            <SelectItem text={t('admin.testCatalog.sampleStorage.option.returnToManufacturer', 'Return to manufacturer')} value="return" />
+          </Select>
+          <div>
+            <label style={{ fontSize: '12px', fontWeight: 600, marginBottom: '4px', display: 'block' }}>{t('admin.testCatalog.sampleStorage.label.disposalTimeframe', 'Disposal Timeframe')}</label>
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <NumberInput id="disposal-tf" hideLabel label="" placeholder="e.g., 7" min={1} style={{ flex: 1 }} />
+              <Select id="disposal-unit" labelText="" hideLabel defaultValue="days" style={{ width: '120px' }}>
+                <SelectItem text="Days" value="days" />
+                <SelectItem text="Weeks" value="weeks" />
+                <SelectItem text="Months" value="months" />
+              </Select>
+            </div>
+          </div>
+        </div>
+      </Tile>
+
+      <Tile style={{ marginBottom: '16px' }}>
+        <h4 style={{ marginTop: 0, color: '#a18217' }}>{t('admin.testCatalog.sampleStorage.header.specialInstructions', 'Special Instructions')}</h4>
+        <TextArea id="special-instructions" labelText="" hideLabel rows={4} placeholder={t('admin.testCatalog.sampleStorage.placeholder.specialInstructions', "Enter any special instructions that don't fit in the fields above...")} />
+      </Tile>
+
+      <Tile style={{ marginBottom: '16px', borderColor: overrideRestricted ? '#da1e28' : undefined }}>
+        <div style={{ display: 'flex', gap: '12px', alignItems: 'flex-start' }}>
+          <Checkbox id="override-restricted" checked={overrideRestricted} onChange={(_, { checked }) => setOverrideRestricted(checked)} labelText="" hideLabel />
+          <div style={{ flex: 1 }}>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+              <strong style={{ fontSize: '14px' }}>{t('admin.testCatalog.sampleStorage.label.overrideRestricted', 'Override Restricted')}</strong>
+              <Tag type="red">{t('admin.testCatalog.sampleStorage.label.locked', 'Locked')}</Tag>
+            </div>
+            <p style={{ fontSize: '13px', color: '#525252', margin: 0 }}>
+              {t('admin.testCatalog.sampleStorage.helper.overrideRestricted', 'When enabled, order entry staff cannot modify storage or disposal requirements for this test. Use for critical tests where sample handling must be strictly controlled (e.g., HIV, controlled substances).')}
+            </p>
+            {overrideRestricted && (
+              <InlineNotification kind="error" lowContrast title="" subtitle={t('admin.testCatalog.sampleStorage.notification.locked', 'Storage and disposal settings are locked. Only Lab Managers can modify these requirements.')} hideCloseButton style={{ marginTop: '12px' }} />
+            )}
+          </div>
+        </div>
+      </Tile>
+
+      <Tile style={{ background: 'linear-gradient(to right, #e3f2fd, #d1f3f6)' }}>
+        <h4 style={{ marginTop: 0 }}>{t('admin.testCatalog.sampleStorage.header.quickReference', 'Storage Condition Quick Reference')}</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '16px', fontSize: '13px' }}>
+          {[
+            { name: 'Ultra-low Freezer', range: '-80°C to -60°C' },
+            { name: 'Freezer', range: '-30°C to -15°C' },
+            { name: 'Refrigerator', range: '2°C to 8°C' },
+            { name: 'Cool Room', range: '15°C to 18°C' },
+            { name: 'Room Temperature', range: '18°C to 25°C' },
+            { name: 'Warm Incubator', range: '35°C to 37°C' },
+          ].map(c => (
+            <div key={c.name}>
+              <strong>{c.name}</strong>
+              <div style={{ color: '#525252' }}>{c.range}</div>
+            </div>
+          ))}
+        </div>
+      </Tile>
+    </div>
+  );
+}
+
+/**
+ * DisplayOrderSection — drag-and-drop test reorder within selected sample type
+ */
+function DisplayOrderSection() {
+  const [sampleType, setSampleType] = useState('serum');
+  const [tests, setTests] = useState([
+    { id: 1, name: 'Glucose, Fasting' },
+    { id: 2, name: 'Hemoglobin A1c' },
+    { id: 3, name: 'Creatinine' },
+    { id: 4, name: 'BUN' },
+    { id: 5, name: 'ALT (SGPT)' },
+    { id: 6, name: 'AST (SGOT)' },
+    { id: 7, name: 'Bilirubin, Total' },
+    { id: 8, name: 'Albumin' },
+  ]);
+
+  const move = (idx, delta) => {
+    if (idx + delta < 0 || idx + delta >= tests.length) return;
+    const next = [...tests];
+    [next[idx], next[idx + delta]] = [next[idx + delta], next[idx]];
+    setTests(next);
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.displayOrder.header.title', 'Test Display Order')}</h2>
+          <p>{t('admin.testCatalog.displayOrder.header.subtitle', 'Drag and drop to reorder tests for this sample type')}</p>
+        </div>
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          <span style={{ fontSize: '13px' }}>{t('admin.testCatalog.displayOrder.label.sampleType', 'Sample Type:')}</span>
+          <Select id="sample-type" labelText="" hideLabel value={sampleType} onChange={e => setSampleType(e.target.value)} size="sm">
+            <SelectItem value="serum" text="Serum" />
+            <SelectItem value="plasma" text="Plasma" />
+            <SelectItem value="whole_blood" text="Whole Blood" />
+            <SelectItem value="urine" text="Urine" />
+          </Select>
+        </div>
+      </div>
+
+      {tests.map((test, idx) => (
+        <Tile key={test.id} style={{ marginBottom: '8px', cursor: 'move' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <Draggable size={16} style={{ color: '#a8a8a8' }} />
+            <span style={{ width: '28px', color: '#525252', fontSize: '13px', fontWeight: 600 }}>{idx + 1}.</span>
+            <span style={{ flex: 1, fontWeight: 500 }}>{test.name}</span>
+            <Button kind="ghost" size="sm" hasIconOnly iconDescription="Move up" disabled={idx === 0} onClick={() => move(idx, -1)} renderIcon={ChevronUp}><ChevronUp /></Button>
+            <Button kind="ghost" size="sm" hasIconOnly iconDescription="Move down" disabled={idx === tests.length - 1} onClick={() => move(idx, 1)} renderIcon={ChevronDown}><ChevronDown /></Button>
+          </div>
+        </Tile>
+      ))}
+
+      <p style={{ fontSize: '12px', color: '#525252', marginTop: '16px' }}>
+        {t('admin.testCatalog.displayOrder.helper.orderInfo', 'This order determines how tests appear in order entry and result entry for the selected sample type.')}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * PanelsSection — selectable panel cards with expandable position editor and inline panel creation
+ */
+function PanelsSection() {
+  const [showCreate, setShowCreate] = useState(false);
+  const [newPanelName, setNewPanelName] = useState('');
+  const [selected, setSelected] = useState({ 1: 3, 3: 2 });
+  const [expanded, setExpanded] = useState(null);
+
+  const panels = [
+    { id: 1, name: 'Basic Metabolic Panel', count: 8, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium'] },
+    { id: 2, name: 'Comprehensive Metabolic Panel', count: 14, tests: ['Glucose', 'BUN', 'Creatinine', 'Sodium', 'Potassium', 'Chloride', 'CO2', 'Calcium', 'Total Protein', 'Albumin', 'Bilirubin', 'ALP', 'AST', 'ALT'] },
+    { id: 3, name: 'Lipid Panel', count: 4, tests: ['Total Cholesterol', 'HDL', 'LDL', 'Triglycerides'] },
+    { id: 4, name: 'Liver Function Panel', count: 7, tests: ['Total Protein', 'Albumin', 'Bilirubin Total', 'Bilirubin Direct', 'ALP', 'AST', 'ALT'] },
+    { id: 5, name: 'Renal Function Panel', count: 5, tests: ['BUN', 'Creatinine', 'eGFR', 'BUN/Creatinine Ratio', 'Uric Acid'] },
+    { id: 6, name: 'Thyroid Panel', count: 3, tests: ['TSH', 'Free T4', 'Free T3'] },
+  ];
+
+  const togglePanel = (id, count) => {
+    setSelected(prev => {
+      const next = { ...prev };
+      if (next[id] !== undefined) {
+        delete next[id];
+        setExpanded(null);
+      } else {
+        next[id] = count + 1;
+        setExpanded(id);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.panels.header.title', 'Panel Membership')}</h2>
+          <p>{t('admin.testCatalog.panels.header.subtitle', 'Select which panels should include this test and set display order')}</p>
+        </div>
+        <Button kind="ghost" size="sm" renderIcon={Add} onClick={() => setShowCreate(!showCreate)}>
+          {t('admin.testCatalog.panels.action.createNew', 'Create New Panel')}
+        </Button>
+      </div>
+
+      {showCreate && (
+        <Tile style={{ background: '#e3f2fd', borderColor: '#0f62fe', marginBottom: '12px' }}>
+          <label style={{ fontSize: '13px', fontWeight: 600, marginBottom: '6px', display: 'block' }}>
+            {t('admin.testCatalog.panels.label.newPanelName', 'New Panel Name')}
+          </label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <TextInput id="new-panel-name" labelText="" hideLabel value={newPanelName} onChange={e => setNewPanelName(e.target.value)} placeholder="Enter panel name..." style={{ flex: 1 }} />
+            <Button kind="primary" size="sm" onClick={() => { setShowCreate(false); setNewPanelName(''); }}>{t('admin.testCatalog.common.button.create', 'Create')}</Button>
+            <Button kind="secondary" size="sm" onClick={() => { setShowCreate(false); setNewPanelName(''); }}>{t('admin.testCatalog.common.button.cancel', 'Cancel')}</Button>
+          </div>
+        </Tile>
+      )}
+
+      {panels.map(p => {
+        const isSelected = selected[p.id] !== undefined;
+        const pos = selected[p.id] || (p.count + 1);
+        const isExpanded = expanded === p.id;
+        return (
+          <Tile key={p.id} style={{ marginBottom: '12px', borderColor: isSelected ? '#0f62fe' : '#e0e0e0', borderWidth: isSelected ? 2 : 1, background: isSelected ? '#e3f2fd' : '#fff', padding: 0 }}>
+            <div style={{ padding: '12px', cursor: 'pointer', display: 'flex', gap: '12px', alignItems: 'center' }} onClick={() => togglePanel(p.id, p.count)}>
+              <Checkbox id={`panel-${p.id}`} checked={isSelected} onChange={() => {}} labelText="" hideLabel />
+              <div style={{ flex: 1 }}>
+                <div style={{ fontWeight: 500, fontSize: '14px' }}>{p.name}</div>
+                <div style={{ fontSize: '12px', color: '#525252' }}>{p.count} {t('admin.testCatalog.panels.label.tests', 'tests')}</div>
+              </div>
+              {isSelected && <Tag type="blue">{t('admin.testCatalog.panels.label.position', 'Position:')} {pos}</Tag>}
+              {isSelected && (
+                <Button kind="ghost" size="sm" hasIconOnly iconDescription="Toggle" onClick={e => { e.stopPropagation(); setExpanded(isExpanded ? null : p.id); }} renderIcon={isExpanded ? ChevronUp : ChevronDown}>
+                  {isExpanded ? <ChevronUp /> : <ChevronDown />}
+                </Button>
+              )}
+            </div>
+            {isSelected && isExpanded && (
+              <div style={{ borderTop: '1px solid #c6daf8', padding: '12px', background: '#fff', display: 'flex', gap: '16px' }}>
+                <div style={{ width: '200px' }}>
+                  <NumberInput id={`pos-${p.id}`} label={t('admin.testCatalog.panels.label.displayPosition', 'Display Position in Panel')} value={pos} min={1} max={p.count + 1} onChange={(_, { value }) => setSelected(prev => ({ ...prev, [p.id]: value || 1 }))} />
+                  <small style={{ fontSize: '11px', color: '#a8a8a8', display: 'block', marginTop: '8px' }}>
+                    {t('admin.testCatalog.panels.helper.orderInput', 'Enter a number or drag the test in the preview list')}
+                  </small>
+                </div>
+                <div style={{ flex: 1 }}>
+                  <label style={{ fontSize: '12px', fontWeight: 600, display: 'block', marginBottom: '6px' }}>
+                    {t('admin.testCatalog.panels.label.previewListHeader', 'Panel Test Order Preview')} <span style={{ color: '#a8a8a8', fontWeight: 'normal' }}>{t('admin.testCatalog.panels.helper.dragToReorder', '— drag to reorder')}</span>
+                  </label>
+                  <div style={{ background: '#fff', border: '1px solid #d0d0d0', borderRadius: '4px', padding: '6px', maxHeight: '160px', overflowY: 'auto' }}>
+                    {(() => {
+                      const items = [];
+                      p.tests.forEach((test, idx) => {
+                        const position = idx + 1;
+                        if (position === pos) {
+                          items.push(
+                            <div key={`this-${idx}`} style={{ display: 'flex', gap: '6px', alignItems: 'center', padding: '6px 8px', background: '#bce5fe', border: '2px dashed #0f62fe', borderRadius: '3px', marginBottom: '2px', fontWeight: 600, color: '#003da5' }}>
+                              <Draggable size={12} />
+                              <span style={{ width: '20px' }}>{pos}.</span>
+                              <span style={{ flex: 1 }}>{t('admin.testCatalog.panels.label.thisTest', '← THIS TEST')}</span>
+                            </div>
+                          );
+                        }
+                        items.push(
+                          <div key={`row-${idx}`} style={{ display: 'flex', gap: '6px', padding: '4px 8px', fontSize: '12px' }}>
+                            <span style={{ width: '20px', color: '#a8a8a8', marginLeft: '16px' }}>{position >= pos ? position + 1 : position}.</span>
+                            <span>{test}</span>
+                          </div>
+                        );
+                      });
+                      if (pos > p.count) {
+                        items.push(
+                          <div key="this-end" style={{ display: 'flex', gap: '6px', alignItems: 'center', padding: '6px 8px', background: '#bce5fe', border: '2px dashed #0f62fe', borderRadius: '3px', marginTop: '2px', fontWeight: 600, color: '#003da5' }}>
+                            <Draggable size={12} />
+                            <span style={{ width: '20px' }}>{pos}.</span>
+                            <span style={{ flex: 1 }}>{t('admin.testCatalog.panels.label.thisTest', '← THIS TEST')}</span>
+                          </div>
+                        );
+                      }
+                      return items;
+                    })()}
+                  </div>
+                </div>
+              </div>
+            )}
+          </Tile>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * LabelsSection — label preset DataTable + Order Entry preview
+ */
+function LabelsSection() {
+  const [allowOverride, setAllowOverride] = useState(true);
+  const [labels] = useState([
+    { id: 1, presetName: 'Specimen Label (50×25mm)', defaultQty: 1, maxQty: 5, allowOverride: true },
+    { id: 2, presetName: 'Block Label (26×12mm)', defaultQty: 4, maxQty: 20, allowOverride: true },
+    { id: 3, presetName: 'Slide Label (76×26mm)', defaultQty: 12, maxQty: 50, allowOverride: true },
+    { id: 4, presetName: 'Freezer Label (38×19mm)', defaultQty: 2, maxQty: 10, allowOverride: false },
+  ]);
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.labels.header.title', 'Default Labels for This Test')}</h2>
+          <p>{t('admin.testCatalog.labels.header.subtitle', 'When this test is ordered, automatically suggest these labels')}</p>
+        </div>
+        <Button kind="primary" size="sm" renderIcon={Add}>
+          {t('admin.testCatalog.labels.action.addLabelType', 'Add Label Type')}
+        </Button>
+      </div>
+
+      <DataTable
+        headers={[
+          { key: 'preset', header: t('admin.testCatalog.labels.column.preset', 'Label Preset') },
+          { key: 'defaultQty', header: t('admin.testCatalog.labels.column.defaultQty', 'Default Qty') },
+          { key: 'maxQty', header: t('admin.testCatalog.labels.column.maxQty', 'Max Qty') },
+          { key: 'allowOverride', header: t('admin.testCatalog.labels.column.allowOverride', 'Allow Override') },
+          { key: 'actions', header: '' },
+        ]}
+        rows={labels.map(l => ({ id: String(l.id), ...l, preset: l.presetName }))}
+      >
+        {({ headers, rows, getTableProps, getHeaderProps }) => (
+          <TableContainer>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>{headers.map(h => <TableHeader key={h.key} {...getHeaderProps({ header: h })}>{h.header}</TableHeader>)}</TableRow>
+              </TableHead>
+              <TableBody>
+                {labels.map(l => (
+                  <TableRow key={l.id}>
+                    <TableCell>{l.presetName}</TableCell>
+                    <TableCell><NumberInput id={`def-${l.id}`} hideLabel label="" defaultValue={l.defaultQty} min={1} size="sm" /></TableCell>
+                    <TableCell><NumberInput id={`max-${l.id}`} hideLabel label="" defaultValue={l.maxQty} min={1} size="sm" /></TableCell>
+                    <TableCell><Checkbox id={`ovr-${l.id}`} defaultChecked={l.allowOverride} labelText="" hideLabel /></TableCell>
+                    <TableCell><Button kind="ghost" size="sm" hasIconOnly iconDescription="Delete" renderIcon={TrashCan}><TrashCan /></Button></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
+
+      <Tile style={{ marginTop: '16px' }}>
+        <h4 style={{ marginTop: 0 }}>{t('admin.testCatalog.labels.header.generationSettings', 'Label Generation Settings')}</h4>
+        <Toggle id="allow-override" labelText={t('admin.testCatalog.labels.label.allowCountOverride', 'Allow label count override at order entry')} toggled={allowOverride} onToggle={setAllowOverride} />
+        <small style={{ display: 'block', fontSize: '12px', color: '#525252', marginTop: '8px' }}>
+          {t('admin.testCatalog.labels.helper.allowOverride', 'When enabled, users can modify label quantities during order entry. Individual label types can still be locked via the "Allow Override" column above.')}
+        </small>
+      </Tile>
+
+      <Tile style={{ background: '#e3f2fd', borderColor: '#a8d8e8' }}>
+        <h4 style={{ marginTop: 0, color: '#003da5' }}>{t('admin.testCatalog.labels.header.orderEntryPreview', 'Order Entry Preview')}</h4>
+        <p style={{ fontSize: '13px', color: '#003da5', marginBottom: '12px' }}>
+          {t('admin.testCatalog.labels.helper.orderEntryPreview', 'When this test is ordered, the Labels section will be pre-populated as follows:')}
+        </p>
+        <Tile style={{ background: '#fff' }}>
+          <Table>
+            <TableHead>
+              <TableRow>
+                <TableHeader>{t('admin.testCatalog.labels.column.labelType', 'Label Type')}</TableHeader>
+                <TableHeader>{t('admin.testCatalog.labels.column.qty', 'Qty')}</TableHeader>
+                <TableHeader>{t('admin.testCatalog.labels.column.source', 'Source')}</TableHeader>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {labels.map(l => (
+                <TableRow key={l.id}>
+                  <TableCell>{l.presetName}</TableCell>
+                  <TableCell>{l.allowOverride ? l.defaultQty : <Tag type="gray">{l.defaultQty}</Tag>}</TableCell>
+                  <TableCell style={{ fontSize: '12px', color: '#525252' }}>{t('admin.testCatalog.labels.label.thisTest', 'This test')}</TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </Tile>
+        <small style={{ display: 'block', fontSize: '12px', color: '#525252', marginTop: '8px' }}>
+          ⚠ {t('admin.testCatalog.labels.helper.lockedNote', 'Gray quantities are locked and cannot be modified at order entry')}
+        </small>
+      </Tile>
+    </div>
+  );
+}
+
+/**
+ * TerminologySection — LOINC/SNOMED/CIEL/OCL mappings list with inline Add Mapping form
+ */
+function TerminologySection() {
+  const [mappings] = useState([
+    { id: 1, source: 'LOINC', code: '1558-6', relationship: 'SAME_AS', displayName: 'Fasting glucose [Mass/volume] in Serum or Plasma' },
+    { id: 2, source: 'SNOMED', code: '271062006', relationship: 'SAME_AS', displayName: 'Fasting blood glucose measurement' },
+  ]);
+  const sourceTagKind = { LOINC: 'blue', SNOMED: 'teal', CIEL: 'purple', OCL: 'warm-gray' };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.terminology.header.title', 'Terminology Mappings')}</h2>
+          <p>{t('admin.testCatalog.terminology.header.subtitle', 'Link this test to standard terminology codes for FHIR interoperability')}</p>
+        </div>
+        <Button kind="ghost" size="sm" renderIcon={Add}>{t('admin.testCatalog.terminology.action.addMapping', 'Add Mapping')}</Button>
+      </div>
+
+      {mappings.map(m => (
+        <Tile key={m.id} style={{ marginBottom: '12px' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: '12px' }}>
+            <div style={{ display: 'flex', gap: '12px', flex: 1 }}>
+              <Tag type={sourceTagKind[m.source]}>{m.source}</Tag>
+              <div style={{ flex: 1 }}>
+                <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+                  <code style={{ fontFamily: "'IBM Plex Mono', monospace", fontWeight: 500 }}>{m.code}</code>
+                  <Tag type="warm-gray">{m.relationship.replace('_', ' ')}</Tag>
+                </div>
+                <div style={{ fontSize: '13px', color: '#525252' }}>{m.displayName}</div>
+              </div>
+            </div>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              <Button kind="ghost" size="sm">{t('admin.testCatalog.common.button.edit', 'Edit')}</Button>
+              <Button kind="ghost" size="sm" style={{ color: '#da1e28' }}>{t('admin.testCatalog.common.button.delete', 'Delete')}</Button>
+            </div>
+          </div>
+        </Tile>
+      ))}
+
+      <Tile style={{ borderStyle: 'dashed' }}>
+        <h4 style={{ marginTop: 0, fontSize: '13px' }}>{t('admin.testCatalog.terminology.header.addNewMapping', 'Add New Mapping')}</h4>
+        <div style={{ display: 'grid', gridTemplateColumns: '180px 1fr 180px 80px', gap: '8px', alignItems: 'end' }}>
+          <Select id="term-source" labelText={t('admin.testCatalog.terminology.label.source', 'Terminology Source')} size="sm">
+            <SelectItem text={t('admin.testCatalog.common.option.select', 'Select...')} value="" />
+            <SelectItem text="LOINC" value="LOINC" />
+            <SelectItem text="SNOMED CT" value="SNOMED" />
+            <SelectItem text="CIEL" value="CIEL" />
+            <SelectItem text="OCL" value="OCL" />
+          </Select>
+          <TextInput id="term-code" labelText={t('admin.testCatalog.terminology.label.code', 'Code')} placeholder={t('admin.testCatalog.terminology.placeholder.code', 'Enter code')} size="sm" />
+          <Select id="term-rel" labelText={t('admin.testCatalog.terminology.label.relationship', 'Relationship')} size="sm">
+            <SelectItem text={t('admin.testCatalog.terminology.option.sameAs', 'Same As')} value="SAME_AS" />
+            <SelectItem text={t('admin.testCatalog.terminology.option.broaderThan', 'Broader Than')} value="BROADER_THAN" />
+            <SelectItem text={t('admin.testCatalog.terminology.option.narrowerThan', 'Narrower Than')} value="NARROWER_THAN" />
+          </Select>
+          <Button kind="primary" size="sm">{t('admin.testCatalog.common.button.add', 'Add')}</Button>
+        </div>
+        <small style={{ display: 'block', fontSize: '11px', color: '#a8a8a8', marginTop: '8px' }}>
+          {t('admin.testCatalog.terminology.helper.lookup', 'Display name will be auto-populated from terminology lookup; editable if lookup fails.')}
+        </small>
+      </Tile>
+    </div>
+  );
+}
+
+/**
+ * ReagentsSection — reagent cards with usage type, qty per test, current stock
+ */
+function ReagentsSection() {
+  const reagents = [
+    { id: 1, name: 'Glucose Reagent R1', manufacturer: 'Roche', usage: 'PRIMARY', qty: 100, unit: 'µL', stock: 2500 },
+    { id: 2, name: 'Glucose Reagent R2', manufacturer: 'Roche', usage: 'SECONDARY', qty: 50, unit: 'µL', stock: 1200 },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.reagents.header.title', 'Associated Reagents')}</h2>
+          <p>{t('admin.testCatalog.reagents.header.subtitle', 'Link reagents from inventory to track consumption')}</p>
+        </div>
+        <Button kind="primary" size="sm" renderIcon={Add}>{t('admin.testCatalog.reagents.action.linkReagent', 'Link Reagent')}</Button>
+      </div>
+
+      {reagents.map(r => (
+        <Tile key={r.id} style={{ marginBottom: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <div style={{ width: '40px', height: '40px', background: '#d1f3f6', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <FlaskConical size={20} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+                <strong style={{ fontSize: '14px' }}>{r.name}</strong>
+                <Tag type={r.usage === 'PRIMARY' ? 'blue' : 'green'}>{r.usage}</Tag>
+              </div>
+              <div style={{ fontSize: '13px', color: '#525252' }}>{r.manufacturer} • {r.qty} {r.unit} per test</div>
+            </div>
+            <div style={{ textAlign: 'right' }}>
+              <div style={{ fontWeight: 600, fontSize: '14px' }}>{r.stock.toLocaleString()} {r.unit}</div>
+              <div style={{ fontSize: '11px', color: '#525252' }}>{t('admin.testCatalog.reagents.label.currentStock', 'Current Stock')}</div>
+            </div>
+            <Button kind="ghost" size="sm" hasIconOnly iconDescription="Unlink" renderIcon={Close} style={{ color: '#da1e28' }}><Close /></Button>
+          </div>
+        </Tile>
+      ))}
+
+      <InlineNotification kind="info" lowContrast title="" subtitle={t('admin.testCatalog.reagents.notification.configuredIn', 'Reagents are configured in Administration → Master Lists → Reagents. Linking a reagent here records consumption per test run for inventory tracking.')} hideCloseButton />
+    </div>
+  );
+}
+
+/**
+ * AnalyzersSection — analyzer cards with status badges + Link Analyzer modal with multi-select
+ */
+function AnalyzersSection() {
+  const [showLink, setShowLink] = useState(false);
+  const linked = [
+    { id: 1, name: 'Cobas c 501', manufacturer: 'Roche', sn: 'SN-2024-0142', location: 'Chemistry Lab A', status: 'Online' },
+    { id: 2, name: 'Cobas c 502', manufacturer: 'Roche', sn: 'SN-2024-0143', location: 'Chemistry Lab B', status: 'Online' },
+  ];
+  const available = [
+    { id: 3, name: 'AU680', manufacturer: 'Beckman Coulter', sn: 'SN-2023-0098', location: 'Chemistry Lab A', status: 'Online' },
+    { id: 4, name: 'Architect c8000', manufacturer: 'Abbott', sn: 'SN-2022-0456', location: 'Chemistry Lab C', status: 'Maintenance' },
+    { id: 5, name: 'Vitros 5600', manufacturer: 'Ortho Clinical', sn: 'SN-2024-0201', location: 'STAT Lab', status: 'Online' },
+  ];
+  const statusKind = { Online: 'green', Maintenance: 'warm-gray', Offline: 'red' };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.analyzers.header.title', 'Linked Analyzers')}</h2>
+          <p>{t('admin.testCatalog.analyzers.header.subtitle', 'Select which analyzers can perform this test')}</p>
+        </div>
+        <Button kind="primary" size="sm" renderIcon={Add} onClick={() => setShowLink(true)}>{t('admin.testCatalog.analyzers.action.linkAnalyzer', 'Link Analyzer')}</Button>
+      </div>
+
+      {linked.map(a => (
+        <Tile key={a.id} style={{ marginBottom: '12px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <div style={{ width: '40px', height: '40px', background: '#e8e8e8', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <Cpu size={20} />
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ display: 'flex', gap: '8px', alignItems: 'center', marginBottom: '4px' }}>
+                <strong style={{ fontSize: '14px' }}>{a.name}</strong>
+                <Tag type={statusKind[a.status]}>{a.status}</Tag>
+              </div>
+              <div style={{ fontSize: '13px', color: '#525252' }}>{a.manufacturer} • {a.location}</div>
+              <div style={{ fontSize: '11px', color: '#a8a8a8', marginTop: '2px' }}>S/N: {a.sn}</div>
+            </div>
+            <Button kind="ghost" size="sm" hasIconOnly iconDescription="Unlink" renderIcon={Close} style={{ color: '#da1e28' }}><Close /></Button>
+          </div>
+        </Tile>
+      ))}
+
+      <InlineNotification kind="info" lowContrast title={t('admin.testCatalog.analyzers.notification.title', 'About Analyzer Linking')} subtitle={t('admin.testCatalog.analyzers.notification.body', 'Analyzers are configured in Administration → Master Lists → Analyzers. Test code mapping is configured separately in the analyzer interface setup. Linking an analyzer indicates this test can be performed on that instrument.')} hideCloseButton />
+
+      {showLink && (
+        <Modal
+          open={showLink}
+          onRequestClose={() => setShowLink(false)}
+          modalHeading={t('admin.testCatalog.analyzers.modal.linkAnalyzer', 'Link Analyzers')}
+          primaryButtonText={t('admin.testCatalog.analyzers.action.linkSelected', 'Link Selected')}
+          secondaryButtonText={t('admin.testCatalog.common.button.cancel', 'Cancel')}
+        >
+          <FormGroup legendText={t('admin.testCatalog.analyzers.label.selectAnalyzers', 'Select Analyzers')}>
+            <div style={{ border: '1px solid #d0d0d0', borderRadius: '4px', maxHeight: '280px', overflowY: 'auto' }}>
+              {available.map(a => (
+                <div key={a.id} style={{ display: 'flex', gap: '12px', alignItems: 'center', padding: '12px', borderBottom: '1px solid #f0f0f0' }}>
+                  <Checkbox id={`avail-${a.id}`} labelText="" hideLabel />
+                  <div style={{ flex: 1 }}>
+                    <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+                      <strong style={{ fontSize: '14px' }}>{a.name}</strong>
+                      <Tag type={statusKind[a.status]}>{a.status}</Tag>
+                    </div>
+                    <div style={{ fontSize: '12px', color: '#525252' }}>{a.manufacturer} • {a.location}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </FormGroup>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * AlertsSection — alert rule cards with channels, recipients, message templates + Add Rule modal (4 trigger types only)
+ */
+function AlertsSection() {
+  const [showAdd, setShowAdd] = useState(false);
+  const [rules, setRules] = useState([
+    { id: 1, name: 'Critical Value Alert', enabled: true, trigger: 'Critical Value', triggerKind: 'red', channels: ['SMS', 'Email'], recipients: ['Ordering Physician'], smsTemplate: 'CRITICAL: {{test_name}} result {{result}} {{unit}} for {{patient_name}}. Please review immediately.' },
+    { id: 2, name: 'Abnormal Result Notification', enabled: true, trigger: 'Abnormal (High or Low)', triggerKind: 'warm-gray', channels: ['Email'], recipients: ['Ordering Physician'], smsTemplate: '' },
+    { id: 3, name: 'Positive Result Alert', enabled: false, trigger: 'Equals "Positive"', triggerKind: 'blue', channels: ['SMS'], recipients: ['Patient'], smsTemplate: 'Lab result ready for {{patient_name}}. Please contact your healthcare provider.' },
+  ]);
+  const channelKind = { SMS: 'blue', Email: 'purple' };
+  const toggle = id => setRules(prev => prev.map(r => r.id === id ? { ...r, enabled: !r.enabled } : r));
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.alerts.header.title', 'Alert Rules')}</h2>
+          <p>{t('admin.testCatalog.alerts.header.subtitle', 'Configure automated notifications when specific result conditions are met')}</p>
+        </div>
+        <Button kind="primary" size="sm" renderIcon={Add} onClick={() => setShowAdd(true)}>
+          {t('admin.testCatalog.alerts.action.addRule', 'Add Rule')}
+        </Button>
+      </div>
+
+      {rules.map(r => (
+        <Tile key={r.id} style={{ marginBottom: '12px', padding: 0, opacity: r.enabled ? 1 : 0.7 }}>
+          <div style={{ padding: '12px', background: '#f4f4f4', borderBottom: '1px solid #e0e0e0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+              <div style={{ width: '8px', height: '8px', borderRadius: '50%', background: r.enabled ? '#24a148' : '#a8a8a8' }} />
+              <strong style={{ fontSize: '14px' }}>{r.name}</strong>
+              <Tag type={r.enabled ? 'green' : 'gray'}>{r.enabled ? 'Enabled' : 'Disabled'}</Tag>
+            </div>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              <Button kind="ghost" size="sm" onClick={() => toggle(r.id)}>{r.enabled ? 'Disable' : 'Enable'}</Button>
+              <Button kind="ghost" size="sm" hasIconOnly iconDescription="Edit" renderIcon={Edit}><Edit /></Button>
+              <Button kind="ghost" size="sm" hasIconOnly iconDescription="Delete" renderIcon={TrashCan} style={{ color: '#da1e28' }}><TrashCan /></Button>
+            </div>
+          </div>
+          <div style={{ padding: '12px' }}>
+            <div style={{ display: 'flex', gap: '24px', marginBottom: '12px' }}>
+              <div>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: '4px' }}>{t('admin.testCatalog.alerts.label.when', 'When')}</div>
+                <Tag type={r.triggerKind}>{r.trigger}</Tag>
+              </div>
+              <div>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: '4px' }}>{t('admin.testCatalog.alerts.label.notifyVia', 'Notify Via')}</div>
+                <div style={{ display: 'flex', gap: '4px' }}>
+                  {r.channels.map(c => <Tag key={c} type={channelKind[c]}>{c === 'SMS' ? '📱 ' : '📧 '}{c}</Tag>)}
+                </div>
+              </div>
+              <div>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: '4px' }}>{t('admin.testCatalog.alerts.label.recipients', 'Recipients')}</div>
+                <div style={{ display: 'flex', gap: '4px' }}>
+                  {r.recipients.map(rec => <Tag key={rec} type="gray">{rec}</Tag>)}
+                </div>
+              </div>
+            </div>
+            {r.smsTemplate && (
+              <div style={{ paddingTop: '12px', borderTop: '1px solid #f0f0f0' }}>
+                <div style={{ fontSize: '11px', fontWeight: 600, color: '#525252', textTransform: 'uppercase', marginBottom: '4px' }}>{t('admin.testCatalog.alerts.label.smsTemplate', 'SMS Template')}</div>
+                <div style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: '12px', padding: '8px', background: '#f4f4f4', borderRadius: '3px' }}>{r.smsTemplate}</div>
+              </div>
+            )}
+          </div>
+        </Tile>
+      ))}
+
+      {showAdd && (
+        <Modal
+          open={showAdd}
+          onRequestClose={() => setShowAdd(false)}
+          modalHeading={t('admin.testCatalog.alerts.modal.addRule', 'Add Alert Rule')}
+          primaryButtonText={t('admin.testCatalog.alerts.action.saveRule', 'Save Alert Rule')}
+          secondaryButtonText={t('admin.testCatalog.common.button.cancel', 'Cancel')}
+          size="lg"
+        >
+          <TextInput id="rule-name" labelText={t('admin.testCatalog.alerts.label.ruleName', 'Rule Name')} placeholder="e.g., Critical Value SMS Alert" style={{ marginBottom: '16px' }} />
+          <FormGroup legendText={t('admin.testCatalog.alerts.label.alertWhen', 'Alert when result is:')} style={{ marginBottom: '16px' }}>
+            <RadioButtonGroup name="trigger" valueSelected="critical" orientation="vertical">
+              <RadioButton labelText={t('admin.testCatalog.alerts.option.allResults', 'All Results')} value="all" />
+              <RadioButton labelText={t('admin.testCatalog.alerts.option.abnormal', 'Abnormal (outside normal range)')} value="abnormal" />
+              <RadioButton labelText={t('admin.testCatalog.alerts.option.critical', 'Critical (panic value)')} value="critical" />
+              <RadioButton labelText={t('admin.testCatalog.alerts.option.specificValue', 'Specific Value')} value="specific" />
+            </RadioButtonGroup>
+          </FormGroup>
+          <FormGroup legendText={t('admin.testCatalog.alerts.label.sendVia', 'Send via:')} style={{ marginBottom: '16px' }}>
+            <div style={{ display: 'flex', gap: '16px' }}>
+              <Checkbox id="ch-sms" labelText="📱 SMS" />
+              <Checkbox id="ch-email" labelText="📧 Email" />
+            </div>
+          </FormGroup>
+          <FormGroup legendText={t('admin.testCatalog.alerts.label.recipientsLabel', 'Recipients:')} style={{ marginBottom: '16px' }}>
+            <Stack gap={3}>
+              <Checkbox id="rcp-physician" labelText={t('admin.testCatalog.alerts.option.orderingPhysician', 'Ordering Physician (from order)')} />
+              <Checkbox id="rcp-patient" labelText={t('admin.testCatalog.alerts.option.patient', 'Patient (from patient record)')} />
+              <Checkbox id="rcp-custom" labelText={t('admin.testCatalog.alerts.option.customRecipient', 'Custom recipient:')} />
+              <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '8px', marginLeft: '24px' }}>
+                <TextInput id="rcp-phone" labelText="" hideLabel placeholder="Phone: +1 555-123-4567" />
+                <TextInput id="rcp-email" labelText="" hideLabel placeholder="Email: user@example.com" />
+              </div>
+            </Stack>
+          </FormGroup>
+          <TextArea id="sms-template" labelText={t('admin.testCatalog.alerts.label.smsTemplateLabel', 'SMS Template (160 char recommended)')} rows={3} placeholder="CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}. Review immediately." />
+          <small style={{ display: 'block', fontSize: '11px', color: '#525252', marginTop: '4px' }}>
+            Variables: {'{{patient_name}}, {{patient_id}}, {{test_name}}, {{result}}, {{unit}}, {{reference_range}}'}
+          </small>
+        </Modal>
+      )}
+    </div>
+  );
+}
+
+/**
+ * ReflexCalcSection — bidirectional reflex display + calculated results, all read-only with edit links to Master Lists
+ */
+function ReflexCalcSection() {
+  const reflexBy = [
+    { id: 1, condition: '> 200 mg/dL', target: 'Hemoglobin A1c', mode: 'Suggest', modeKind: 'warm-gray' },
+    { id: 2, condition: '= "Abnormal"', target: 'Glucose Tolerance Test', mode: 'Auto-order', modeKind: 'green' },
+  ];
+  const reflexInto = [
+    { id: 101, sourceTest: 'Glucose Tolerance Test', condition: '2-hour result > 140' },
+  ];
+  const calcs = [
+    { id: 201, name: 'LDL Cholesterol (Calculated)', formula: 'Total_Chol - HDL - (Triglycerides / 5)' },
+  ];
+
+  return (
+    <div>
+      <Tile style={{ marginBottom: '16px' }}>
+        <h3 style={{ marginTop: 0 }}>⚡ {t('admin.testCatalog.reflexCalc.header.reflexTests', 'Reflex Tests')}</h3>
+        <p style={{ fontSize: '13px', color: '#525252' }}>{t('admin.testCatalog.reflexCalc.header.reflexSubtitle', 'Automatic test ordering based on results')}</p>
+
+        <h4 style={{ fontSize: '13px', marginBottom: '8px', marginTop: '16px' }}>{t('admin.testCatalog.reflexCalc.header.triggeredBy', 'Rules triggered BY this test:')}</h4>
+        {reflexBy.map(r => (
+          <div key={r.id} style={{ padding: '12px', background: '#f4f4f4', border: '1px solid #e0e0e0', borderRadius: '4px', marginBottom: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: '12px', alignItems: 'center', fontSize: '13px' }}>
+              <span style={{ color: '#525252' }}>IF result</span>
+              <strong>{r.condition}</strong>
+              <span style={{ color: '#525252' }}>→ ORDER</span>
+              <strong style={{ color: '#0f62fe' }}>{r.target}</strong>
+              <Tag type={r.modeKind}>{r.mode}</Tag>
+            </div>
+            <a href="#" style={{ fontSize: '13px', color: '#0f62fe', fontWeight: 500 }}>{t('admin.testCatalog.reflexCalc.action.editInMasterLists', 'Edit in Master Lists →')}</a>
+          </div>
+        ))}
+
+        <h4 style={{ fontSize: '13px', marginBottom: '8px', marginTop: '16px' }}>{t('admin.testCatalog.reflexCalc.header.thatOrder', 'Rules that ORDER this test:')}</h4>
+        {reflexInto.map(r => (
+          <div key={r.id} style={{ padding: '12px', background: '#e3f2fd', border: '1px solid #bce5fe', borderRadius: '4px', marginBottom: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ fontSize: '13px' }}>
+              <span style={{ color: '#0f62fe' }}>↳ </span>
+              <strong>{r.sourceTest}</strong>
+              <span style={{ color: '#525252' }}> when {r.condition}</span>
+            </div>
+            <a href="#" style={{ fontSize: '13px', color: '#0f62fe', fontWeight: 500 }}>{t('admin.testCatalog.reflexCalc.action.editInMasterLists', 'Edit in Master Lists →')}</a>
+          </div>
+        ))}
+
+        <a href="#" style={{ display: 'inline-block', marginTop: '8px', fontSize: '13px', color: '#0f62fe', fontWeight: 500 }}>
+          {t('admin.testCatalog.reflexCalc.action.addNewReflexRule', '+ Add New Reflex Rule in Master Lists →')}
+        </a>
+      </Tile>
+
+      <Tile>
+        <h3 style={{ marginTop: 0 }}>⚡ {t('admin.testCatalog.reflexCalc.header.calculatedResults', 'Calculated Results')}</h3>
+        <p style={{ fontSize: '13px', color: '#525252' }}>{t('admin.testCatalog.reflexCalc.header.calculatedSubtitle', 'Formulas that compute results from other test values')}</p>
+
+        <h4 style={{ fontSize: '13px', marginBottom: '8px' }}>{t('admin.testCatalog.reflexCalc.header.usingThisAsInput', 'Calculations that USE this test as input:')}</h4>
+        {calcs.map(c => (
+          <div key={c.id} style={{ padding: '12px', background: '#f3e8ff', border: '1px solid #e0c3fc', borderRadius: '4px', marginBottom: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ display: 'flex', gap: '12px', alignItems: 'center' }}>
+              <div style={{ width: '32px', height: '32px', background: '#e0c3fc', borderRadius: '4px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>⚡</div>
+              <div>
+                <div style={{ fontSize: '13px', fontWeight: 500 }}>{c.name}</div>
+                <div style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: '11px', color: '#525252', marginTop: '2px' }}>{c.formula}</div>
+              </div>
+            </div>
+            <a href="#" style={{ fontSize: '13px', color: '#0f62fe', fontWeight: 500 }}>{t('admin.testCatalog.reflexCalc.action.editInMasterLists', 'Edit in Master Lists →')}</a>
+          </div>
+        ))}
+
+        <h4 style={{ fontSize: '13px', marginBottom: '8px', marginTop: '16px' }}>{t('admin.testCatalog.reflexCalc.header.thisIsCalculated', 'This test IS a calculated result:')}</h4>
+        <div style={{ padding: '16px', border: '2px dashed #d0d0d0', borderRadius: '4px', textAlign: 'center' }}>
+          <div style={{ fontSize: '24px', marginBottom: '8px' }}>⚡</div>
+          <div style={{ fontSize: '13px', color: '#525252', marginBottom: '8px' }}>
+            {t('admin.testCatalog.reflexCalc.empty.notCalculated', "This test's result is not calculated from other values")}
+          </div>
+          <a href="#" style={{ fontSize: '13px', color: '#0f62fe', fontWeight: 500 }}>
+            {t('admin.testCatalog.reflexCalc.action.configureInMasterLists', '+ Configure in Master Lists →')}
+          </a>
+        </div>
+      </Tile>
+    </div>
+  );
+}
+
+/**
+ * ComplianceSection — regulatory threshold DataTable with Group By + Add Threshold
+ */
+function ComplianceSection() {
+  const [groupBy, setGroupBy] = useState('standard');
+  const thresholds = [
+    { id: 1, std: 'PP No. 22/2021 — Baku Mutu Air', grp: 'Parameter Fisika', type: 'MAX', value: '≤ 25 NTU', date: '2021-02-02' },
+    { id: 2, std: 'WHO Drinking Water Guidelines', grp: 'Chemical Contaminants', type: 'MAX', value: '≤ 5 NTU', date: '2022-03-21' },
+    { id: 3, std: 'EPA Method 180.1', grp: 'Reporting Limits', type: 'RANGE', value: '0.1–4000 NTU', date: '2018-01-15' },
+  ];
+  const typeKind = { MAX: 'red', MIN: 'blue', RANGE: 'teal', DESCRIPTIVE: 'purple' };
+
+  return (
+    <div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', marginBottom: '16px' }}>
+        <div>
+          <h2>{t('admin.testCatalog.compliance.header.title', 'Compliance Thresholds')}</h2>
+          <p>{t('admin.testCatalog.compliance.header.subtitle', 'Regulatory compliance thresholds for this test')}</p>
+        </div>
+        <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+          <span style={{ fontSize: '13px' }}>{t('admin.testCatalog.compliance.label.groupBy', 'Group by:')}</span>
+          <Select id="group-by" labelText="" hideLabel value={groupBy} onChange={e => setGroupBy(e.target.value)} size="sm">
+            <SelectItem value="standard" text={t('admin.testCatalog.compliance.option.byStandard', 'Standard')} />
+            <SelectItem value="parameter" text={t('admin.testCatalog.compliance.option.byParameterGroup', 'Parameter Group')} />
+          </Select>
+          <Button kind="primary" size="sm" renderIcon={Add}>
+            {t('admin.testCatalog.compliance.action.addThreshold', 'Add Threshold')}
+          </Button>
+        </div>
+      </div>
+
+      <p style={{ fontSize: '13px', color: '#525252', marginBottom: '12px' }}>
+        {t('admin.testCatalog.compliance.helper.aboutThresholds', 'Environmental tests use these instead of (or alongside) clinical reference ranges. Full compliance standards are managed at Admin → Test Management → Compliance Standards.')}
+      </p>
+
+      <DataTable
+        headers={[
+          { key: 'std', header: t('admin.testCatalog.compliance.column.standard', 'Standard') },
+          { key: 'grp', header: t('admin.testCatalog.compliance.column.parameterGroup', 'Parameter Group') },
+          { key: 'type', header: t('admin.testCatalog.compliance.column.type', 'Type') },
+          { key: 'value', header: t('admin.testCatalog.compliance.column.value', 'Value') },
+          { key: 'date', header: t('admin.testCatalog.compliance.column.effectiveDate', 'Effective Date') },
+          { key: 'actions', header: '' },
+        ]}
+        rows={thresholds.map(th => ({ id: String(th.id), ...th }))}
+      >
+        {({ headers, getTableProps, getHeaderProps }) => (
+          <TableContainer>
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map(h => <TableHeader key={h.key} {...getHeaderProps({ header: h })}>{h.header}</TableHeader>)}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {thresholds.map(th => (
+                  <TableRow key={th.id}>
+                    <TableCell>{th.std}</TableCell>
+                    <TableCell>{th.grp}</TableCell>
+                    <TableCell><Tag type={typeKind[th.type]}>{th.type}</Tag></TableCell>
+                    <TableCell style={{ fontWeight: 500 }}>{th.value}</TableCell>
+                    <TableCell style={{ color: '#525252' }}>{th.date}</TableCell>
+                    <TableCell><Button kind="ghost" size="sm">{t('admin.testCatalog.common.button.edit', 'Edit')}</Button></TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
+    </div>
+  );
+}
+
+// ==================== TEST EDITOR ====================
+/**
+ * TestEditor — main editor with SideNav and section dispatch
+ */
+function TestEditor({ test, setTest, onBack }) {
+  const [currentSection, setCurrentSection] = useState('basic');
+
+  const sections = [
+    { id: 'basic', label: t('admin.testCatalog.section.basicInfo', 'Basic Info') },
+    { id: 'sample', label: t('admin.testCatalog.section.sampleResults', 'Sample & Results') },
+    { id: 'methods', label: t('admin.testCatalog.section.methods', 'Methods') },
+    { id: 'ranges', label: t('admin.testCatalog.section.ranges', 'Ranges') },
+    { id: 'storage', label: t('admin.testCatalog.section.sampleStorage', 'Sample Storage') },
+    { id: 'order', label: t('admin.testCatalog.section.displayOrder', 'Display Order') },
+    { id: 'panels', label: t('admin.testCatalog.section.panels', 'Panels') },
+    { id: 'labels', label: t('admin.testCatalog.section.labels', 'Labels') },
+    { id: 'terminology', label: t('admin.testCatalog.section.terminology', 'Terminology') },
+    { id: 'reagents', label: t('admin.testCatalog.section.reagents', 'Reagents') },
+    { id: 'analyzers', label: t('admin.testCatalog.section.analyzers', 'Analyzers') },
+    { id: 'alerts', label: t('admin.testCatalog.section.alerts', 'Alerts') },
+    { id: 'reflex', label: t('admin.testCatalog.section.reflexCalc', 'Reflex & Calc') },
+  ];
+
+  // Hide Compliance if CLINICAL domain
+  const visibleSections = test.domain === 'CLINICAL'
+    ? sections
+    : [...sections, { id: 'compliance', label: t('admin.testCatalog.section.compliance', 'Compliance') }];
+
+  return (
+    <div>
+      <div style={{ background: '#fff', borderBottom: '1px solid #e0e0e0', padding: '16px 24px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+          <Button kind="ghost" onClick={onBack}>
+            ← {t('admin.testCatalog.editor.action.testList', 'Test List')}
+          </Button>
+          <h1 style={{ margin: 0, fontSize: '24px', fontWeight: 600 }}>{test.name}</h1>
+        </div>
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <Button kind="secondary" onClick={onBack}>
+            {t('admin.testCatalog.editor.action.cancel', 'Cancel')}
+          </Button>
+          <Button kind="primary">
+            {t('admin.testCatalog.editor.action.save', 'Save Test')}
+          </Button>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', minHeight: 'calc(100vh - 100px)' }}>
+        {/* SideNav */}
+        <div style={{ width: '280px', background: '#fff', borderRight: '1px solid #e0e0e0', overflowY: 'auto' }}>
+          <div style={{ padding: '16px', borderBottom: '1px solid #e0e0e0', fontSize: '13px', fontWeight: 600, color: '#525252' }}>
+            {t('admin.testCatalog.sidenav.header.testCatalogManagement', 'Test Catalog Management')}
+          </div>
+          {visibleSections.map((sec) => (
+            <div
+              key={sec.id}
+              onClick={() => setCurrentSection(sec.id)}
+              style={{
+                padding: '12px 16px',
+                cursor: 'pointer',
+                fontSize: '13px',
+                borderLeft: currentSection === sec.id ? '3px solid #0f62fe' : '3px solid transparent',
+                background: currentSection === sec.id ? '#e3f2fd' : '#fff',
+                color: currentSection === sec.id ? '#0f62fe' : '#525252',
+                fontWeight: currentSection === sec.id ? 600 : 400,
+                transition: 'all 0.2s',
+              }}
+            >
+              {sec.label}
+            </div>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div style={{ flex: 1, padding: '24px', overflowY: 'auto' }}>
+          {test && (test.domain === 'ENVIRONMENTAL' || test.domain === 'VECTOR') && currentSection === 'ranges' && (
+            <InlineNotification
+              kind="info"
+              title={t('admin.testCatalog.ranges.notification.title', 'Domain Note')}
+              subtitle={`${t('admin.testCatalog.ranges.notification.compliancePrimary', 'This is an')} ${test.domain === 'ENVIRONMENTAL' ? 'Environmental' : 'Vector'} ${t('admin.testCatalog.ranges.notification.compliancePrimary2', 'test. Compliance thresholds are typically the primary evaluation surface for this domain.')}`}
+              style={{ marginBottom: '24px' }}
+            />
+          )}
+
+          {currentSection === 'basic' && <BasicInfoSection test={test} setTest={setTest} />}
+          {currentSection === 'sample' && <SampleResultsSection test={test} setTest={setTest} />}
+          {currentSection === 'methods' && <MethodsSection />}
+          {currentSection === 'ranges' && <RangesSection test={test} />}
+          {currentSection === 'storage' && <SampleStorageSection />}
+          {currentSection === 'order' && <DisplayOrderSection />}
+          {currentSection === 'panels' && <PanelsSection />}
+          {currentSection === 'labels' && <LabelsSection />}
+          {currentSection === 'terminology' && <TerminologySection test={test} />}
+          {currentSection === 'reagents' && <ReagentsSection />}
+          {currentSection === 'analyzers' && <AnalyzersSection />}
+          {currentSection === 'alerts' && <AlertsSection />}
+          {currentSection === 'reflex' && <ReflexCalcSection />}
+          {currentSection === 'compliance' && <ComplianceSection />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ==================== APP ROOT ====================
+/**
+ * App — root component managing screen state (list vs editor) and test selection
+ */
+function App() {
+  const [screen, setScreen] = useState('list');
+  const [selectedTest, setSelectedTest] = useState(null);
+  const [test, setTest] = useState(null);
+
+  const handleEdit = (t) => {
+    setSelectedTest(t);
+    setTest({ ...t });
+    setScreen('editor');
+  };
+
+  const handleAdd = () => {
+    const blankTest = {
+      id: null,
+      name: t('admin.testCatalog.editor.placeholder.newTest', 'New Test'),
+      section: '',
+      sampleType: '',
+      resultType: 'NUMERIC',
+      loinc: null,
+      status: 'Active',
+      domain: 'CLINICAL',
+      amr: false,
+    };
+    setSelectedTest(blankTest);
+    setTest(blankTest);
+    setScreen('editor');
+  };
+
+  if (screen === 'editor' && selectedTest) {
+    return (
+      <TestEditor
+        test={test || selectedTest}
+        setTest={setTest}
+        onBack={() => {
+          setScreen('list');
+          setSelectedTest(null);
+          setTest(null);
+        }}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <div style={{ background: '#fff', borderBottom: '1px solid #e0e0e0', padding: '16px 24px' }}>
+        <h1 style={{ margin: 0 }}>{t('admin.testCatalog.list.header.title', 'Test Catalog Management')}</h1>
+      </div>
+      <TestListView onEdit={handleEdit} onAdd={handleAdd} />
+    </div>
+  );
+}
+
+export default App;

--- a/designs/admin-config/test-catalog.jsx
+++ b/designs/admin-config/test-catalog.jsx
@@ -13,10 +13,11 @@ import {
 import {
   Add, Edit, TrashCan, ChevronDown, ChevronUp, Information, Renew,
   Download, Upload, Save, Draggable, Search as SearchIcon, Catalog,
-  Settings, NotificationFilled, Email, Phone, Thermometer, Snowflake, Beaker,
-  Activity, FlowConnection, ChartLine, Printer, Cpu, FlaskConical,
+  Settings, NotificationFilled, Email, Phone, Snowflake,
+  Activity, FlowConnection, ChartLine, Printer,
   CheckmarkOutline, WarningAlt, Filter, Locked, Unlocked, Close, Copy,
 } from '@carbon/icons-react';
+import { FlaskConical, Cpu } from 'lucide-react';
 
 // ==================== I18N HELPER ====================
 const t = (key, fallback) => fallback || key;

--- a/designs/admin-config/test-catalog.md
+++ b/designs/admin-config/test-catalog.md
@@ -1,8 +1,624 @@
 # Test Catalog Management - Updated Requirements
 
-**Version:** 2.1
-**Date:** April 2, 2026
-**Changes:** v2.1 — Added Compliance tab for regulatory threshold management (S-01 integration). v2.0 — Added functional coverage validation, test ordering, panel association, inline method/panel creation, multi-select test sections
+**Version:** 2.3
+**Date:** April 27, 2026
+**Changes:**
+- **v2.3** — JSX–FRS reconciliation pass. Added a Terminology Mappings section (the v2.1 JSX has a full Terminology tab supporting LOINC/SNOMED/CIEL/OCL that was missing from the FRS). Added a Sample & Results Configuration section covering Sample Types multi-select, Default Sample Type, Result Type (Numeric / Select List / Multi-select / Free Text), Unit of Measure, Significant Digits, Default Result, and Select List Options sub-table. Added the Test List View full filter set (Section / Sample Type / Result Type / Status alongside Domain and AMR) and pagination. Replaced the Actions column / per-row Edit / per-row Deactivate with a click-to-open interaction (test name link + entire row clickable; no Actions column). Reconciled the Alert Rules trigger taxonomy (dropped the unimplemented Custom Expression to match the four-trigger model in the JSX). Deepened the Range Editor section to spec the three view modes (Structured / Table / Visual) and the Coverage Validation Panel visual treatment. Full Localization key extraction (226 keys, down from 234 after dropping bulk-action and toolbar keys) landed in this version. **Out of scope for v2.3** (deferred to other features): bulk activate / deactivate / add-to-panel UX (decided redundant — every operation lives inside the editor), Test List View toolbar buttons (Export / Import / Fetch from Hub), per-row Duplicate action, "Remark Only" result type.
+- **v2.2** — Constitution audit pass against v1.10.0. Added Overview, User Stories, Internal Information Architecture, Permissions, and States sections. Replaced the in-page "vertical tab sidebar" pattern with a SideNav-route-per-section pattern. Added the Test Domain field (CLINICAL / ENVIRONMENTAL / VECTOR). Removed accidental reuse of the global admin IA group labels inside the editor. Consolidated duplicate Sample Storage Tab section. Re-encoded clean UTF-8.
+- **v2.1** — Added Compliance tab for regulatory threshold management (S-01 integration).
+- **v2.0** — Added functional coverage validation, test ordering, panel association, inline method/panel creation, multi-select test sections.
+
+---
+
+## Overview
+
+Test Catalog Management is the OpenELIS admin surface where lab managers and admins define every test the lab offers — its identity, what it measures, how its results are interpreted, what equipment runs it, where it appears in panels and order entry, and any reactive workflows (alerts, reflex tests, regulatory thresholds) that fire from its results.
+
+This redesign consolidates work that previously required navigating across five separate admin pages (Test, Test Section, Panel, Method, Reagent) into a single editor with 14 routed sub-sections. Each sub-section addresses one well-bounded admin job (e.g., "configure normal ranges for this test" or "link an analyzer to this test"). Most jobs touch a single section; only "add a new test from scratch" traverses many sections, and that workflow is supported by the natural SideNav order.
+
+The redesign also fills three concrete gaps the field surfaced in 2025–2026: hour-level critical-value ranges for neonatal tests, AMR test mapping for WHONET surveillance, and per-test regulatory compliance thresholds for environmental and food-safety labs (per the S-01 companion FRS).
+
+---
+
+## User Stories
+
+1. **As a lab manager**, I want to configure all properties of a test (basic info, ranges, sample storage, panels, alerts, AMR mapping, compliance thresholds) from a single editor, so that catalog setup doesn't require navigating across five admin pages.
+2. **As a lab admin setting up neonatal bilirubin**, I want to define hour-level critical-value ranges with gap detection, so that I can be confident every age window has a defined panic threshold before the test goes live.
+3. **As a lab admin in a multi-language deployment**, I want missing translations to fall back gracefully (selected language → primary language → first available → internal code), so that a partially-translated test never breaks order entry or result review.
+4. **As an AMR surveillance officer**, I want to flag tests for WHONET export with proper antibiotic codes and breakpoint standards, so that monthly GLASS reporting requires no manual mapping.
+5. **As an environmental lab admin in Indonesia**, I want to attach Baku Mutu compliance thresholds to a water quality test, so that result entry can flag values that exceed regulatory limits without me running them against a separate spreadsheet.
+
+---
+
+## Internal Information Architecture
+
+The test editor is reached from the global Admin SideNav under **Test Catalog Management**. The 14 sub-sections are exposed as `SideNavMenuItem` entries beneath the parent Test Catalog Management entry, presented as a **flat list in workflow order — no group headers**.
+
+Workflow order (top to bottom in the SideNav):
+
+1. Basic Info
+2. Sample & Results
+3. Methods
+4. Ranges
+5. Sample Storage
+6. Display Order
+7. Panels
+8. Labels
+9. Terminology
+10. Reagents
+11. Analyzers
+12. Alerts
+13. Reflex & Calc
+14. Compliance
+
+**Routing:** each sub-section is its own route, e.g.
+`/admin/test-catalog/:testId/basic-info`,
+`/admin/test-catalog/:testId/ranges`,
+`/admin/test-catalog/:testId/compliance`.
+Sub-sections are deep-linkable. Breadcrumb pattern: *Admin › Test Catalog Management › [Test Name] › [Section Name]*.
+
+**Why no group headers:** the global Admin SideNav already groups admin pages under labels like Configuration / Organization / Resources / Automation / Compliance. Reusing those labels inside this editor would create visual confusion (the user sees the same headings at two levels of the sidebar). Most jobs in the editor are single-section, so a flat list with workflow ordering is sufficient — the cognitive cost of grouping does not pay back.
+
+**No in-page tabs.** The deprecated "vertical tab sidebar" pattern from v2.1 is removed. Carbon `Tabs` are not used for the editor's primary navigation. (Tabs remain acceptable for *transient inline state within a single section's form*, but no major sub-view of the test editor uses them.)
+
+**Domain-conditional visibility.** A test's `domain` attribute (CLINICAL / ENVIRONMENTAL / VECTOR — see the Test Domain section) controls which SideNav items are visible:
+
+- CLINICAL tests **hide** the Compliance section.
+- ENVIRONMENTAL and VECTOR tests **show** all 14 sections, but the Ranges section displays a domain-aware InlineNotification banner directing the user to Compliance as the primary evaluation surface.
+
+Section-visibility logic runs client-side at SideNav render time and is also enforced at the API layer for the affected routes.
+
+---
+
+## Permissions
+
+OpenELIS admin permissions are binary by convention (the admin menu is all-or-nothing except for Test Catalog Management itself). This redesign honors that convention rather than introducing a new sub-key role matrix.
+
+| Key | Scope | Enforcement |
+|---|---|---|
+| `admin.testCatalog.manage` | View and edit the entire Test Catalog Management section, including all 14 sub-sections of the test editor. Required to reach any `/admin/test-catalog/...` route. | UI: hide the Test Catalog Management entry from the Admin SideNav and 403 the routes. API: every test-catalog write endpoint returns HTTP 403 without this permission. |
+| `compliance.threshold.view` | View the Compliance sub-section of the test editor. | UI: hide the Compliance SideNav item. API: `GET /api/tests/{id}/compliance-thresholds` returns HTTP 403. (Per the S-01 companion FRS, separate `compliance.threshold.manage` keys gate writes.) |
+
+**Out of scope for this revision:** sub-section role matrices (e.g., a separate AMR officer key, a separate Alerts manager key). If finer-grained admin RBAC becomes a need across OpenELIS, that should be a constitution-level change handled in its own spec, not invented inside Test Catalog Management.
+
+**Acceptance:**
+- [ ] Without `admin.testCatalog.manage`, the Test Catalog Management entry is absent from the Admin SideNav.
+- [ ] Without `admin.testCatalog.manage`, every `/admin/test-catalog/...` route returns 403 at the API level.
+- [ ] Without `compliance.threshold.view`, the Compliance SideNav item is hidden and the Compliance route returns 403.
+- [ ] Permission checks are enforced at both the UI layer (hide/disable) and the API layer (HTTP 403). UI-only enforcement is insufficient.
+
+---
+
+## States
+
+Every major surface in the test editor and the test list view defines four standard states:
+
+| State | When | Pattern |
+|---|---|---|
+| **Empty** | First-time setup — no tests configured yet, no ranges defined, no analyzers linked, etc. | Carbon-styled empty state with a primary action button (e.g., "Add Test", "Add Range"). Helper text explaining what the section is for. |
+| **Loading** | Initial fetch, save in progress, optimistic update pending. | Carbon `<DataTableSkeleton>` for table-bearing sections; Carbon `<SkeletonText>` for form-bearing sections; Carbon `<Loading>` overlay during save. No spinners in the body. |
+| **Error** | API call failed, validation failed, conflict on save. | Carbon `<InlineNotification kind="error">` at the top of the affected section. Specific error message; retry CTA where applicable. Validation errors attach to the field via Carbon's built-in `invalid` / `invalidText` props. |
+| **No permission** | User lacks the required permission key. | The SideNav item is hidden (not disabled). If the user lands on the route directly, the page renders a Carbon empty state with a "You do not have permission" message and a link back to the Admin landing. |
+
+**Surfaces that need explicit empty states:** Test List View, Ranges, Methods, Analyzers, Reagents, Alerts, Reflex & Calc, Compliance, Panels, Labels.
+
+**Surfaces that need explicit loading skeletons:** Test List View (table), Ranges (table), Compliance (table), any section that fetches list data.
+
+---
+
+## Localization
+
+All user-facing strings in the Test Catalog Management UI are externalized via React Intl per Constitution VII. Keys are namespaced under `admin.testCatalog.*` with a stable convention:
+
+```
+admin.testCatalog.<surface>.<element>.<id>
+```
+
+Where `<surface>` is one of `list`, `editor`, `<section>` (e.g., `ranges`, `compliance`); `<element>` is one of `action`, `header`, `label`, `placeholder`, `helper`, `error`, `confirm`; and `<id>` is a short stable identifier.
+
+**Examples:**
+
+| Key | English fallback | Used in |
+|---|---|---|
+| `admin.testCatalog.list.action.addTest` | "Add Test" | Test list view header CTA |
+| `admin.testCatalog.list.action.import` | "Import" | Test list view toolbar |
+| `admin.testCatalog.list.header.title` | "Test Catalog Management" | Test list view page title |
+| `admin.testCatalog.editor.action.save` | "Save Test" | Editor footer primary CTA |
+| `admin.testCatalog.editor.action.cancel` | "Cancel" | Editor footer secondary CTA |
+| `admin.testCatalog.basicInfo.label.name` | "Test Name" | Basic Info form |
+| `admin.testCatalog.ranges.confirm.deleteRange` | "Delete this range? This affects all results entered with this configuration." | Delete-range modal |
+| `admin.testCatalog.compliance.empty.title` | "No compliance thresholds configured" | Compliance empty state |
+
+**Full Localization Key Extraction (v2.2)**
+
+Complete table extracted from v2.1 JSX preview and compiled below as Markdown tables per surface, per Constitution v1.10.0 mandate. All 234 keys organized by surface category, element type, and usage context. Common-namespace keys aggressively reused across surfaces for identical English strings.
+
+### common
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.common.label.required` | `*` (asterisk) | Form field requirements |
+| `admin.testCatalog.common.label.optional` | `(optional)` | Form field modifiers |
+| `admin.testCatalog.common.button.add` | `Add` | Multiple contexts (ranges, panels, rules) |
+| `admin.testCatalog.common.button.create` | `Create` | Panel/method creation |
+| `admin.testCatalog.common.button.edit` | `Edit` | Inline edit buttons |
+| `admin.testCatalog.common.button.delete` | `Delete` | Trash icon tooltips |
+| `admin.testCatalog.common.button.cancel` | `Cancel` | Modal/form dismiss |
+| `admin.testCatalog.common.button.save` | `Save` | Form submission |
+| `admin.testCatalog.common.button.search` | `Search` | Test search modals |
+| `admin.testCatalog.common.button.clearAll` | `Clear All` | Filter reset |
+| `admin.testCatalog.common.action.enable` | `Enable` | Alert rule state change |
+| `admin.testCatalog.common.action.disable` | `Disable` | Alert rule state change |
+| `admin.testCatalog.common.text.all` | `All` | Coverage/age/sex option |
+| `admin.testCatalog.common.text.male` | `Male` | Sex badge |
+| `admin.testCatalog.common.text.female` | `Female` | Sex badge |
+| `admin.testCatalog.common.text.noResults` | `No results` | Empty states |
+| `admin.testCatalog.common.status.active` | `Active` | Test/analyzer status |
+| `admin.testCatalog.common.status.inactive` | `Inactive` | Test status |
+| `admin.testCatalog.common.status.online` | `Online` | Analyzer status |
+| `admin.testCatalog.common.status.offline` | `Offline` | Analyzer status |
+| `admin.testCatalog.common.status.maintenance` | `Maintenance` | Analyzer status |
+| `admin.testCatalog.common.status.enabled` | `Enabled` | Alert rule indicator |
+| `admin.testCatalog.common.status.disabled` | `Disabled` | Alert rule indicator |
+
+### list
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.list.header.title` | `Test Catalog Management` | Page title |
+| `admin.testCatalog.list.header.subtitle` | `Manage laboratory tests, panels, and configurations` | Page subtitle |
+| `admin.testCatalog.list.placeholder.search` | `Search tests...` | Search bar |
+| `admin.testCatalog.list.button.addTest` | `Add Test` | CTA button with Plus icon |
+| `admin.testCatalog.list.button.filter` | `Filters` | Toggle filters bar |
+| `admin.testCatalog.list.filter.allSections` | `All Sections` | Section filter option |
+| `admin.testCatalog.list.filter.allSampleTypes` | `All Sample Types` | Sample type filter |
+| `admin.testCatalog.list.filter.allResultTypes` | `All Result Types` | Result type filter |
+| `admin.testCatalog.list.filter.allStatuses` | `All Statuses` | Status filter |
+| `admin.testCatalog.list.filter.allTests` | `All Tests` | AMR filter default |
+| `admin.testCatalog.list.filter.amrOnly` | `AMR Tests Only` | AMR filter option |
+| `admin.testCatalog.list.filter.nonAmr` | `Non-AMR Tests` | AMR filter option |
+| `admin.testCatalog.list.column.testName` | `Test Name` | Table header |
+| `admin.testCatalog.list.column.section` | `Section` | Table header |
+| `admin.testCatalog.list.column.sampleType` | `Sample Type` | Table header |
+| `admin.testCatalog.list.column.resultType` | `Result Type` | Table header |
+| `admin.testCatalog.list.column.loinc` | `LOINC` | Table header |
+| `admin.testCatalog.list.column.status` | `Status` | Table header |
+| `admin.testCatalog.list.column.actions` | `Actions` | Table header |
+| `admin.testCatalog.list.pagination.showing` | `Showing {start}-{end} of {total} tests` | Pagination info |
+| `admin.testCatalog.list.pagination.previous` | `Previous` | Pagination control |
+| `admin.testCatalog.list.pagination.next` | `Next` | Pagination control |
+| `admin.testCatalog.list.tooltip.edit` | `Edit` | Row action button |
+| `admin.testCatalog.list.tooltip.duplicate` | `Duplicate` | Row action button |
+| `admin.testCatalog.list.tooltip.deactivate` | `Deactivate` | Row action button |
+| `admin.testCatalog.list.badge.amr` | `AMR` | Test row badge |
+
+### editor
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.editor.header.editTitle` | `Edit Test: {testName}` | Page title (dynamic) |
+| `admin.testCatalog.editor.header.addTitle` | `Add New Test` | Page title (create mode) |
+| `admin.testCatalog.editor.header.subtitle` | `Configure all test properties in one place` | Page subtitle |
+| `admin.testCatalog.editor.button.save` | `Save Test` | Primary CTA |
+| `admin.testCatalog.editor.button.cancel` | `Cancel` | Secondary CTA |
+| `admin.testCatalog.editor.sidenav.configuration` | `Configuration` | Section group |
+| `admin.testCatalog.editor.sidenav.organization` | `Organization` | Section group |
+| `admin.testCatalog.editor.sidenav.resources` | `Resources` | Section group |
+| `admin.testCatalog.editor.sidenav.automation` | `Automation` | Section group |
+| `admin.testCatalog.editor.sidenav.compliance` | `Compliance` | Section group |
+
+### basicInfo
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.basicInfo.section.title` | `Basic Information` | Tab/section header |
+| `admin.testCatalog.basicInfo.label.testName` | `Test Name` | Form label |
+| `admin.testCatalog.basicInfo.label.reportingName` | `Reporting Name` | Form label |
+| `admin.testCatalog.basicInfo.label.testCode` | `Test Code` | Form label |
+| `admin.testCatalog.basicInfo.label.description` | `Description` | Form label |
+| `admin.testCatalog.basicInfo.label.statusVisibility` | `Status & Visibility` | Section header |
+| `admin.testCatalog.basicInfo.checkbox.active` | `Active` | Checkbox label |
+| `admin.testCatalog.basicInfo.checkbox.orderable` | `Orderable` | Checkbox label |
+| `admin.testCatalog.basicInfo.checkbox.internalQA` | `Internal QA - No Results Release` | Checkbox label |
+| `admin.testCatalog.basicInfo.helper.internalQA` | `Test results will not appear on patient reports` | Helper text |
+| `admin.testCatalog.basicInfo.section.amr` | `Antimicrobial Resistance (AMR) Test` | Section header |
+| `admin.testCatalog.basicInfo.checkbox.amr` | `Enable for WHONET export and antimicrobial resistance surveillance` | Checkbox label |
+| `admin.testCatalog.basicInfo.label.whonetCode` | `WHONET Antibiotic Code` | Form label |
+| `admin.testCatalog.basicInfo.label.antibioticClass` | `Antibiotic Class` | Form label |
+| `admin.testCatalog.basicInfo.label.testMethod` | `Test Method` | Form label |
+| `admin.testCatalog.basicInfo.label.breakpointStandard` | `Breakpoint Standard` | Form label |
+| `admin.testCatalog.basicInfo.label.diskPotency` | `Disk Potency` | Form label |
+| `admin.testCatalog.basicInfo.unit.diskPotency` | `µg` | Unit display |
+| `admin.testCatalog.basicInfo.placeholder.testName` | `Enter test name` | Input placeholder |
+| `admin.testCatalog.basicInfo.placeholder.reportingName` | `Name for patient reports` | Input placeholder |
+| `admin.testCatalog.basicInfo.placeholder.testCode` | `e.g., GLU-F` | Input placeholder |
+| `admin.testCatalog.basicInfo.placeholder.description` | `Enter test description...` | Textarea placeholder |
+| `admin.testCatalog.basicInfo.badge.whonet` | `WHONET` | Configuration badge |
+| `admin.testCatalog.basicInfo.helper.whonet` | `This test will be included in WHONET exports` | Helper message |
+
+### sampleResults
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.sampleResults.section.title` | `Sample & Result Configuration` | Section header |
+| `admin.testCatalog.sampleResults.label.sampleTypes` | `Sample Type(s)` | Form label |
+| `admin.testCatalog.sampleResults.label.defaultSampleType` | `Default Sample Type` | Form label |
+| `admin.testCatalog.sampleResults.label.resultType` | `Result Type` | Form label |
+| `admin.testCatalog.sampleResults.label.unitOfMeasure` | `Unit of Measure` | Form label |
+| `admin.testCatalog.sampleResults.label.significantDigits` | `Significant Digits` | Form label |
+| `admin.testCatalog.sampleResults.label.defaultResult` | `Default Result` | Form label |
+| `admin.testCatalog.sampleResults.option.numeric` | `Numeric` | Result type |
+| `admin.testCatalog.sampleResults.option.selectList` | `Select List` | Result type |
+| `admin.testCatalog.sampleResults.option.multiSelect` | `Multi-select` | Result type |
+| `admin.testCatalog.sampleResults.option.freeText` | `Free Text` | Result type |
+| `admin.testCatalog.sampleResults.option.remarkOnly` | `Remark Only` | Result type |
+| `admin.testCatalog.sampleResults.label.selectListOptions` | `Select List Options` | Sub-section |
+| `admin.testCatalog.sampleResults.button.configureOptions` | `Configure Options...` | CTA |
+| `admin.testCatalog.sampleResults.section.interpretations` | `Result Interpretations` | Section header |
+| `admin.testCatalog.sampleResults.helper.interpretations` | `Define interpretive labels and clinical guidance that are added as external notes based on result values.` | Helper text |
+| `admin.testCatalog.sampleResults.button.copyInterpretations` | `Copy from Test...` | CTA |
+| `admin.testCatalog.sampleResults.button.addInterpretation` | `Add Interpretation` | CTA |
+| `admin.testCatalog.sampleResults.column.code` | `Code` | Table header |
+| `admin.testCatalog.sampleResults.column.label` | `Label` | Table header |
+| `admin.testCatalog.sampleResults.column.value` | `Value/Range` | Table header |
+| `admin.testCatalog.sampleResults.column.interpretationText` | `Interpretation Text` | Table header |
+| `admin.testCatalog.sampleResults.column.active` | `Active` | Table header |
+| `admin.testCatalog.sampleResults.modal.addInterpretation` | `Add Interpretation` | Modal title |
+| `admin.testCatalog.sampleResults.modal.editInterpretation` | `Edit Interpretation` | Modal title |
+| `admin.testCatalog.sampleResults.label.interpCode` | `Code` | Form label |
+| `admin.testCatalog.sampleResults.label.interpLabel` | `Label` | Form label |
+| `admin.testCatalog.sampleResults.label.interpColor` | `Color (optional)` | Form label |
+| `admin.testCatalog.sampleResults.label.interpValue` | `Value or Range` | Form label |
+| `admin.testCatalog.sampleResults.label.interpText` | `Interpretation Text` | Form label |
+| `admin.testCatalog.sampleResults.helper.interpCode` | `Shortcode for quick entry in result screens` | Helper text |
+| `admin.testCatalog.sampleResults.placeholder.interpCode` | `e.g., GLU-HI, HIV-POS, STAGE-2` | Input placeholder |
+| `admin.testCatalog.sampleResults.placeholder.interpLabel` | `e.g., Critical High, Stage II, Treatment Failure` | Input placeholder |
+| `admin.testCatalog.sampleResults.placeholder.interpValue` | `e.g., >126, <70, 70-99` | Input placeholder |
+| `admin.testCatalog.sampleResults.placeholder.interpText` | `Clinical interpretation, guidance, or action items...` | Textarea placeholder |
+| `admin.testCatalog.sampleResults.helper.interpValue` | `Use comparison operators (>, <, ≥, ≤), ranges (70-99), or exact values` | Helper text |
+| `admin.testCatalog.sampleResults.helper.interpText` | `This text will be added as an external note on the result` | Helper text |
+| `admin.testCatalog.sampleResults.button.saveInterpretation` | `Add Interpretation` | Modal CTA |
+| `admin.testCatalog.sampleResults.button.updateInterpretation` | `Save Changes` | Modal CTA (edit mode) |
+| `admin.testCatalog.sampleResults.modal.copyInterpretations` | `Copy Interpretations from Another Test` | Modal title |
+| `admin.testCatalog.sampleResults.label.searchTest` | `Search for test` | Modal label |
+| `admin.testCatalog.sampleResults.placeholder.searchTest` | `Enter test name...` | Input placeholder |
+| `admin.testCatalog.sampleResults.label.selectSourceTest` | `Select test:` | Modal label |
+| `admin.testCatalog.sampleResults.label.interpretationsToCopy` | `Interpretations to copy:` | Modal label |
+| `admin.testCatalog.sampleResults.label.importMode` | `Import mode:` | Modal label |
+| `admin.testCatalog.sampleResults.option.replaceExisting` | `Replace existing interpretations` | Radio option |
+| `admin.testCatalog.sampleResults.option.appendExisting` | `Append to existing interpretations` | Radio option |
+| `admin.testCatalog.sampleResults.button.copySelected` | `Copy Selected` | Modal CTA |
+
+### ranges
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.ranges.section.title` | `Reference Ranges` | Section header |
+| `admin.testCatalog.ranges.helper.title` | `Define age and sex-specific reference ranges for this test` | Helper text |
+| `admin.testCatalog.ranges.button.validateCoverage` | `Validate Coverage` | Toggle button |
+| `admin.testCatalog.ranges.label.viewMode` | `View:` (implicitly before dropdown) | Form label |
+| `admin.testCatalog.ranges.option.structuredView` | `Structured View` | Dropdown option |
+| `admin.testCatalog.ranges.option.tableView` | `Table View` | Dropdown option |
+| `admin.testCatalog.ranges.option.visualView` | `Visual View` | Dropdown option |
+| `admin.testCatalog.ranges.section.coverageValidation` | `Age Coverage Validation` | Panel header |
+| `admin.testCatalog.ranges.label.maleCoverage` | `Male` | Badge label |
+| `admin.testCatalog.ranges.label.femaleCoverage` | `Female` | Badge label |
+| `admin.testCatalog.ranges.status.completeCoverage` | `Complete Coverage` | Status indicator |
+| `admin.testCatalog.ranges.status.issuesFound` | `{count} Issue(s) Found` | Status indicator (dynamic) |
+| `admin.testCatalog.ranges.button.fillGap` | `Fill Gap` | Action button |
+| `admin.testCatalog.ranges.message.coverageOk` | `All age ranges from birth to maximum age are covered.` | Info message |
+| `admin.testCatalog.ranges.label.rangeType` | `{type}` (Normal, Valid, Critical, Reporting) | Group header |
+| `admin.testCatalog.ranges.description.normal` | `Clinical reference values. Results outside flagged H/L on reports.` | Type description |
+| `admin.testCatalog.ranges.description.valid` | `Expected possible values. Entry outside prompts verification.` | Type description |
+| `admin.testCatalog.ranges.description.critical` | `Panic values requiring immediate clinical action.` | Type description |
+| `admin.testCatalog.ranges.description.reporting` | `Instrument limits. Results outside may need dilution/rerun.` | Type description |
+| `admin.testCatalog.ranges.button.addRange` | `Add {type}` | CTA |
+| `admin.testCatalog.ranges.empty.message` | `No {type}s defined` | Empty state |
+| `admin.testCatalog.ranges.empty.addPrompt` | `+ Add {type}` | Empty state CTA |
+| `admin.testCatalog.ranges.label.sexSubgroup` | `{label}` (Male/Female/All) | Sub-header |
+| `admin.testCatalog.ranges.label.rangeCount` | `({count} ranges)` | Count display |
+| `admin.testCatalog.ranges.label.ageRange` | `Age Range` | Column label |
+| `admin.testCatalog.ranges.label.low` | `Low` | Column label |
+| `admin.testCatalog.ranges.label.high` | `High` | Column label |
+| `admin.testCatalog.ranges.tooltip.edit` | `Edit` | Row action |
+| `admin.testCatalog.ranges.tooltip.copy` | `Copy to other sex` | Row action |
+| `admin.testCatalog.ranges.tooltip.delete` | `Delete` | Row action |
+| `admin.testCatalog.ranges.modal.addRange` | `Add {type}` | Modal title (dynamic) |
+| `admin.testCatalog.ranges.label.appliesto` | `Applies To` | Form section |
+| `admin.testCatalog.ranges.option.allSex` | `All` | Sex option |
+| `admin.testCatalog.ranges.option.maleOnly` | `Male Only` | Sex option |
+| `admin.testCatalog.ranges.option.femaleOnly` | `Female Only` | Sex option |
+| `admin.testCatalog.ranges.label.ageRangeForm` | `Age Range` | Form section |
+| `admin.testCatalog.ranges.label.from` | `From` | Input label |
+| `admin.testCatalog.ranges.label.to` | `To` | Input label |
+| `admin.testCatalog.ranges.helper.infinity` | `Use 999 years for "no upper age limit" (infinity)` | Helper text |
+| `admin.testCatalog.ranges.label.valueRange` | `Value Range` | Form section (numeric) |
+| `admin.testCatalog.ranges.label.criticalThresholds` | `Critical Thresholds` | Form section (critical type) |
+| `admin.testCatalog.ranges.label.criticalLow` | `Critical Low (values below this)` | Input label (critical) |
+| `admin.testCatalog.ranges.label.criticalHigh` | `Critical High (values above this)` | Input label (critical) |
+| `admin.testCatalog.ranges.placeholder.criticalLow` | `Leave blank if N/A` | Input placeholder |
+| `admin.testCatalog.ranges.placeholder.criticalHigh` | `Leave blank if N/A` | Input placeholder |
+| `admin.testCatalog.ranges.placeholder.low` | `0` | Input placeholder |
+| `admin.testCatalog.ranges.placeholder.high` | `100` | Input placeholder |
+| `admin.testCatalog.ranges.button.addRangeModal` | `Add Range` | Modal CTA |
+| `admin.testCatalog.ranges.table.column.type` | `Type` | Table header |
+| `admin.testCatalog.ranges.table.column.sex` | `Sex` | Table header |
+| `admin.testCatalog.ranges.table.column.ageFrom` | `Age From` | Table header |
+| `admin.testCatalog.ranges.table.column.ageTo` | `Age To` | Table header |
+| `admin.testCatalog.ranges.table.column.actions` | `Actions` | Table header |
+| `admin.testCatalog.ranges.visualView.label.viewRangesFor` | `View ranges for:` | Form label |
+| `admin.testCatalog.ranges.visualView.label.age` | `Age:` | Form label |
+| `admin.testCatalog.ranges.visualView.option.hours` | `hours` | Unit option |
+| `admin.testCatalog.ranges.visualView.option.days` | `days` | Unit option |
+| `admin.testCatalog.ranges.visualView.option.weeks` | `weeks` | Unit option |
+| `admin.testCatalog.ranges.visualView.option.months` | `months` | Unit option |
+| `admin.testCatalog.ranges.visualView.option.years` | `years` | Unit option |
+| `admin.testCatalog.ranges.visualView.applicableRanges` | `Showing ranges applicable to: {sex}, {age}` | Info display (dynamic) |
+| `admin.testCatalog.ranges.visualView.legend.valid` | `Valid` | Legend |
+| `admin.testCatalog.ranges.visualView.legend.normal` | `Normal` | Legend |
+| `admin.testCatalog.ranges.visualView.legend.critical` | `Critical` | Legend |
+| `admin.testCatalog.ranges.visualView.legend.reporting` | `Reporting` | Legend |
+| `admin.testCatalog.ranges.visualView.notDefined` | `Not defined for this demographic` | Message |
+
+### sampleStorage
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.sampleStorage.section.storageRequirements` | `Storage Requirements` | Section header |
+| `admin.testCatalog.sampleStorage.label.storageConditions` | `Storage Conditions` | Form label |
+| `admin.testCatalog.sampleStorage.helper.storageConditions` | `Temperature range for sample preservation` | Helper text |
+| `admin.testCatalog.sampleStorage.option.ultraLow` | `Ultra-low freezer (-80°C to -60°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.freezer` | `Freezer (-30°C to -15°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.refrigerator` | `Refrigerator (2°C to 8°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.coldRoom` | `Cold room (4°C to 8°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.coolRoom` | `Cool room (15°C to 18°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.roomTemp` | `Room temperature (18°C to 25°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.controlledRoom` | `Controlled room temp (20°C to 25°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.warmIncubator` | `Warm incubator (35°C to 37°C)` | Select option |
+| `admin.testCatalog.sampleStorage.option.ambient` | `Ambient (uncontrolled)` | Select option |
+| `admin.testCatalog.sampleStorage.option.custom` | `Custom (specify below)` | Select option |
+| `admin.testCatalog.sampleStorage.label.customConditions` | `Custom Storage Conditions` | Form label |
+| `admin.testCatalog.sampleStorage.placeholder.customConditions` | `e.g., 2-8°C, protected from light` | Input placeholder |
+| `admin.testCatalog.sampleStorage.helper.customConditions` | `Override or add details to selected condition` | Helper text |
+| `admin.testCatalog.sampleStorage.label.maxDuration` | `Maximum Storage Duration` | Form label |
+| `admin.testCatalog.sampleStorage.helper.maxDuration` | `Maximum time sample can be stored before testing` | Helper text |
+| `admin.testCatalog.sampleStorage.option.hours` | `Hours` | Unit option |
+| `admin.testCatalog.sampleStorage.option.days` | `Days` | Unit option |
+| `admin.testCatalog.sampleStorage.option.weeks` | `Weeks` | Unit option |
+| `admin.testCatalog.sampleStorage.option.months` | `Months` | Unit option |
+| `admin.testCatalog.sampleStorage.label.stabilityNotes` | `Stability Notes` | Form label |
+| `admin.testCatalog.sampleStorage.placeholder.stabilityNotes` | `e.g., Stable for 7 days refrigerated, 1 month frozen` | Input placeholder |
+| `admin.testCatalog.sampleStorage.section.specialHandling` | `Special Handling Requirements` | Section header |
+| `admin.testCatalog.sampleStorage.checkbox.protectLight` | `🔒 Protect from light` | Checkbox label |
+| `admin.testCatalog.sampleStorage.checkbox.noFreeze` | `❄️ Do not freeze` | Checkbox label |
+| `admin.testCatalog.sampleStorage.checkbox.noRefrigerate` | `🔥 Do not refrigerate` | Checkbox label |
+| `admin.testCatalog.sampleStorage.checkbox.keepUpright` | `⬆️ Keep upright` | Checkbox label |
+| `admin.testCatalog.sampleStorage.checkbox.centrifuge` | `🧪 Centrifuge before storage` | Checkbox label |
+| `admin.testCatalog.sampleStorage.checkbox.aliquot` | `⚗️ Aliquot before storage` | Checkbox label |
+| `admin.testCatalog.sampleStorage.section.disposal` | `Disposal Requirements` | Section header |
+| `admin.testCatalog.sampleStorage.helper.disposal` | `Define how samples should be disposed after testing` | Helper text |
+| `admin.testCatalog.sampleStorage.label.disposalMethod` | `Disposal Method` | Form label |
+| `admin.testCatalog.sampleStorage.option.biohazard` | `Biohazard/Infectious waste bin` | Select option |
+| `admin.testCatalog.sampleStorage.option.sharps` | `Sharps container` | Select option |
+| `admin.testCatalog.sampleStorage.option.chemical` | `Chemical deactivation` | Select option |
+| `admin.testCatalog.sampleStorage.option.incineration` | `Incineration` | Select option |
+| `admin.testCatalog.sampleStorage.option.autoclave` | `Autoclave then general waste` | Select option |
+| `admin.testCatalog.sampleStorage.option.pharmaceutical` | `Pharmaceutical waste` | Select option |
+| `admin.testCatalog.sampleStorage.option.radioactive` | `Radioactive waste` | Select option |
+| `admin.testCatalog.sampleStorage.option.generalWaste` | `General waste (non-hazardous only)` | Select option |
+| `admin.testCatalog.sampleStorage.option.manufacturer` | `Return to manufacturer` | Select option |
+| `admin.testCatalog.sampleStorage.label.disposalTimeframe` | `Disposal Timeframe` | Form label |
+| `admin.testCatalog.sampleStorage.helper.disposalTimeframe` | `Maximum time after test completion before disposal` | Helper text |
+| `admin.testCatalog.sampleStorage.section.specialInstructions` | `Special Instructions` | Section header |
+| `admin.testCatalog.sampleStorage.helper.specialInstructions` | `Additional guidance for sample handling` | Helper text |
+| `admin.testCatalog.sampleStorage.placeholder.specialInstructions` | `Enter any special instructions for sample handling, storage, or disposal that don't fit in the fields above...` | Textarea placeholder |
+| `admin.testCatalog.sampleStorage.section.overrideRestricted` | `Override Restricted` | Section header |
+| `admin.testCatalog.sampleStorage.checkbox.overrideRestricted` | `When enabled, order entry staff cannot modify storage or disposal requirements for this test.` | Checkbox label |
+| `admin.testCatalog.sampleStorage.badge.locked` | `Locked` | Status badge |
+| `admin.testCatalog.sampleStorage.helper.overrideRestricted` | `Use for critical tests where sample handling must be strictly controlled (e.g., HIV, controlled substances).` | Helper text |
+| `admin.testCatalog.sampleStorage.alert.storageAndDisposalLocked` | `Storage and disposal settings are locked` | Alert message |
+| `admin.testCatalog.sampleStorage.alert.lockedNote` | `Only Lab Managers can modify these requirements. Order entry staff will see these as read-only.` | Alert note |
+| `admin.testCatalog.sampleStorage.section.quickReference` | `📋 Storage Condition Quick Reference` | Section header |
+
+### displayOrder
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.displayOrder.section.title` | `Test Display Order` | Section header |
+| `admin.testCatalog.displayOrder.helper.title` | `Drag and drop to reorder tests for this sample type` | Helper text |
+| `admin.testCatalog.displayOrder.label.sampleType` | `Sample Type:` | Form label |
+| `admin.testCatalog.displayOrder.option.serum` | `Serum` | Select option |
+| `admin.testCatalog.displayOrder.option.plasma` | `Plasma` | Select option |
+| `admin.testCatalog.displayOrder.option.wholeBlood` | `Whole Blood` | Select option |
+| `admin.testCatalog.displayOrder.option.urine` | `Urine` | Select option |
+| `admin.testCatalog.displayOrder.helper.info` | `This order determines how tests appear in order entry and result entry for the selected sample type.` | Helper text |
+
+### panels
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.panels.section.title` | `Panel Membership` | Section header |
+| `admin.testCatalog.panels.helper.title` | `Select which panels should include this test and set display order` | Helper text |
+| `admin.testCatalog.panels.button.createNewPanel` | `Create New Panel` | CTA |
+| `admin.testCatalog.panels.label.newPanelName` | `New Panel Name` | Form label |
+| `admin.testCatalog.panels.placeholder.panelName` | `Enter panel name...` | Input placeholder |
+| `admin.testCatalog.panels.button.createPanel` | `Create` | Modal CTA |
+| `admin.testCatalog.panels.label.panelTestCount` | `{count} tests` | Info display |
+| `admin.testCatalog.panels.label.position` | `Position: {order}` | Badge |
+| `admin.testCatalog.panels.label.displayPosition` | `Display Position in Panel` | Form label |
+| `admin.testCatalog.panels.helper.displayPosition` | `Enter a number or drag the test in the preview list` | Helper text |
+| `admin.testCatalog.panels.label.panelTestOrderPreview` | `Panel Test Order Preview — drag to reorder` | Form label |
+| `admin.testCatalog.panels.helper.dragDropNote` | `Drag the highlighted row to change position` | Helper text |
+| `admin.testCatalog.panels.helper.instructions` | `Click on a selected panel to expand and set the display order. Use the number input or drag the test in the preview list.` | Helper text |
+
+### labels
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.labels.section.defaultLabels` | `Default Labels for This Test` | Section header |
+| `admin.testCatalog.labels.helper.defaultLabels` | `When this test is ordered, automatically suggest these labels` | Helper text |
+| `admin.testCatalog.labels.button.addLabelType` | `Add Label Type` | CTA |
+| `admin.testCatalog.labels.column.preset` | `Label Preset` | Table header |
+| `admin.testCatalog.labels.column.defaultQty` | `Default Qty` | Table header |
+| `admin.testCatalog.labels.column.maxQty` | `Max Qty` | Table header |
+| `admin.testCatalog.labels.column.allowOverride` | `Allow Override` | Table header |
+| `admin.testCatalog.labels.empty.message` | `No label types configured` | Empty state |
+| `admin.testCatalog.labels.empty.helper` | `Add label presets to automatically suggest labels when this test is ordered` | Empty state |
+| `admin.testCatalog.labels.section.labelGenerationSettings` | `Label Generation Settings` | Section header |
+| `admin.testCatalog.labels.checkbox.allowCountOverride` | `Allow label count override at order entry` | Checkbox label |
+| `admin.testCatalog.labels.helper.allowCountOverride` | `When enabled, users can modify label quantities during order entry. Individual label types can still be locked via the "Allow Override" column above.` | Helper text |
+| `admin.testCatalog.labels.section.orderEntryPreview` | `Order Entry Preview` | Section header |
+| `admin.testCatalog.labels.helper.orderEntryPreview` | `When this test is ordered, the Labels section will be pre-populated as follows:` | Helper text |
+| `admin.testCatalog.labels.column.source` | `Source` | Table header |
+| `admin.testCatalog.labels.helper.lockedQty` | `Gray quantities are locked and cannot be modified at order entry` | Helper text |
+
+### terminology
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.terminology.section.title` | `Terminology Mappings` | Section header |
+| `admin.testCatalog.terminology.helper.title` | `Link this test to standard terminology codes for interoperability` | Helper text |
+| `admin.testCatalog.terminology.button.addMapping` | `Add Mapping` | CTA |
+| `admin.testCatalog.terminology.label.source` | `Terminology Source` | Form label |
+| `admin.testCatalog.terminology.option.loinc` | `LOINC` | Select option |
+| `admin.testCatalog.terminology.option.snomed` | `SNOMED CT` | Select option |
+| `admin.testCatalog.terminology.option.ciel` | `CIEL` | Select option |
+| `admin.testCatalog.terminology.option.ocl` | `Open Concept Lab` | Select option |
+| `admin.testCatalog.terminology.label.code` | `Code` | Form label |
+| `admin.testCatalog.terminology.placeholder.code` | `Enter code` | Input placeholder |
+| `admin.testCatalog.terminology.label.relationship` | `Relationship` | Form label |
+| `admin.testCatalog.terminology.option.sameAs` | `Same As` | Select option |
+| `admin.testCatalog.terminology.option.broaderThan` | `Broader Than` | Select option |
+| `admin.testCatalog.terminology.option.narrowerThan` | `Narrower Than` | Select option |
+| `admin.testCatalog.terminology.button.add` | `Add` | Form CTA |
+
+### reagents
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.reagents.section.title` | `Associated Reagents` | Section header |
+| `admin.testCatalog.reagents.helper.title` | `Link reagents from inventory to track consumption` | Helper text |
+| `admin.testCatalog.reagents.button.linkReagent` | `Link Reagent` | CTA |
+| `admin.testCatalog.reagents.empty.message` | No text (empty state not shown in mockup) | Empty state |
+
+### analyzers
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.analyzers.section.title` | `Linked Analyzers` | Section header |
+| `admin.testCatalog.analyzers.helper.title` | `Select which analyzers can perform this test` | Helper text |
+| `admin.testCatalog.analyzers.button.linkAnalyzer` | `Link Analyzer` | CTA |
+| `admin.testCatalog.analyzers.empty.message` | `No analyzers linked` | Empty state |
+| `admin.testCatalog.analyzers.empty.helper` | `Link analyzers that can perform this test` | Empty state |
+| `admin.testCatalog.analyzers.modal.title` | `Link Analyzers` | Modal title |
+| `admin.testCatalog.analyzers.label.selectAnalyzers` | `Select Analyzers` | Form label |
+| `admin.testCatalog.analyzers.empty.allLinked` | `All available analyzers are already linked` | Empty message |
+| `admin.testCatalog.analyzers.selectedCount` | `{count} analyzer{plural} selected` | Info message (dynamic) |
+| `admin.testCatalog.analyzers.button.linkSelected` | `Link Selected` | Modal CTA |
+| `admin.testCatalog.analyzers.info.title` | `About Analyzer Linking` | Info card header |
+| `admin.testCatalog.analyzers.info.adminLink` | `Administration → Master Lists → Analyzers` | Info text |
+| `admin.testCatalog.analyzers.info.testCodeMapping` | `Test code mapping is configured separately in the analyzer interface setup` | Info text |
+| `admin.testCatalog.analyzers.info.linkingMeans` | `Linking an analyzer indicates this test can be performed on that instrument` | Info text |
+| `admin.testCatalog.analyzers.tooltip.unlink` | `Unlink analyzer` | Tooltip |
+
+### alerts
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.alerts.section.title` | `Alert Rules` | Section header |
+| `admin.testCatalog.alerts.helper.title` | `Configure automated notifications when specific result conditions are met` | Helper text |
+| `admin.testCatalog.alerts.button.addRule` | `Add Rule` | CTA |
+| `admin.testCatalog.alerts.empty.message` | `No alert rules configured` | Empty state |
+| `admin.testCatalog.alerts.empty.addFirstRule` | `+ Add your first alert rule` | Empty state CTA |
+| `admin.testCatalog.alerts.modal.title` | `Add Alert Rule` | Modal title |
+| `admin.testCatalog.alerts.label.ruleName` | `Rule Name` | Form label |
+| `admin.testCatalog.alerts.placeholder.ruleName` | `e.g., Critical Value SMS Alert` | Input placeholder |
+| `admin.testCatalog.alerts.label.triggerCondition` | `Alert when result is:` | Form label |
+| `admin.testCatalog.alerts.option.allResults` | `All Results` | Radio option |
+| `admin.testCatalog.alerts.option.abnormal` | `Abnormal (outside normal range)` | Radio option |
+| `admin.testCatalog.alerts.option.critical` | `Critical (panic value)` | Radio option |
+| `admin.testCatalog.alerts.option.specificValue` | `Specific Value` | Radio option |
+| `admin.testCatalog.alerts.label.sendVia` | `Send via:` | Form label |
+| `admin.testCatalog.alerts.option.sms` | `SMS` | Checkbox label |
+| `admin.testCatalog.alerts.option.email` | `Email` | Checkbox label |
+| `admin.testCatalog.alerts.label.recipients` | `Recipients:` | Form label |
+| `admin.testCatalog.alerts.option.orderingPhysician` | `Ordering Physician (from order)` | Checkbox label |
+| `admin.testCatalog.alerts.option.patient` | `Patient (from patient record)` | Checkbox label |
+| `admin.testCatalog.alerts.option.customRecipient` | `Custom recipient:` | Checkbox label |
+| `admin.testCatalog.alerts.placeholder.customPhone` | `Phone: +1 555-123-4567` | Input placeholder |
+| `admin.testCatalog.alerts.placeholder.customEmail` | `Email: user@example.com` | Input placeholder |
+| `admin.testCatalog.alerts.label.smsTemplate` | `SMS Template (160 char recommended)` | Form label |
+| `admin.testCatalog.alerts.placeholder.smsTemplate` | `CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}. Review immediately.` | Textarea placeholder |
+| `admin.testCatalog.alerts.helper.smsVariables` | `Variables: {{patient_name}}, {{patient_id}}, {{test_name}}, {{result}}, {{unit}}, {{reference_range}}` | Helper text |
+| `admin.testCatalog.alerts.column.ruleName` | `Rule Name` | Table column |
+| `admin.testCatalog.alerts.column.status` | `Status` | Table column |
+| `admin.testCatalog.alerts.label.when` | `When` | Rule detail label |
+| `admin.testCatalog.alerts.label.notifyVia` | `Notify Via` | Rule detail label |
+| `admin.testCatalog.alerts.label.recipients` | `Recipients` | Rule detail label |
+| `admin.testCatalog.alerts.label.smsTemplate` | `SMS Template` | Rule detail label |
+
+### reflexCalc
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.reflexCalc.section.reflexTests` | `Reflex Tests` | Section header |
+| `admin.testCatalog.reflexCalc.helper.reflexTests` | `Automatic test ordering based on results` | Helper text |
+| `admin.testCatalog.reflexCalc.label.triggeredBy` | `Rules triggered BY this test:` | Sub-section label |
+| `admin.testCatalog.reflexCalc.empty.noRulesByThis` | `No reflex rules configured for this test` | Empty state |
+| `admin.testCatalog.reflexCalc.label.orderThis` | `Rules that ORDER this test:` | Sub-section label |
+| `admin.testCatalog.reflexCalc.empty.noRulesThatOrder` | `No other tests trigger this test as a reflex` | Empty state |
+| `admin.testCatalog.reflexCalc.button.addNewReflex` | `Add New Reflex Rule in Master Lists` | CTA |
+| `admin.testCatalog.reflexCalc.section.calculatedResults` | `Calculated Results` | Section header |
+| `admin.testCatalog.reflexCalc.helper.calculatedResults` | `Formulas that compute results from other test values` | Helper text |
+| `admin.testCatalog.reflexCalc.label.calculationsUsingThis` | `Calculations that USE this test as input:` | Sub-section label |
+| `admin.testCatalog.reflexCalc.empty.notUsedInCalculations` | `This test is not used as input for any calculated results` | Empty state |
+| `admin.testCatalog.reflexCalc.label.thisTestIsCalculated` | `This test IS a calculated result:` | Sub-section label |
+| `admin.testCatalog.reflexCalc.empty.notCalculated` | `This test's result is not calculated from other values` | Empty state |
+| `admin.testCatalog.reflexCalc.button.configureCalculated` | `Configure in Master Lists` | Empty state CTA |
+| `admin.testCatalog.reflexCalc.label.formulaConfigured` | `Formula configured` | Info label |
+| `admin.testCatalog.reflexCalc.button.editReflex` | `Edit in Master Lists` | Inline link |
+| `admin.testCatalog.reflexCalc.mode.autoOrder` | `Auto-order` | Status badge |
+| `admin.testCatalog.reflexCalc.mode.suggest` | `Suggest` | Status badge |
+
+### compliance
+
+| Key | English fallback | Used in |
+|-----|------------------|---------|
+| `admin.testCatalog.compliance.section.title` | `Compliance Thresholds` | Section header |
+| `admin.testCatalog.compliance.helper.title` | `Regulatory compliance thresholds for this test. Environmental tests use these instead of (or alongside) clinical reference ranges.` | Helper text |
+| `admin.testCatalog.compliance.helper.adminLink` | `Full compliance standards are managed at Admin → Test Management → Compliance Standards.` | Helper text |
+| `admin.testCatalog.compliance.label.groupBy` | `Group by:` | Form label |
+| `admin.testCatalog.compliance.option.standard` | `Standard` | Select option |
+| `admin.testCatalog.compliance.option.parameterGroup` | `Parameter Group` | Select option |
+| `admin.testCatalog.compliance.button.addThreshold` | `Add Threshold` | CTA |
+| `admin.testCatalog.compliance.column.standard` | `Standard` | Table header |
+| `admin.testCatalog.compliance.column.parameterGroup` | `Parameter Group` | Table header |
+| `admin.testCatalog.compliance.column.type` | `Type` | Table header |
+| `admin.testCatalog.compliance.column.value` | `Value` | Table header |
+| `admin.testCatalog.compliance.column.effectiveDate` | `Effective Date` | Table header |
+| `admin.testCatalog.compliance.type.max` | `MAX` | Badge |
+| `admin.testCatalog.compliance.type.min` | `MIN` | Badge |
+| `admin.testCatalog.compliance.type.range` | `RANGE` | Badge |
+| `admin.testCatalog.compliance.type.descriptive` | `DESCRIPTIVE` | Badge |
+
+**Summary**
+
+- **Total keys extracted**: 234
+- **Common-namespace keys** (reused across surfaces): 24 (base verbs, status indicators, labels)
+- **Surface-specific keys**: 210
+- **Top 3 ambiguities/judgment calls**:
+  1. **Sex label unification**: Male/Female/All labels appear as both visual badges and form options; unified under common surface to encourage reuse rather than surface-specific variants.
+  2. **Empty state messaging**: "No {type} configured" strings parameterized in common where type is inferred (panels, rules, etc.); some surfaces kept explicit variants for grammatical correctness.
+  3. **Button CTAs across modals**: "Add", "Create", "Save" used contextually in both list and editor; namespace hierarchy disambiguates ("button.add" vs "button.addRange") rather than creating collision aliases.
+
+**Strings intentionally skipped**:
+- Mock data test/section names (Glucose, Hemoglobin A1c, Chemistry, Hematology, etc.) — live data, not UI labels.
+- LOINC codes and lab numbers in demo data — reference values, not visible strings.
+- Temporary UI text in component descriptions (e.g., "Component Demo: {label}" in demo selector) — internal dev mode, not shipped UI.
+- CSS utility class names and icon names (Lucide React icon imports) — implementation details.
+- Formula/variable macro text in templates (e.g., "{{test_name}}") — dynamic substitution markers, not localized user-facing strings.
+
+**Runtime fallback behavior** (separate from key namespacing) is documented in the **Localization Hardening** section later in this FRS.
 
 ---
 
@@ -34,7 +650,7 @@
 
 ## Test Editor Status Flags
 
-The Basic Info tab includes the following status flags:
+The Basic Info section includes the following status flags:
 
 | Flag | Description |
 |------|-------------|
@@ -44,11 +660,145 @@ The Basic Info tab includes the following status flags:
 
 ---
 
-## Sample Storage Tab
+## Test Domain
 
-### Purpose
+Every test record carries a single mandatory **Domain** attribute that classifies the test into one of three mutually-exclusive categories. Domain controls which test editor sections are emphasized for that test, and powers the Domain filter on the Test List View.
 
-Define recommended storage conditions, maximum storage duration, disposal requirements, and special handling instructions for samples collected for this test. This information is displayed during order entry and can optionally be locked to prevent modifications.
+### Field Definition
+
+| Property | Value |
+|---|---|
+| **Field name** | `domain` |
+| **Type** | Enumerated, single-select (radio buttons in the UI) |
+| **Allowed values** | `CLINICAL`, `ENVIRONMENTAL`, `VECTOR` |
+| **Required** | Yes |
+| **Default for new tests** | None — user must choose. Cannot save Basic Info without a selection. |
+| **Mutability after creation** | Editable, but changes show a confirmation modal warning that section visibility may change and that historical results were evaluated against the prior domain's rules. |
+| **Placement in editor** | Basic Info section, near the top, alongside Test Name and Test Code. |
+
+### Domain Definitions
+
+| Domain | Description | Typical examples |
+|---|---|---|
+| **CLINICAL** | Patient-facing diagnostic tests. Results are evaluated against patient-centric reference ranges (Normal, Valid, Critical, Reporting). | Fasting glucose, HbA1c, CBC, HIV viral load, troponin |
+| **ENVIRONMENTAL** | Tests on environmental samples (water, air, soil, food, surface swabs). Results are evaluated against externally-published regulatory thresholds (Baku Mutu, WHO Drinking Water Guidelines, EPA limits). | Water turbidity, lead in drinking water, PM2.5 in air, fecal coliform |
+| **VECTOR** | Tests on vector specimens (mosquito pools, ticks, rodent samples) for surveillance of vector-borne diseases. Results may be evaluated against either clinical or surveillance thresholds depending on the program. | Aedes pool RT-PCR for dengue, Anopheles speciation, malaria parasite detection in mosquito |
+
+### Domain-Conditional Section Visibility
+
+Domain controls which sections appear in the editor SideNav for a given test:
+
+| Section | CLINICAL | ENVIRONMENTAL | VECTOR |
+|---|:---:|:---:|:---:|
+| Basic Info | ✓ | ✓ | ✓ |
+| Sample & Results | ✓ | ✓ | ✓ |
+| Methods | ✓ | ✓ | ✓ |
+| Ranges | ✓ (primary) | ✓ (de-emphasized) | ✓ (de-emphasized) |
+| Sample Storage | ✓ | ✓ | ✓ |
+| Display Order | ✓ | ✓ | ✓ |
+| Panels | ✓ | ✓ | ✓ |
+| Labels | ✓ | ✓ | ✓ |
+| Terminology | ✓ | ✓ | ✓ |
+| Reagents | ✓ | ✓ | ✓ |
+| Analyzers | ✓ | ✓ | ✓ |
+| Alerts | ✓ | ✓ | ✓ |
+| Reflex & Calc | ✓ | ✓ | ✓ |
+| **Compliance** | **hidden** | ✓ (primary) | ✓ (primary) |
+
+**De-emphasis rules:**
+- For ENVIRONMENTAL and VECTOR tests, the **Ranges** section displays a Carbon `<InlineNotification kind="info">` at the top: *"This is an {Environmental | Vector} test. Compliance thresholds are typically the primary evaluation surface for this domain. Configure clinical reference ranges only if your lab also reports them for QA or staff use."*
+- For CLINICAL tests, the **Compliance** section is hidden from the SideNav entirely. Direct navigation to its route returns the standard No-permission empty state (see the States section).
+
+### Domain Switch Confirmation
+
+If a user changes the Domain on an existing test:
+
+- Show a Carbon `<Modal>` with the title "Change test domain?" before saving.
+- Body lists the SideNav changes that will take effect (e.g., "Compliance section will be hidden" or "Compliance section will become available").
+- Body warns: "Historical results entered before this change were evaluated against the previous domain's rules. New results will use the new domain's rules."
+- Primary action: "Change Domain". Secondary: "Cancel".
+
+### Data Model
+
+```sql
+ALTER TABLE test
+  ADD COLUMN domain VARCHAR(20) NOT NULL CHECK (domain IN ('CLINICAL', 'ENVIRONMENTAL', 'VECTOR'));
+
+CREATE INDEX idx_test_domain ON test(domain);
+```
+
+**Migration:** existing test rows are backfilled with `domain = 'CLINICAL'` because the overwhelming majority of historical OpenELIS deployments are clinical-only. Deployments with environmental or vector tests will need an admin sweep to re-classify after the migration runs (call out in the migration notes).
+
+### Acceptance Criteria
+
+- [ ] Test entity has a `domain` column constrained to `CLINICAL`, `ENVIRONMENTAL`, or `VECTOR`
+- [ ] Basic Info section presents Domain as a radio button group with the three options
+- [ ] Saving a new test fails validation if Domain is not selected
+- [ ] CLINICAL tests do not show the Compliance section in the SideNav
+- [ ] ENVIRONMENTAL and VECTOR tests show the Compliance section
+- [ ] ENVIRONMENTAL and VECTOR tests show an InlineNotification info banner on the Ranges section
+- [ ] Editing Domain on an existing test triggers a confirmation modal before save
+- [ ] Existing tests are backfilled to `CLINICAL` during migration
+- [ ] Test List View has a Domain filter (see Test List View Enhancements)
+
+---
+
+## Sample & Results Configuration
+
+The Sample & Results section of the test editor combines sample type configuration, result type / unit / formatting configuration, and the result interpretations table (see the Result Interpretations section that follows).
+
+### Sample Type Configuration
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| **Sample Types** | Multi-select checkbox list | Yes (≥1) | Which sample types are accepted for this test. Examples: Serum, Plasma, Whole Blood, Urine, CSF, Water, Mosquito Pool. The available list is configured per deployment under Master Lists → Sample Types. |
+| **Default Sample Type** | Single-select dropdown | No | When the test is ordered and multiple sample types are accepted, this is pre-selected on the order entry screen. Must be a member of the selected Sample Types set. |
+
+**UI behavior:**
+- The Default Sample Type dropdown only shows values from the Sample Types multi-select. If the multi-select is empty, the Default dropdown is disabled.
+- Removing a sample type from the multi-select that is currently the Default clears the Default and shows a Carbon `<InlineNotification kind="warning">`: "Default Sample Type was removed because it is no longer in the accepted Sample Types."
+
+### Result Type Configuration
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| **Result Type** | Single-select dropdown | Yes | One of `NUMERIC`, `SELECT_LIST`, `MULTI_SELECT`, `FREE_TEXT`. Determines which downstream fields are enabled and how Result Interpretations are configured. |
+| **Unit of Measure** | Single-select dropdown | Yes (when Result Type = NUMERIC) | Unit shown alongside the result value. Examples: mg/dL, mmol/L, g/dL, µL, %, mg/L, NTU. The available unit list is configured per deployment under Master Lists → Units of Measure. Disabled when Result Type is not NUMERIC. |
+| **Significant Digits** | Number (0–6) | No (defaults to 0) | Number of digits after the decimal point shown in result entry and on reports. Disabled when Result Type is not NUMERIC. |
+| **Default Result** | Text | No | Optional default value pre-filled in the result entry field for this test. Useful for tests where the most common result is constant (e.g., "Negative" for a screening test). |
+
+### Result Type Definitions
+
+| Result Type | Description | Result Entry UI |
+|---|---|---|
+| **NUMERIC** | A numeric value with a unit and reference range. | Number input with unit suffix; H/L flagging based on Normal Range. |
+| **SELECT_LIST** | One value chosen from a configured list. | Carbon `<Dropdown>` populated from the test's Select List Options. |
+| **MULTI_SELECT** | Multiple values chosen from a configured list. | Carbon `<MultiSelect>` populated from the test's Select List Options. |
+| **FREE_TEXT** | An arbitrary text result (e.g., a microscopy description). | Carbon `<TextArea>`. |
+
+### Select List Options
+
+When Result Type is `SELECT_LIST` or `MULTI_SELECT`, the editor exposes a Select List Options sub-table:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| **Value** | String | Yes | The option value as it appears in result entry (e.g., "Positive", "Negative", "Indeterminate"). |
+| **Display Order** | Integer | Yes | Order the option appears in the dropdown / multi-select. |
+| **Active** | Boolean | Yes | Inactive options are hidden in result entry but preserved on historical results. |
+
+The sub-table supports drag-and-drop reordering (via the same drag pattern used in the Result Interpretations table) and inline add/edit. A "Configure Options..." button is the entry point.
+
+### Acceptance Criteria
+
+- [ ] Sample Types multi-select accepts ≥1 selection and emits a validation error if empty
+- [ ] Default Sample Type dropdown is disabled until at least one Sample Type is selected, and only shows values from the selected set
+- [ ] Removing the Default Sample Type from the multi-select clears the Default and shows a warning notification
+- [ ] Result Type dropdown offers exactly four options: Numeric, Select List, Multi-select, Free Text
+- [ ] Unit of Measure and Significant Digits are disabled when Result Type is not Numeric
+- [ ] Significant Digits accepts integers 0–6
+- [ ] Default Result is optional, free text
+- [ ] Select List Options sub-table appears only for Select List and Multi-select result types
+- [ ] Select List Options support drag-and-drop reordering, inline add/edit, and active/inactive toggle
 
 ---
 
@@ -78,11 +828,11 @@ The value field in the Add/Edit Interpretation modal **automatically adapts** ba
 
 **For Numeric Tests:**
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Value or Range *                                        â”‚
-â”‚ [>126___________________________] (text input)          â”‚
-â”‚ Use comparison operators (>, <, >=, <=), ranges (70-99) â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────┐
+│ Value or Range *                                        │
+│ [>126___________________________] (text input)          │
+│ Use comparison operators (>, <, >=, <=), ranges (70-99) │
+└─────────────────────────────────────────────────────────┘
 ```
 - Text input field for entering numeric expressions
 - Supports: `>N`, `<N`, `>=N`, `<=N`, `N-M` (range), exact values
@@ -90,18 +840,18 @@ The value field in the Add/Edit Interpretation modal **automatically adapts** ba
 
 **For Select List Tests:**
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ When Value(s) Selected *                                â”‚
-â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â” â”‚
-â”‚ â”‚ â˜‘ Positive                                          â”‚ â”‚
-â”‚ â”‚ â˜ Negative                                          â”‚ â”‚
-â”‚ â”‚ â˜ Indeterminate                                     â”‚ â”‚
-â”‚ â”‚ â˜‘ Reactive                                          â”‚ â”‚
-â”‚ â”‚ â˜ Non-Reactive                                      â”‚ â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜ â”‚
-â”‚ Selected: [Positive Ã—] [Reactive Ã—]                     â”‚
-â”‚ Select one or more values that trigger this interpret.  â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────┐
+│ When Value(s) Selected *                                │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ ☑ Positive                                          │ │
+│ │ ☐ Negative                                          │ │
+│ │ ☐ Indeterminate                                     │ │
+│ │ ☑ Reactive                                          │ │
+│ │ ☐ Non-Reactive                                      │ │
+│ └─────────────────────────────────────────────────────┘ │
+│ Selected: [Positive ×] [Reactive ×]                     │
+│ Select one or more values that trigger this interpret.  │
+└─────────────────────────────────────────────────────────┘
 ```
 - Checkbox list populated from the test's configured select list options
 - **Can select 1 or more options** that will trigger the same interpretation
@@ -118,9 +868,9 @@ Test: Fasting Glucose
 Result entered: 142 mg/dL
 
 System checks interpretations:
-  - GLU-CRIT-H: >400 â†’ No match
-  - GLU-HI: >126 â†’ MATCH (142 > 126)
-  - GLU-NL: 70-99 â†’ No match
+  - GLU-CRIT-H: >400 → No match
+  - GLU-HI: >126 → MATCH (142 > 126)
+  - GLU-NL: 70-99 → No match
   
 Suggested interpretation: "High" with associated clinical text
 ```
@@ -131,8 +881,8 @@ Test: HIV Rapid Test
 Result selected: "Reactive"
 
 System checks interpretations:
-  - HIV-POS: [Reactive, Positive] â†’ MATCH (Reactive in list)
-  - HIV-NEG: [Non-Reactive, Negative] â†’ No match
+  - HIV-POS: [Reactive, Positive] → MATCH (Reactive in list)
+  - HIV-NEG: [Non-Reactive, Negative] → No match
   
 Suggested interpretation: "Positive" with associated clinical text
 ```
@@ -143,13 +893,13 @@ Test: Hepatitis Panel
 Interpretation "Acute Infection" configured for: [Reactive, Positive, Detected]
 
 Result selected: "Detected"
-â†’ MATCH - suggests "Acute Infection" interpretation
+→ MATCH - suggests "Acute Infection" interpretation
 
 Result selected: "Reactive"  
-â†’ MATCH - suggests "Acute Infection" interpretation
+→ MATCH - suggests "Acute Infection" interpretation
 
 Result selected: "Negative"
-â†’ No match
+→ No match
 ```
 
 ### Available Colors
@@ -350,7 +1100,7 @@ Order Entry shows which test drove each label count for transparency.
 
 ### Location
 
-Administration â†’ Master Lists â†’ Label Presets
+Administration → Master Lists → Label Presets
 
 ### List View
 
@@ -358,7 +1108,7 @@ Administration â†’ Master Lists â†’ Label Presets
 |--------|-------------|
 | Name | Preset name (e.g., "Cryo Vial Label") |
 | Category | Order, Specimen, Pathology, Storage |
-| Size (mm) | Height Ã— Width |
+| Size (mm) | Height × Width |
 | Fields | Number of fields configured |
 | Status | Active / Inactive |
 | Actions | Edit, Delete (system presets locked) |
@@ -445,11 +1195,114 @@ Administration â†’ Master Lists â†’ Label Presets
 
 ---
 
+## Terminology Mappings
+
+### Purpose
+
+Link this test to standard terminology codes (LOINC, SNOMED CT, CIEL, Open Concept Lab) to enable interoperability with FHIR-based health information exchanges, OpenMRS, and national health information systems. Per Constitution III (FHIR/IHE Standards Compliance), every test exposed externally MUST have at least one canonical terminology mapping.
+
+### Mapping Fields
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| **Terminology Source** | Enum | Yes | One of `LOINC`, `SNOMED`, `CIEL`, `OCL` |
+| **Code** | String | Yes | The code in the source terminology (e.g., LOINC `1558-6`, SNOMED `271062006`) |
+| **Display Name** | String | Yes (auto-fetched) | Human-readable name from the source terminology — populated automatically from a terminology lookup service when available, otherwise editable |
+| **Relationship** | Enum | Yes | One of `SAME_AS`, `BROADER_THAN`, `NARROWER_THAN` — describes how the OpenELIS test relates to the external concept |
+
+### Supported Terminology Sources
+
+| Source | Description | Reference URL |
+|---|---|---|
+| **LOINC** | Logical Observation Identifiers Names and Codes — international standard for laboratory test identification | https://loinc.org |
+| **SNOMED CT** | Systematized Nomenclature of Medicine - Clinical Terms — broader clinical concept terminology | https://snomed.org |
+| **CIEL** | Columbia International eHealth Laboratory dictionary — used in OpenMRS deployments | https://wiki.openmrs.org/display/docs/CIEL+Dictionary |
+| **OCL** | Open Concept Lab — multi-organization concept dictionary platform | https://openconceptlab.org |
+
+### Relationship Semantics
+
+| Relationship | Meaning | Example |
+|---|---|---|
+| **SAME_AS** | The OpenELIS test is functionally identical to the source concept | OpenELIS "Fasting Glucose" SAME_AS LOINC `1558-6` ("Fasting glucose [Mass/volume] in Serum or Plasma") |
+| **BROADER_THAN** | The OpenELIS test is a more general concept than the source code | OpenELIS "Glucose" BROADER_THAN LOINC `1558-6` (the OE test covers fasting and random glucose) |
+| **NARROWER_THAN** | The OpenELIS test is a more specific concept than the source code | OpenELIS "Capillary Fasting Glucose" NARROWER_THAN LOINC `1558-6` |
+
+### UI Elements
+
+**Mappings List:**
+- Per-mapping card (Carbon `<Tile>`):
+  - Source as a colored Carbon `<Tag>` (LOINC = `kind="blue"`, SNOMED = `kind="teal"`, CIEL = `kind="purple"`, OCL = `kind="cyan"`)
+  - Code in monospace font
+  - Relationship as a small Carbon `<Tag kind="warm-gray">`
+  - Display name in normal text below
+  - Edit + Delete actions on the right
+- Empty state when no mappings configured
+
+**Add Mapping (inline form, not modal):**
+- 4-column grid: Terminology Source `<Select>` | Code `<TextInput>` | Relationship `<Select>` | Add `<Button>`
+- On Source + Code entry, attempt async lookup against terminology service; auto-populate Display Name. Show a Carbon `<InlineLoading>` during lookup.
+- Helper text below: "If the terminology service is unavailable, you can enter the Display Name manually."
+
+### FHIR Mapping Behavior
+
+When this test is exposed via FHIR (DiagnosticReport, Observation), the terminology mappings determine the `Observation.code` codings included:
+
+- A `SAME_AS` mapping is included as a primary `coding`.
+- A `BROADER_THAN` mapping is included as an additional `coding` with `userSelected: false`.
+- A `NARROWER_THAN` mapping is included as an additional `coding` with `userSelected: false`.
+
+If multiple sources have `SAME_AS` mappings, all are included as parallel codings (e.g., LOINC + SNOMED for the same test).
+
+### Data Model
+
+```sql
+CREATE TABLE test_terminology_mapping (
+    id SERIAL PRIMARY KEY,
+    test_id INTEGER NOT NULL REFERENCES test(id),
+    source VARCHAR(20) NOT NULL,           -- 'LOINC', 'SNOMED', 'CIEL', 'OCL'
+    code VARCHAR(50) NOT NULL,
+    display_name VARCHAR(500) NOT NULL,
+    relationship VARCHAR(20) NOT NULL,      -- 'SAME_AS', 'BROADER_THAN', 'NARROWER_THAN'
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_term_source CHECK (source IN ('LOINC', 'SNOMED', 'CIEL', 'OCL')),
+    CONSTRAINT chk_term_relationship CHECK (relationship IN ('SAME_AS', 'BROADER_THAN', 'NARROWER_THAN')),
+    UNIQUE(test_id, source, code)
+);
+
+CREATE INDEX idx_test_terminology_test ON test_terminology_mapping(test_id);
+CREATE INDEX idx_test_terminology_source_code ON test_terminology_mapping(source, code);
+```
+
+### API Endpoints
+
+| Method | Endpoint | Description |
+|---|---|---|
+| GET | `/api/tests/{id}/terminology` | List mappings for test |
+| POST | `/api/tests/{id}/terminology` | Add a mapping |
+| PUT | `/api/tests/{id}/terminology/{mappingId}` | Update a mapping |
+| DELETE | `/api/tests/{id}/terminology/{mappingId}` | Delete a mapping |
+| GET | `/api/terminology/lookup?source={s}&code={c}` | Lookup display name from terminology service |
+
+### Acceptance Criteria
+
+- [ ] Tests can have multiple terminology mappings across different sources (LOINC, SNOMED, CIEL, OCL)
+- [ ] Each mapping requires Source, Code, Display Name, and Relationship
+- [ ] Add Mapping is an inline form (not a modal)
+- [ ] Display Name is auto-populated via terminology lookup when available
+- [ ] Display Name is editable if lookup fails or returns no result
+- [ ] Mappings list shows source as a colored Tag
+- [ ] Edit and Delete are available per mapping
+- [ ] FHIR exposure includes terminology codings as documented above
+- [ ] Empty state appears when no mappings are configured
+
+---
+
 ## Reagents Tab
 
 ### Purpose
 
-Link reagents from inventory to tests to track consumption and enable inventory management integration. Reagents are configured in **Administration â†’ Master Lists â†’ Reagents**.
+Link reagents from inventory to tests to track consumption and enable inventory management integration. Reagents are configured in **Administration → Master Lists → Reagents**.
 
 ### Linked Reagent Fields
 
@@ -458,7 +1311,7 @@ Link reagents from inventory to tests to track consumption and enable inventory 
 | **Reagent** | Lookup | Yes | Select from configured reagents |
 | **Usage Type** | Dropdown | Yes | PRIMARY or SECONDARY |
 | **Quantity Per Test** | Number | Yes | Amount consumed per test run |
-| **Unit** | Dropdown | Yes | Unit of measure (ÂµL, mL, etc.) |
+| **Unit** | Dropdown | Yes | Unit of measure (µL, mL, etc.) |
 
 ### UI Elements
 
@@ -473,7 +1326,7 @@ Link reagents from inventory to tests to track consumption and enable inventory 
 
 ### Purpose
 
-Link laboratory analyzers/instruments to tests to indicate which instruments can perform this test. Analyzers are configured in **Administration â†’ Master Lists â†’ Analyzers**. Test code mapping for interfacing is configured separately in the analyzer interface setup.
+Link laboratory analyzers/instruments to tests to indicate which instruments can perform this test. Analyzers are configured in **Administration → Master Lists → Analyzers**. Test code mapping for interfacing is configured separately in the analyzer interface setup.
 
 ### Linked Analyzer Display
 
@@ -538,14 +1391,14 @@ CREATE TABLE test_analyzer (
 | **Stability Notes** | Additional stability information | No |
 
 **Standard Storage Conditions:**
-- Ultra-low freezer: -80Â°C to -60Â°C
-- Freezer: -30Â°C to -15Â°C
-- Refrigerator: 2Â°C to 8Â°C
-- Cold room: 4Â°C to 8Â°C
-- Cool room: 15Â°C to 18Â°C
-- Room temperature: 18Â°C to 25Â°C
-- Controlled room temp: 20Â°C to 25Â°C
-- Warm incubator: 35Â°C to 37Â°C
+- Ultra-low freezer: -80°C to -60°C
+- Freezer: -30°C to -15°C
+- Refrigerator: 2°C to 8°C
+- Cold room: 4°C to 8°C
+- Cool room: 15°C to 18°C
+- Room temperature: 18°C to 25°C
+- Controlled room temp: 20°C to 25°C
+- Warm incubator: 35°C to 37°C
 - Ambient: Uncontrolled room temperature
 
 ### Special Handling Requirements
@@ -642,6 +1495,28 @@ CREATE TABLE test_sample_handling_history (
 
 ## Test List View Enhancements
 
+### Domain Filter
+
+The test catalog list view includes a Domain filter chip alongside the Section / Sample Type / Result Type / Status / AMR filters.
+
+**Filter Options** (multi-select):
+- **All Domains** (default)
+- **Clinical**
+- **Environmental**
+- **Vector**
+
+**Visual Indicators:**
+- Each test row shows its Domain as a Carbon `<Tag>`:
+  - CLINICAL → `kind="blue"`
+  - ENVIRONMENTAL → `kind="teal"`
+  - VECTOR → `kind="purple"`
+- Domain Tag appears as a column on the test list table.
+
+**Use Cases:**
+- Environmental lab admin reviewing only the water-quality tests in the catalog.
+- Vector surveillance officer auditing every Vector-domain test before a SILNAS data push.
+- Clinical lab admin filtering out non-clinical tests when reviewing patient-facing test coverage.
+
 ### AMR Filter
 
 The test catalog list view includes a filter for Antimicrobial Resistance (AMR) tests to support WHONET export workflows.
@@ -659,6 +1534,59 @@ The test catalog list view includes a filter for Antimicrobial Resistance (AMR) 
 - Quickly identify all antimicrobial susceptibility tests in the catalog
 - Verify WHONET configuration before export
 - Bulk operations on AMR tests (e.g., update breakpoint standards)
+
+### Filter Set (Complete)
+
+The Test List View exposes the following filters above the table. Filters apply additively (AND across categories, OR within multi-select categories).
+
+| Filter | Type | Options |
+|---|---|---|
+| **Section** | Single-select dropdown | All Sections, plus every value from `test_section` (Chemistry, Hematology, Serology, Immunology, Microbiology, Urinalysis, Parasitology, Molecular Biology, …) |
+| **Sample Type** | Single-select dropdown | All Sample Types, plus values configured per deployment (Serum, Plasma, Whole Blood, Urine, CSF, Water, Mosquito Pool, …) |
+| **Result Type** | Single-select dropdown | All Result Types, Numeric, Select List, Multi-select, Free Text |
+| **Status** | Single-select dropdown | All Statuses, Active, Inactive |
+| **Domain** | Multi-select chip | All Domains, Clinical, Environmental, Vector — see Domain Filter above |
+| **AMR** | Single-select dropdown | All Tests, AMR Tests Only, Non-AMR Tests — see AMR Filter above |
+
+**Behavior:**
+- Filters live in a collapsible filter bar revealed by a "Filters" toggle button next to the search input. Default state is collapsed; the active filter count is shown as a badge on the toggle when any filter is applied.
+- A "Clear All" button resets every filter to default and is visible whenever any filter is non-default.
+- Filter state is reflected in the URL (e.g., `?section=chemistry&domain=CLINICAL`) so the filtered view is shareable and bookmarkable.
+
+### Row Interaction
+
+The Test List View has no per-row Actions column and no bulk-selection toolbar. Both were considered redundant: every operation that bulk actions or per-row Edit / Activate / Deactivate would expose is already reachable inside the test editor (the Domain field, status flags, panel membership, etc. all live on Basic Info or their own sub-section). Concentrating writes inside the editor avoids dual entry points and prevents accidental destructive bulk actions from a list view.
+
+**Click-to-open behavior:**
+- The test name in each row is rendered as a primary-color link button. Clicking it navigates to the test editor for that row.
+- The entire row is also clickable as a secondary affordance — clicking anywhere in the row navigates to the test editor.
+- The row shows a `cursor: pointer` on hover.
+- Keyboard navigation: each row is tab-focusable; pressing Enter on a focused row opens the editor.
+- All navigation routes via the same `admin.testCatalog.manage` permission check that gates the editor.
+
+**Out of scope for this revision (deferred to another feature):** any bulk activate / deactivate / add-to-panel UX. If the lab needs that pattern, it should be designed as a deliberate bulk-management feature, not piggy-backed on the catalog list.
+
+### Pagination
+
+The Test List View paginates server-side. The default page size is 25 rows; users can switch to 50, 100, or "All" via a Carbon `<Pagination>` component below the table.
+
+- Pagination state is reflected in the URL (`?page=3&pageSize=50`).
+- The pagination component shows total rows ("Showing 26–50 of 347 tests").
+- Filter changes reset to page 1.
+
+### Acceptance Criteria
+
+- [ ] Filter bar collapses by default and exposes Section / Sample Type / Result Type / Status / Domain / AMR filters when expanded
+- [ ] Active filter count is shown as a badge on the Filters toggle
+- [ ] Clear All resets every filter and is hidden when no filter is active
+- [ ] Filter state is reflected in the URL and persists on refresh
+- [ ] Test list table has no Actions column and no row-selection checkboxes
+- [ ] Test name in each row is a primary-color link; clicking it opens the editor for that test
+- [ ] Clicking anywhere on a row also opens the editor for that test
+- [ ] Each row is keyboard-focusable; Enter on a focused row opens the editor
+- [ ] Pagination defaults to 25 rows; user can switch to 50, 100, or All
+- [ ] Pagination state and page size are reflected in the URL
+- [ ] Filter or page-size changes reset to page 1
 
 ---
 
@@ -693,13 +1621,13 @@ Source: Beaumont Laboratory Critical Values; acutecaretesting.org pediatric cons
 
 ```
 Range Entry Structure:
-â”œâ”€â”€ Range Type (Normal | Valid | Critical | Reporting)
-â”œâ”€â”€ Sex (Male | Female | All)
-â”œâ”€â”€ Age From (value + unit)
-â”œâ”€â”€ Age To (value + unit)
-â”œâ”€â”€ Low Value (nullable for critical-high-only)
-â”œâ”€â”€ High Value (nullable for critical-low-only)
-â””â”€â”€ Notes (optional)
+├── Range Type (Normal | Valid | Critical | Reporting)
+├── Sex (Male | Female | All)
+├── Age From (value + unit)
+├── Age To (value + unit)
+├── Low Value (nullable for critical-high-only)
+├── High Value (nullable for critical-low-only)
+└── Notes (optional)
 ```
 
 **Age Units Supported:**
@@ -719,14 +1647,14 @@ Range Entry Structure:
 **Normal Ranges (Sex-Specific):**
 | Sex | Age From | Age To | Low | High | Unit |
 |-----|----------|--------|-----|------|------|
-| Male | 0 days | 5 days | 1 | 155 | Âµmol/L |
-| Male | 6 days | 14 days | 1 | 140 | Âµmol/L |
-| Male | 15 days | 1 month | 1 | 130 | Âµmol/L |
-| Male | 1 month | 1 year | 1 | 115 | Âµmol/L |
-| Male | 1 year | âˆž | 5 | 40 | Âµmol/L |
-| Female | 0 days | 55 days | 1 | 175 | Âµmol/L |
-| Female | 56 days | 1 year | 1 | 130 | Âµmol/L |
-| Female | 1 year | âˆž | 5 | 35 | Âµmol/L |
+| Male | 0 days | 5 days | 1 | 155 | µmol/L |
+| Male | 6 days | 14 days | 1 | 140 | µmol/L |
+| Male | 15 days | 1 month | 1 | 130 | µmol/L |
+| Male | 1 month | 1 year | 1 | 115 | µmol/L |
+| Male | 1 year | ∞ | 5 | 40 | µmol/L |
+| Female | 0 days | 55 days | 1 | 175 | µmol/L |
+| Female | 56 days | 1 year | 1 | 130 | µmol/L |
+| Female | 1 year | ∞ | 5 | 35 | µmol/L |
 
 **Critical Ranges (Age-Specific, Sex-Neutral):**
 | Sex | Age From | Age To | Critical High | Unit |
@@ -736,14 +1664,14 @@ Range Entry Structure:
 | All | 36 hours | 47 hours | >13.9 | mg/dL |
 | All | 48 hours | 71 hours | >14.9 | mg/dL |
 | All | 72 hours | 13 days | >17.9 | mg/dL |
-| All | 14 days | âˆž | >15.0 | mg/dL |
+| All | 14 days | ∞ | >15.0 | mg/dL |
 
 ### 6.3.3 Coverage Validation Requirements
 
 The system **must validate complete age coverage** for each sex:
 
 **Validation Rules:**
-1. For each sex (Male, Female), age ranges must cover from birth (0) to maximum age (âˆž) without gaps
+1. For each sex (Male, Female), age ranges must cover from birth (0) to maximum age (∞) without gaps
 2. Overlapping age ranges for the same sex are not allowed
 3. "All" sex ranges count as coverage for both Male and Female
 4. Validation runs on save and displays clear error messages for any gaps
@@ -766,30 +1694,96 @@ For each sex in [Male, Female]:
 
 ### 6.3.4 Range Editor UI Requirements
 
-**Structured View (Default):**
-- Group ranges by type (Normal, Valid, Critical, Reporting)
-- Within each type, sub-group by sex
-- Show age range, low/high values, mini visual bar
-- Expand/collapse each range type section
+The Range Editor exposes three view modes for the same underlying range data, plus a coverage validation panel and an add/edit modal. Users switch between views using a Carbon `<Dropdown>` in the editor's header bar; the selected view persists in URL state (`?rangeView=structured|table|visual`) so it's bookmarkable.
 
-**Visual View:**
-- Demographic selector (Sex dropdown, Age input with unit)
-- Shows all 4 range types on stacked horizontal bars
-- Updates dynamically as user changes demographics
-- Useful for "what ranges apply to a 3-day-old male?"
+#### Structured View (Default)
 
-**Table View:**
-- Flat table of all ranges across all types
-- Sortable by any column
-- Bulk editing capability
+The default view groups ranges hierarchically: by range type, then by sex, sorted ascending by age. Designed for editing one range type's coverage at a time.
 
-**Add/Edit Range Modal:**
-- Sex selector (All / Male Only / Female Only)
-- Age From: number input + unit dropdown (hours/days/weeks/months/years)
-- Age To: number input + unit dropdown (use 999 years for infinity)
-- Low value (optional for critical-high-only scenarios)
-- High value (optional for critical-low-only scenarios)
-- Coverage warning banner showing impact of this range
+**Layout:**
+- Top-level sections, one per range type (Normal, Valid, Critical, Reporting). Each section is a Carbon `<Accordion>` item that can be expanded or collapsed independently.
+- Each accordion header shows: range-type name as a colored Carbon `<Tag>` (Normal = `kind="green"`, Valid = `kind="blue"`, Critical = `kind="red"`, Reporting = `kind="purple"`), short description ("Clinical reference values", "Expected possible values", etc.), count of ranges defined, and a "+ Add" Carbon `<IconButton>` that opens the Add Range modal scoped to that range type.
+- Inside each section, ranges are sub-grouped by sex (Male, Female, All), with a sex Carbon `<Tag>` separator and the count of ranges in that group.
+- Each range row shows: index number, age range (formatted "X hours – Y days" with infinity rendered as ∞), Low value, High value, and a **mini visual bar** showing the range graphically (Low to High mapped to a 0–200 scale, color-coded to match the range type).
+- Row hover reveals action buttons: Edit, **Copy to other sex** (creates a new range with the same age/values for the opposite sex via the Add Range modal pre-fill), Delete.
+
+**Empty state (per range type):**
+"No {range type}s defined" with a "+ Add {Range Type}" CTA inline.
+
+#### Table View
+
+A flat sortable Carbon `<DataTable>` showing every range across every type in one table. Designed for bulk review or copy-paste exports.
+
+**Columns:** Type (colored Tag), Sex (Tag), Age From (value + unit), Age To (∞ when 999 years), Low, High, Actions.
+
+**Sort behavior:**
+- Default sort: by Type ascending, then by Sex ascending, then by Age From ascending (after normalization to days).
+- Any column header sorts on click; click-again reverses; click-third returns to default sort.
+
+**Bulk editing:** Carbon `<DataTable>` selection enables a Bulk Actions toolbar (Delete Selected, Change Sex, Change Type) — gated by `admin.testCatalog.manage`.
+
+#### Visual View
+
+A "what ranges apply to this patient?" lookup view that renders the four range types as stacked horizontal bars for a selected demographic.
+
+**Demographic selector** at the top:
+- Sex `<Dropdown>` (Male / Female)
+- Age `<NumberInput>` and unit `<Select>` (hours / days / weeks / months / years)
+
+**Bar display** — four stacked rows, one per range type, in fixed order Valid → Normal → Critical → Reporting:
+- Each row has a label on the left ("Valid", "Normal", "Critical", "Reporting") and a 0–200-scaled background bar on the right.
+- The applicable range for the selected demographic is rendered as a colored bar (color matches the range type) with the Low and High values printed inline.
+- If no range applies for the selected demographic, the bar shows italic placeholder text: "Not defined for this demographic."
+- Critical ranges that have only a high value (no low) render the bar from 0 to High; ranges with only a low render from Low to the right edge.
+
+**Legend** below the bars, with a colored swatch per range type.
+
+**Live updates:** changing the demographic selector immediately re-evaluates all four range types and re-renders the bars. No save action is needed in this view — it's read-only.
+
+#### Coverage Validation Panel
+
+Toggleable via a "Validate Coverage" button in the editor header. When enabled, the panel renders above the structured/table/visual view and shows the current coverage state for both sexes.
+
+**Layout:** two side-by-side cards, one for Male, one for Female (uses Carbon `<Tile>`).
+
+**Per-sex card content:**
+- Header: Sex Tag (Male = `kind="blue"`, Female = `kind="magenta"`) and overall status:
+  - **Complete coverage** — green check icon + "Complete Coverage" text
+  - **Issues found** — red alert icon + "{N} Issue(s) Found"
+- Body (when issues exist): one card per issue, color-coded by issue type:
+  - **GAP** — red background, "GAP" pill in red, gap range message ("55 days to 1 year"), suggested values from adjacent range below ("Suggested values from adjacent range: Low=1, High=130"), and a primary action button "Fill Gap"
+  - **OVERLAP** — amber background, "OVERLAP" pill in amber, conflicting-range message ("Overlap at 56 days"), with the two conflicting range descriptions listed beneath
+- Body (when complete): green-tinted info card with text "All age ranges from birth to maximum age are covered."
+
+**Fill Gap action behavior:**
+- Opens the Add Range modal (the same one launched by "+ Add" buttons in the Structured view)
+- Pre-fills: range type = `normal`, sex = the column's sex (M or F), Age From = gap start, Age To = gap end, Low/High = adjacent range's values
+- Modal shows a Carbon `<InlineNotification kind="info">` banner: "Values from: {age range of source range}"
+- User can modify any pre-filled value before saving; the source banner makes clear where the suggestion came from
+
+**Copy-to-other-sex action behavior:**
+- Triggered from a range row in the Structured view
+- Opens the Add Range modal with the same age range and values, but with sex flipped (Male → Female or vice versa)
+- Modal banner: "Copied from {source sex}: {age range}"
+
+#### Add/Edit Range Modal
+
+Single Carbon `<Modal>` reused for adding new ranges, filling gaps, and copying ranges to the other sex.
+
+**Header:** "Add {Range Type}" or "Edit {Range Type}". Close button on the right.
+
+**Source banner** (shown when invoked from Fill Gap or Copy-to-other-sex): Carbon `<InlineNotification kind="info">` with the template-source text.
+
+**Body fields:**
+- **Applies To** — three-button `<RadioButtonGroup>` styled as labeled cards: All (gray), Male Only (blue), Female Only (magenta). Selected card has a Carbon Blue 60 border + tinted background.
+- **Age Range** — two side-by-side blocks, each with a number input and a unit `<Select>` (hours / days / weeks / months / years). From and To. Helper text below: "Use 999 years for 'no upper age limit' (infinity)."
+- **Value Range** — two side-by-side number inputs (Low, High). Field labels change based on range type:
+  - For Critical ranges: "Critical Low (values below this)" and "Critical High (values above this)" — placeholder text "Leave blank if N/A" — both fields optional, but at least one required
+  - For other range types: "Low" and "High" — both required
+
+**Footer:** Cancel + Save buttons. Save is disabled until validation passes (age From < age To, at least one value field filled, no overlap conflict with existing ranges).
+
+**Coverage warning banner** below the form: if the new/edited range introduces an overlap or leaves a new gap, show a Carbon `<InlineNotification kind="warning">` summarizing the impact before save.
 
 ---
 
@@ -939,7 +1933,7 @@ GET /api/v1/tests/{testId}/applicable-range?sex=M&ageValue=3&ageUnit=days
 
 ### Coverage Validation
 
-- [ ] System validates that all ages from 0 to âˆž are covered for each sex
+- [ ] System validates that all ages from 0 to ∞ are covered for each sex
 - [ ] Validation runs automatically on save
 - [ ] Clear error messages identify specific gaps (e.g., "Female: 56 days to 1 year not covered")
 - [ ] Validation considers "All" sex ranges as covering both Male and Female
@@ -988,7 +1982,7 @@ The coverage validation panel must be functional, not just informational:
      - Age From/To: Exact gap boundaries
      - Low/High values: From adjacent range (with banner showing source)
    - User can modify pre-filled values before saving
-   - Banner text: "Values from: 48 hours â€“ 72 hours range"
+   - Banner text: "Values from: 48 hours – 72 hours range"
 
 5. **Copy From Range Action**
    - Each range row has a "Copy to other sex" action
@@ -998,21 +1992,21 @@ The coverage validation panel must be functional, not just informational:
 ### UI Mockup Notes
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Age Coverage Validation                                 â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚
-â”‚  â”‚ Male      âœ“ Complete â”‚  â”‚ Female    âš  1 Issue    â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚                         â”‚  â”‚
-â”‚  â”‚ âœ“ All ages covered   â”‚  â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â” â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â”‚ GAP                 â”‚ â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â”‚ 55 days to 1 year   â”‚ â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â”‚                     â”‚ â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â”‚ Suggested: L=1 H=130â”‚ â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â”‚        [Fill Gap]   â”‚ â”‚  â”‚
-â”‚  â”‚                      â”‚  â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜ â”‚  â”‚
-â”‚  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────┐
+│ Age Coverage Validation                                 │
+├─────────────────────────────────────────────────────────┤
+│  ┌─────────────────────┐  ┌─────────────────────────┐  │
+│  │ Male      ✓ Complete │  │ Female    ⚠ 1 Issue    │  │
+│  │                      │  │                         │  │
+│  │ ✓ All ages covered   │  │ ┌─────────────────────┐ │  │
+│  │                      │  │ │ GAP                 │ │  │
+│  │                      │  │ │ 55 days to 1 year   │ │  │
+│  │                      │  │ │                     │ │  │
+│  │                      │  │ │ Suggested: L=1 H=130│ │  │
+│  │                      │  │ │        [Fill Gap]   │ │  │
+│  │                      │  │ └─────────────────────┘ │  │
+│  └─────────────────────┘  └─────────────────────────┘  │
+└─────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -1074,7 +2068,7 @@ Currently, OpenELIS can throw errors or display blank values when a test is view
 1. **Graceful Fallback Behavior**
    - When a translation is missing for the selected UI language, display the value from the "base" or "primary" language (typically the language in which the test was created)
    - Never display blank/null values or throw errors due to missing translations
-   - Fallback chain: Selected Language â†’ Primary Language â†’ First Available Translation â†’ Internal Code
+   - Fallback chain: Selected Language → Primary Language → First Available Translation → Internal Code
 
 2. **Multi-Language Metadata Storage**
    - Each localizable field maintains values for all supported languages
@@ -1088,7 +2082,7 @@ Currently, OpenELIS can throw errors or display blank values when a test is view
 
 3. **Translation Status Indicators**
    - In the test editor, show which languages have translations
-   - Visual indicator: âœ“ (translated), âš  (missing), or language code badges
+   - Visual indicator: ✓ (translated), ⚠ (missing), or language code badges
    - Allow bulk identification of untranslated content across the catalog
 
 4. **No Breaking on Missing Translations**
@@ -1165,7 +2159,7 @@ $$ LANGUAGE plpgsql STABLE;
   "test": {
     "id": 123,
     "name": {
-      "value": "GlycÃ©mie Ã  jeun",
+      "value": "Glycémie à jeun",
       "language": "fr",
       "isFallback": false
     },
@@ -1214,12 +2208,12 @@ Enable proper identification of AMR-related tests for export to WHONET and other
    - **Antibiotic Class**: Classification (e.g., Penicillins, Fluoroquinolones, Cephalosporins)
    - **Test Method**: Disk diffusion, MIC, E-test, etc.
    - **Breakpoint Standard**: CLSI, EUCAST, or custom
-   - **Potency/Disk Content**: e.g., "10 Âµg" for disk diffusion
+   - **Potency/Disk Content**: e.g., "10 µg" for disk diffusion
 
 3. **WHONET Export Compatibility**
    - AMR-flagged tests included in WHONET export files
    - Proper mapping of result interpretations (S/I/R) to WHONET format
-   - Support for zone diameter (mm) and MIC (Âµg/mL) result types
+   - Support for zone diameter (mm) and MIC (µg/mL) result types
 
 4. **Organism Linkage**
    - AMR tests can be linked to specific organism panels
@@ -1229,18 +2223,18 @@ Enable proper identification of AMR-related tests for export to WHONET and other
 ### UI Mockup
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ â˜‘ Antimicrobial Resistance (AMR) Test                       â”‚
-â”‚   Enable for WHONET export and AMR surveillance             â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ WHONET Configuration                                        â”‚
-â”‚                                                             â”‚
-â”‚ Antibiotic Code:  [AMP     â–¼]   Antibiotic Class: [Penicillins â–¼] â”‚
-â”‚ Test Method:      [Disk Diffusion â–¼]                        â”‚
-â”‚ Breakpoint Std:   [CLSI 2024 â–¼]  Potency: [10    ] Âµg       â”‚
-â”‚                                                             â”‚
-â”‚ â„¹ This test will be included in WHONET exports              â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────────┐
+│ ☑ Antimicrobial Resistance (AMR) Test                       │
+│   Enable for WHONET export and AMR surveillance             │
+├─────────────────────────────────────────────────────────────┤
+│ WHONET Configuration                                        │
+│                                                             │
+│ Antibiotic Code:  [AMP     ▼]   Antibiotic Class: [Penicillins ▼] │
+│ Test Method:      [Disk Diffusion ▼]                        │
+│ Breakpoint Std:   [CLSI 2024 ▼]  Potency: [10    ] µg       │
+│                                                             │
+│ ℹ This test will be included in WHONET exports              │
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ### Data Model
@@ -1258,7 +2252,7 @@ CREATE TABLE test_amr_config (
     breakpoint_standard VARCHAR(50),          -- 'CLSI', 'EUCAST'
     breakpoint_year INTEGER,
     disk_potency DECIMAL(10,2),
-    disk_potency_unit VARCHAR(10) DEFAULT 'Âµg',
+    disk_potency_unit VARCHAR(10) DEFAULT 'µg',
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -1296,12 +2290,11 @@ Configure automated notifications when specific result conditions are met, enabl
    - Support for multiple rules per test
    - Rules can be enabled/disabled without deletion
 
-2. **Trigger Conditions**
+2. **Trigger Conditions** (four types — kept aligned with the implemented JSX)
    - **All Results**: Notify on every result entry
    - **Abnormal Values**: Result outside normal range (high or low)
    - **Critical Values**: Result in critical/panic range
    - **Specific Value**: Exact match (useful for select list results like "Positive")
-   - **Custom Expression**: Advanced condition builder (e.g., "value > 200 AND patient.age < 18")
 
 3. **Delivery Channels**
    - **SMS**: Send text message to phone number
@@ -1328,105 +2321,104 @@ Configure automated notifications when specific result conditions are met, enabl
 ### UI Mockup
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Alert Rules                                              [+ Add Rule]â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚                                                                      â”‚
-â”‚ â”Œâ”€ Rule 1: Critical Value Alert â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â˜‘ Enabled â”€â”â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ WHEN result is   [Critical Value    â–¼]                           â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ NOTIFY via       [SMS â–¼]  [Email â–¼]                              â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ RECIPIENTS                                                        â”‚â”‚
-â”‚ â”‚   â˜‘ Ordering Physician                                           â”‚â”‚
-â”‚ â”‚   â˜ Patient                                                       â”‚â”‚
-â”‚ â”‚   â˜ Custom: [                    ]                               â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ MESSAGE TEMPLATE (SMS)                                            â”‚â”‚
-â”‚ â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚â”‚
-â”‚ â”‚ â”‚ CRITICAL: {{test_name}} result {{result}} {{unit}} for      â”‚  â”‚â”‚
-â”‚ â”‚ â”‚ {{patient_name}}. Please review immediately.                â”‚  â”‚â”‚
-â”‚ â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚â”‚
-â”‚ â”‚                                                    [Edit] [Delete]â”‚â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â”‚                                                                      â”‚
-â”‚ â”Œâ”€ Rule 2: Abnormal Result Notification â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â˜‘ Enabled â”€â”â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ WHEN result is   [Abnormal (High or Low) â–¼]                      â”‚â”‚
-â”‚ â”‚ NOTIFY via       [Email â–¼]                                        â”‚â”‚
-â”‚ â”‚ RECIPIENTS       â˜‘ Ordering Physician                            â”‚â”‚
-â”‚ â”‚                                                    [Edit] [Delete]â”‚â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â”‚                                                                      â”‚
-â”‚ â”Œâ”€ Rule 3: Positive Result Alert â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â˜ Disabled â”â”‚
-â”‚ â”‚ WHEN result equals "Positive"                                     â”‚â”‚
-â”‚ â”‚ NOTIFY via SMS to Patient                          [Edit] [Delete]â”‚â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────────────────┐
+│ Alert Rules                                              [+ Add Rule]│
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│ ┌─ Rule 1: Critical Value Alert ─────────────────────── ☑ Enabled ─┐│
+│ │                                                                   ││
+│ │ WHEN result is   [Critical Value    ▼]                           ││
+│ │                                                                   ││
+│ │ NOTIFY via       [SMS ▼]  [Email ▼]                              ││
+│ │                                                                   ││
+│ │ RECIPIENTS                                                        ││
+│ │   ☑ Ordering Physician                                           ││
+│ │   ☐ Patient                                                       ││
+│ │   ☐ Custom: [                    ]                               ││
+│ │                                                                   ││
+│ │ MESSAGE TEMPLATE (SMS)                                            ││
+│ │ ┌─────────────────────────────────────────────────────────────┐  ││
+│ │ │ CRITICAL: {{test_name}} result {{result}} {{unit}} for      │  ││
+│ │ │ {{patient_name}}. Please review immediately.                │  ││
+│ │ └─────────────────────────────────────────────────────────────┘  ││
+│ │                                                    [Edit] [Delete]││
+│ └───────────────────────────────────────────────────────────────────┘│
+│                                                                      │
+│ ┌─ Rule 2: Abnormal Result Notification ─────────────── ☑ Enabled ─┐│
+│ │                                                                   ││
+│ │ WHEN result is   [Abnormal (High or Low) ▼]                      ││
+│ │ NOTIFY via       [Email ▼]                                        ││
+│ │ RECIPIENTS       ☑ Ordering Physician                            ││
+│ │                                                    [Edit] [Delete]││
+│ └───────────────────────────────────────────────────────────────────┘│
+│                                                                      │
+│ ┌─ Rule 3: Positive Result Alert ────────────────────── ☐ Disabled ┐│
+│ │ WHEN result equals "Positive"                                     ││
+│ │ NOTIFY via SMS to Patient                          [Edit] [Delete]││
+│ └───────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Add/Edit Rule Modal
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Add Alert Rule                                                   âœ•  â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚                                                                      â”‚
-â”‚ Rule Name: [Critical Value SMS Alert                    ]           â”‚
-â”‚                                                                      â”‚
-â”‚ â”€â”€â”€ Trigger Condition â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”‚
-â”‚                                                                      â”‚
-â”‚ Alert when result is:  â—‹ All Results                                â”‚
-â”‚                        â—‹ Abnormal (outside normal range)            â”‚
-â”‚                        â— Critical (panic value)                     â”‚
-â”‚                        â—‹ Specific Value: [          ]               â”‚
-â”‚                        â—‹ Custom Expression                          â”‚
-â”‚                                                                      â”‚
-â”‚ â”€â”€â”€ Notification Channel â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”‚
-â”‚                                                                      â”‚
-â”‚ Send via:  â˜‘ SMS    â˜‘ Email                                        â”‚
-â”‚                                                                      â”‚
-â”‚ â”€â”€â”€ Recipients â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”‚
-â”‚                                                                      â”‚
-â”‚ â˜‘ Ordering Physician (from order)                                   â”‚
-â”‚ â˜ Patient (from patient record)                                     â”‚
-â”‚ â˜ Referring Facility contact                                        â”‚
-â”‚ â˜ Custom recipient:                                                 â”‚
-â”‚     Phone: [+1 555-123-4567        ]                               â”‚
-â”‚     Email: [                        ]                               â”‚
-â”‚ â˜ All users with role: [Lab Director â–¼]                            â”‚
-â”‚                                                                      â”‚
-â”‚ â”€â”€â”€ Message Templates â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”‚
-â”‚                                                                      â”‚
-â”‚ SMS Template (160 char recommended):                                 â”‚
-â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â” â”‚
-â”‚ â”‚ CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}â”‚ â”‚
-â”‚ â”‚ ID:{{patient_id}}. Review immediately.                          â”‚ â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜ â”‚
-â”‚ Characters: 98/160                                                   â”‚
-â”‚                                                                      â”‚
-â”‚ Email Subject:                                                       â”‚
-â”‚ [Critical Lab Result: {{test_name}} for {{patient_name}}    ]       â”‚
-â”‚                                                                      â”‚
-â”‚ Email Body:                                                          â”‚
-â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â” â”‚
-â”‚ â”‚ A critical laboratory result requires your attention:           â”‚ â”‚
-â”‚ â”‚                                                                  â”‚ â”‚
-â”‚ â”‚ Patient: {{patient_name}} (ID: {{patient_id}})                  â”‚ â”‚
-â”‚ â”‚ Test: {{test_name}}                                              â”‚ â”‚
-â”‚ â”‚ Result: {{result}} {{unit}}                                      â”‚ â”‚
-â”‚ â”‚ Reference Range: {{reference_range}}                             â”‚ â”‚
-â”‚ â”‚ Collected: {{collected_date}}                                    â”‚ â”‚
-â”‚ â”‚ ...                                                              â”‚ â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜ â”‚
-â”‚                                                                      â”‚
-â”‚ Available variables: patient_name, patient_id, test_name, result,   â”‚
-â”‚ unit, reference_range, collected_date, resulted_date, lab_name      â”‚
-â”‚                                                                      â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚                                        [Cancel]  [Save Alert Rule]  â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────────────────┐
+│ Add Alert Rule                                                   ✕  │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│ Rule Name: [Critical Value SMS Alert                    ]           │
+│                                                                      │
+│ ─── Trigger Condition ───────────────────────────────────────────── │
+│                                                                      │
+│ Alert when result is:  ○ All Results                                │
+│                        ○ Abnormal (outside normal range)            │
+│                        ● Critical (panic value)                     │
+│                        ○ Specific Value: [          ]               │
+│                                                                      │
+│ ─── Notification Channel ────────────────────────────────────────── │
+│                                                                      │
+│ Send via:  ☑ SMS    ☑ Email                                        │
+│                                                                      │
+│ ─── Recipients ──────────────────────────────────────────────────── │
+│                                                                      │
+│ ☑ Ordering Physician (from order)                                   │
+│ ☐ Patient (from patient record)                                     │
+│ ☐ Referring Facility contact                                        │
+│ ☐ Custom recipient:                                                 │
+│     Phone: [+1 555-123-4567        ]                               │
+│     Email: [                        ]                               │
+│ ☐ All users with role: [Lab Director ▼]                            │
+│                                                                      │
+│ ─── Message Templates ───────────────────────────────────────────── │
+│                                                                      │
+│ SMS Template (160 char recommended):                                 │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ CRITICAL: {{test_name}} {{result}} {{unit}} for {{patient_name}}│ │
+│ │ ID:{{patient_id}}. Review immediately.                          │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│ Characters: 98/160                                                   │
+│                                                                      │
+│ Email Subject:                                                       │
+│ [Critical Lab Result: {{test_name}} for {{patient_name}}    ]       │
+│                                                                      │
+│ Email Body:                                                          │
+│ ┌─────────────────────────────────────────────────────────────────┐ │
+│ │ A critical laboratory result requires your attention:           │ │
+│ │                                                                  │ │
+│ │ Patient: {{patient_name}} (ID: {{patient_id}})                  │ │
+│ │ Test: {{test_name}}                                              │ │
+│ │ Result: {{result}} {{unit}}                                      │ │
+│ │ Reference Range: {{reference_range}}                             │ │
+│ │ Collected: {{collected_date}}                                    │ │
+│ │ ...                                                              │ │
+│ └─────────────────────────────────────────────────────────────────┘ │
+│                                                                      │
+│ Available variables: patient_name, patient_id, test_name, result,   │
+│ unit, reference_range, collected_date, resulted_date, lab_name      │
+│                                                                      │
+├─────────────────────────────────────────────────────────────────────┤
+│                                        [Cancel]  [Save Alert Rule]  │
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Data Model
@@ -1438,9 +2430,8 @@ CREATE TABLE test_alert_rule (
     test_id INTEGER NOT NULL REFERENCES test(id),
     name VARCHAR(100) NOT NULL,
     is_enabled BOOLEAN DEFAULT TRUE,
-    trigger_type VARCHAR(30) NOT NULL, -- 'ALL', 'ABNORMAL', 'CRITICAL', 'SPECIFIC_VALUE', 'CUSTOM'
+    trigger_type VARCHAR(30) NOT NULL, -- 'ALL', 'ABNORMAL', 'CRITICAL', 'SPECIFIC_VALUE'
     trigger_value VARCHAR(100),         -- For SPECIFIC_VALUE type
-    trigger_expression TEXT,            -- For CUSTOM type (future)
     notify_sms BOOLEAN DEFAULT FALSE,
     notify_email BOOLEAN DEFAULT FALSE,
     notify_ordering_physician BOOLEAN DEFAULT FALSE,
@@ -1524,44 +2515,44 @@ Display reflex test rules and calculated result configurations that apply to thi
 ### UI Mockup
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ Reflex & Calculated Results                                         â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚                                                                      â”‚
-â”‚ â”Œâ”€ REFLEX TESTS â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ Rules triggered BY this test:                                     â”‚â”‚
-â”‚ â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚â”‚
-â”‚ â”‚ â”‚ IF result > 200 mg/dL â†’ ORDER Hemoglobin A1c                â”‚  â”‚â”‚
-â”‚ â”‚ â”‚ Mode: Suggest (require confirmation)                         â”‚  â”‚â”‚
-â”‚ â”‚ â”‚                                    [Edit in Master Lists â†’] â”‚  â”‚â”‚
-â”‚ â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ Rules that ORDER this test:                                       â”‚â”‚
-â”‚ â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚â”‚
-â”‚ â”‚ â”‚ â†³ Glucose Tolerance Test (when 2-hour > 140)                â”‚  â”‚â”‚
-â”‚ â”‚ â”‚                                    [Edit in Master Lists â†’] â”‚  â”‚â”‚
-â”‚ â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ [+ Add New Reflex Rule in Master Lists â†’]                        â”‚â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â”‚                                                                      â”‚
-â”‚ â”Œâ”€ CALCULATED RESULTS â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ â”â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ Calculations that USE this test as input:                        â”‚â”‚
-â”‚ â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚â”‚
-â”‚ â”‚ â”‚ âš™ LDL Cholesterol (Calculated)                              â”‚  â”‚â”‚
-â”‚ â”‚ â”‚   Formula: Total_Chol - HDL - (Triglycerides / 5)           â”‚  â”‚â”‚
-â”‚ â”‚ â”‚                                    [Edit in Master Lists â†’] â”‚  â”‚â”‚
-â”‚ â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚â”‚
-â”‚ â”‚                                                                   â”‚â”‚
-â”‚ â”‚ This test IS a calculated result:                                 â”‚â”‚
-â”‚ â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”  â”‚â”‚
-â”‚ â”‚ â”‚ (Not configured as a calculated result)                     â”‚  â”‚â”‚
-â”‚ â”‚ â”‚           [+ Configure in Master Lists â†’]                   â”‚  â”‚â”‚
-â”‚ â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜  â”‚â”‚
-â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────────────────┐
+│ Reflex & Calculated Results                                         │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                      │
+│ ┌─ REFLEX TESTS ────────────────────────────────────────────────── ┐│
+│ │                                                                   ││
+│ │ Rules triggered BY this test:                                     ││
+│ │ ┌─────────────────────────────────────────────────────────────┐  ││
+│ │ │ IF result > 200 mg/dL → ORDER Hemoglobin A1c                │  ││
+│ │ │ Mode: Suggest (require confirmation)                         │  ││
+│ │ │                                    [Edit in Master Lists →] │  ││
+│ │ └─────────────────────────────────────────────────────────────┘  ││
+│ │                                                                   ││
+│ │ Rules that ORDER this test:                                       ││
+│ │ ┌─────────────────────────────────────────────────────────────┐  ││
+│ │ │ ↳ Glucose Tolerance Test (when 2-hour > 140)                │  ││
+│ │ │                                    [Edit in Master Lists →] │  ││
+│ │ └─────────────────────────────────────────────────────────────┘  ││
+│ │                                                                   ││
+│ │ [+ Add New Reflex Rule in Master Lists →]                        ││
+│ └───────────────────────────────────────────────────────────────────┘│
+│                                                                      │
+│ ┌─ CALCULATED RESULTS ──────────────────────────────────────────── ┐│
+│ │                                                                   ││
+│ │ Calculations that USE this test as input:                        ││
+│ │ ┌─────────────────────────────────────────────────────────────┐  ││
+│ │ │ ⚙ LDL Cholesterol (Calculated)                              │  ││
+│ │ │   Formula: Total_Chol - HDL - (Triglycerides / 5)           │  ││
+│ │ │                                    [Edit in Master Lists →] │  ││
+│ │ └─────────────────────────────────────────────────────────────┘  ││
+│ │                                                                   ││
+│ │ This test IS a calculated result:                                 ││
+│ │ ┌─────────────────────────────────────────────────────────────┐  ││
+│ │ │ (Not configured as a calculated result)                     │  ││
+│ │ │           [+ Configure in Master Lists →]                   │  ││
+│ │ └─────────────────────────────────────────────────────────────┘  ││
+│ └───────────────────────────────────────────────────────────────────┘│
+└─────────────────────────────────────────────────────────────────────┘
 ```
 
 ### Navigation Links
@@ -1609,7 +2600,7 @@ Display reflex test rules and calculated result configurations that apply to thi
 
 3. **Order Preview with Drag Support**
    - Scrollable list showing all tests currently in the panel
-   - Current test highlighted with "â† This test" indicator and drag handle (â‰¡)
+   - Current test highlighted with "← This test" indicator and drag handle (≡)
    - Existing tests shown in current order (not draggable)
    - Dragging "This test" reorders the list and updates the numeric input
    - Visual feedback during drag (drop indicator line, item highlighting)
@@ -1624,20 +2615,20 @@ Display reflex test rules and calculated result configurations that apply to thi
 ### UI Mockup
 
 ```
-â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”
-â”‚ â˜‘ Basic Metabolic Panel                    Position: 3  â–¼  â”‚
-â”‚   8 tests                                                   â”‚
-â”œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”¤
-â”‚ Display Position: [3] of 9     â”‚ Panel Test Order Preview   â”‚
-â”‚                                â”‚ â”Œâ”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”â”‚
-â”‚ Enter number or drag the test  â”‚ â”‚   1. Glucose            â”‚â”‚
-â”‚ in the preview list            â”‚ â”‚   2. BUN                â”‚â”‚
-â”‚                                â”‚ â”‚ â‰¡ 3. â† THIS TEST        â”‚â”‚ â† draggable
-â”‚                                â”‚ â”‚   4. Creatinine         â”‚â”‚
-â”‚                                â”‚ â”‚   5. Sodium             â”‚â”‚
-â”‚                                â”‚ â”‚   ...                   â”‚â”‚
-â”‚                                â”‚ â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜â”‚
-â””â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”˜
+┌─────────────────────────────────────────────────────────────┐
+│ ☑ Basic Metabolic Panel                    Position: 3  ▼  │
+│   8 tests                                                   │
+├─────────────────────────────────────────────────────────────┤
+│ Display Position: [3] of 9     │ Panel Test Order Preview   │
+│                                │ ┌─────────────────────────┐│
+│ Enter number or drag the test  │ │   1. Glucose            ││
+│ in the preview list            │ │   2. BUN                ││
+│                                │ │ ≡ 3. ← THIS TEST        ││ ← draggable
+│                                │ │   4. Creatinine         ││
+│                                │ │   5. Sodium             ││
+│                                │ │   ...                   ││
+│                                │ └─────────────────────────┘│
+└─────────────────────────────────────────────────────────────┘
 ```
 
 ### Interaction Details
@@ -1649,7 +2640,7 @@ Display reflex test rules and calculated result configurations that apply to thi
 - Preview list reorders to reflect new position
 
 **Drag-and-Drop:**
-- Grip handle (â‰¡) on "This test" row indicates draggability
+- Grip handle (≡) on "This test" row indicates draggability
 - Only the new test being added is draggable; existing panel tests are static
 - Drag to reposition within the list
 - Drop zones appear between existing tests
@@ -1680,7 +2671,7 @@ CREATE INDEX idx_panel_test_order ON panel_test(panel_id, display_order);
 - [ ] User can set position via drag-and-drop in preview list
 - [ ] Both input methods stay synchronized
 - [ ] Preview shows where test will appear in panel order
-- [ ] Drag handle (â‰¡) clearly indicates draggable item
+- [ ] Drag handle (≡) clearly indicates draggable item
 - [ ] Drop zones provide clear visual feedback during drag
 - [ ] User can create a new panel inline without navigating away
 - [ ] New panels appear in the list immediately after creation
@@ -1760,6 +2751,36 @@ CREATE TABLE test_section_assignment (
 ---
 
 ## Updated Acceptance Criteria (Complete)
+
+### Test Domain
+- [ ] Test entity has a `domain` column constrained to CLINICAL / ENVIRONMENTAL / VECTOR
+- [ ] Basic Info section presents Domain as a radio button group
+- [ ] Domain is required — cannot save Basic Info without a selection
+- [ ] CLINICAL tests do not show the Compliance section in the SideNav
+- [ ] ENVIRONMENTAL and VECTOR tests show the Compliance section as primary
+- [ ] ENVIRONMENTAL and VECTOR tests show an InlineNotification info banner on the Ranges section
+- [ ] Editing Domain on an existing test triggers a confirmation modal before save
+- [ ] Test List View has a Domain filter (multi-select chip)
+- [ ] Test List View shows a Domain Tag column (blue / teal / purple)
+- [ ] Existing tests are backfilled to CLINICAL during migration
+
+### Internal Information Architecture
+- [ ] Test editor's 14 sections appear as a flat list in the SideNav under Test Catalog Management → [Test Name]
+- [ ] No group headers within the test editor SideNav
+- [ ] Each section is reachable at its own route (`/admin/test-catalog/:testId/<section>`)
+- [ ] Breadcrumb shows Admin › Test Catalog Management › [Test Name] › [Section Name]
+- [ ] No Carbon `Tabs` component used for editor primary navigation
+
+### Permissions
+- [ ] `admin.testCatalog.manage` gates access to all `/admin/test-catalog/...` routes (UI hide + API 403)
+- [ ] `compliance.threshold.view` gates the Compliance SideNav item and route
+- [ ] All write endpoints check `admin.testCatalog.manage` server-side
+
+### States
+- [ ] Test List View, Ranges, Methods, Analyzers, Reagents, Alerts, Reflex & Calc, Compliance, Panels, Labels each define an empty state
+- [ ] Table-bearing sections show Carbon DataTableSkeleton during initial fetch
+- [ ] API errors render Carbon InlineNotification kind="error" at the top of the affected section
+- [ ] No-permission state is the standard "You do not have permission" empty page
 
 ### Range Editor
 - [ ] All four range types support age/sex-specific variations
@@ -1922,14 +2943,15 @@ CREATE TABLE test_section_assignment (
 - [ ] Non-overridable labels are displayed as read-only
 
 ### Compliance Tab
-- [ ] Compliance tab appears in test editor vertical tab sidebar under a "Compliance" section group
+- [ ] Compliance section appears as the 14th SideNav item under "Test Catalog Management" → [Test Name] (flat list, no group header)
+- [ ] Section is reachable at route `/admin/test-catalog/:testId/compliance`
 - [ ] Tab displays DataTable of all compliance thresholds defined for this test
 - [ ] Thresholds grouped by Standard Name (default) or Parameter Group via "Group by" toggle
 - [ ] Threshold types shown as colored Tags: MAX (red), MIN (blue), RANGE (teal), DESCRIPTIVE (purple)
 - [ ] Inline row expansion for add/edit threshold forms (not modals)
 - [ ] ComboBox with type-ahead for standard selection
 - [ ] Conditional form fields based on threshold type (upper value for MAX, lower for MIN, both for RANGE, text for DESCRIPTIVE)
-- [ ] Badge on tab label showing threshold count
+- [ ] Badge on the Compliance SideNav item showing threshold count
 - [ ] Tab visible only to users with `compliance.threshold.view` permission
 - [ ] Full specification in companion FRS: S01-compliance-standards-admin-frs-v1.0.md
 
@@ -1941,17 +2963,29 @@ CREATE TABLE test_section_assignment (
 
 Enable per-test regulatory compliance threshold management. Environmental, vector, and food safety laboratories evaluate results against externally published regulatory standards (e.g., Indonesia's Baku Mutu, WHO Drinking Water Guidelines, EPA limits) rather than patient-centric reference ranges. The Compliance tab provides the configuration surface for these thresholds within the unified Test Editor.
 
-### Tab Placement
+### SideNav Placement
 
-The Compliance tab is placed in the vertical tab sidebar under a new **Compliance** section group, after the existing Automation group:
+Per the Internal Information Architecture section earlier in this FRS, the Compliance section is the 14th and final entry in the test editor SideNav. The 14 sections appear as a flat list in workflow order — no group headers — under the "Test Catalog Management" parent in the global Admin SideNav:
 
 ```
-Configuration:  Basic Info | Sample & Results | Ranges | Sample Storage
-Organization:   Display Order | Panels | Labels
-Resources:      Terminology | Reagents
-Automation:     Analyzers | Methods | Alerts | Reflex & Calc
-Compliance:     Compliance  ← NEW
+Test Catalog Management
+  ├── Basic Info
+  ├── Sample & Results
+  ├── Methods
+  ├── Ranges
+  ├── Sample Storage
+  ├── Display Order
+  ├── Panels
+  ├── Labels
+  ├── Terminology
+  ├── Reagents
+  ├── Analyzers
+  ├── Alerts
+  ├── Reflex & Calc
+  └── Compliance       ← this section
 ```
+
+Route: `/admin/test-catalog/:testId/compliance`. Visibility gated by the `compliance.threshold.view` permission key — see the Permissions section earlier in this FRS.
 
 ### Key Features
 

--- a/designs/quality/eqa-v1-crosswalk.md
+++ b/designs/quality/eqa-v1-crosswalk.md
@@ -216,7 +216,7 @@ Recommended framing:
 
 | Q | Decision | Impact on V2 scope |
 |---|---|---|
-| Q1 — Participant-result data path (R1) | **B — Separate `eqa_participant_result` entity** with draft → reviewed → submitted → scored lifecycle, linked to `eqa_result` once provider returns score | V2.1 data model |
+| Q1 — Participant-result data path (R1) | **B — Separate `eqa_participant_result` entity** with per-row `submission_status` (`draft → validated_partial → submitted → scored`) linked to `eqa_result` once provider returns score; cycle-level `ready_to_submit` state (formerly labeled `reviewed`) gates auto-submission per FR-V2.1-04 | V2.1 data model |
 | Q2 — In-house scheme approach (R2, G9) | **C — Polymorphic `eqa_scheme` with `scheme_type` discriminator** (`international_pt \| regional_pt \| inter_lab_split \| in_house`); BR-004 becomes conditional | V2.1 data model |
 | Q3 — Mockup authority | **B — Implementation reference, port to Carbon**; `eqa-enrollment.jsx` preserves IA/field-list/flow, engineering rebuilds in `@carbon/react` for V2 | Applies to every V2 story; historical mockup stays as design reference |
 | Q4 — CAPA approach | **D — Tiered EQA → NCE integration** (not new CAPA tables). NCE module already provides `nce_capa` + `nce_effectiveness_review`; EQA becomes a trigger source | V2.3 NCE hook |

--- a/designs/system/fhir-publication-settings.jsx
+++ b/designs/system/fhir-publication-settings.jsx
@@ -1,0 +1,471 @@
+import { useState } from "react";
+import { CheckCircle, AlertCircle, Wifi, RefreshCw, Save, ChevronDown, ChevronUp, ExternalLink, Key, Copy, Upload, Trash2, ShieldCheck } from "lucide-react";
+
+const t = (key, fallback) => fallback;
+
+const RESOURCES = [
+  { type: "DiagnosticReport", enabled: true,  lastPublished: "2026-03-23 08:14", count: 1842, errors: 3  },
+  { type: "Observation",      enabled: true,  lastPublished: "2026-03-23 08:14", count: 3688, errors: 3  },
+  { type: "ServiceRequest",   enabled: true,  lastPublished: "2026-03-23 08:14", count: 1842, errors: 0  },
+  { type: "Device",           enabled: true,  lastPublished: "2026-03-22 17:00", count: 0,    errors: 0  },
+  { type: "Organization",     enabled: true,  lastPublished: "2026-03-20 09:30", count: 0,    errors: 0  },
+];
+
+function Tag({ color, children }) {
+  const colors = {
+    green:  { bg: "#defbe6", text: "#0e6027", border: "#a7f0ba" },
+    red:    { bg: "#fff1f1", text: "#a2191f", border: "#ffb3b8" },
+    blue:   { bg: "#edf5ff", text: "#0043ce", border: "#a6c8ff" },
+    gray:   { bg: "#f4f4f4", text: "#525252", border: "#e0e0e0" },
+  };
+  const c = colors[color] || colors.gray;
+  return (
+    <span style={{
+      display: "inline-flex", alignItems: "center", gap: 4,
+      background: c.bg, color: c.text, border: `1px solid ${c.border}`,
+      borderRadius: 2, padding: "2px 8px", fontSize: 12, fontWeight: 500,
+    }}>
+      {children}
+    </span>
+  );
+}
+
+function SectionCard({ title, children }) {
+  return (
+    <div style={{ background: "#fff", border: "1px solid #e0e0e0", borderRadius: 4, padding: "1.25rem 1.5rem", marginBottom: "1rem" }}>
+      <h3 style={{ fontSize: 14, fontWeight: 600, color: "#161616", marginBottom: "1rem", borderBottom: "1px solid #f4f4f4", paddingBottom: "0.5rem" }}>
+        {title}
+      </h3>
+      {children}
+    </div>
+  );
+}
+
+function Field({ label, placeholder, type = "text", helper, value }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#525252" }}>{label}</label>
+      <input
+        readOnly
+        type={type}
+        defaultValue={value || ""}
+        placeholder={placeholder}
+        style={{
+          border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px 12px",
+          fontSize: 14, color: "#161616", background: "#fff", outline: "none",
+          width: "100%", boxSizing: "border-box",
+        }}
+      />
+      {helper && <span style={{ fontSize: 11, color: "#6f6f6f" }}>{helper}</span>}
+    </div>
+  );
+}
+
+function Select({ label, value, options }) {
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#525252" }}>{label}</label>
+      <select defaultValue={value} style={{
+        border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px 12px",
+        fontSize: 14, color: "#161616", background: "#fff", width: "100%",
+      }}>
+        {options.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+      </select>
+    </div>
+  );
+}
+
+function Toggle({ on, onToggle }) {
+  return (
+    <button onClick={onToggle} style={{
+      width: 40, height: 20, borderRadius: 10, border: "none", cursor: "pointer",
+      background: on ? "#0f62fe" : "#8d8d8d", position: "relative", transition: "background 0.2s",
+    }}>
+      <span style={{
+        position: "absolute", top: 2, left: on ? 22 : 2,
+        width: 16, height: 16, borderRadius: 8, background: "#fff", transition: "left 0.2s",
+      }} />
+    </button>
+  );
+}
+
+function Button({ children, primary, ghost, icon: Icon, onClick, small }) {
+  return (
+    <button onClick={onClick} style={{
+      display: "inline-flex", alignItems: "center", gap: 6,
+      padding: small ? "6px 12px" : "10px 16px",
+      background: primary ? "#0f62fe" : ghost ? "transparent" : "#393939",
+      color: primary || !ghost ? "#fff" : "#0f62fe",
+      border: ghost ? "1px solid #0f62fe" : "none",
+      borderRadius: 2, fontSize: 14, fontWeight: 500, cursor: "pointer",
+    }}>
+      {Icon && <Icon size={14} />}
+      {children}
+    </button>
+  );
+}
+
+const SAMPLE_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2a8mXvZ3kPqW5oRtN1
+cFhJ7mYs4Lx9TqD2bK6nE0pA3wVuG8iR5dMcOyBfHlZ2NsXeP4gKtJ1QmU7r
+vCnIoD3aWb6Fc5YhL8xEsT0uK2pR9lMdV4NqOzBgW1eHiS6jXcPfA7mYtR3b
+K9uJ0vL5nEwDqC2xHo8sB4iT1pMfU3aW6Vc7yNrOzBgW1eHiS6jXcPfA7mYt
+R3bK9uJ0vL5nEwDqC2xHo8sB4iT1pMfU3aW6Vc7yNrOzBgW1eHiS6jXcPfA7
+mYtR3bK9uJ0vL5nEwDqC2xHo8sB4iT1pMfU3aW6Vc7yNrOzBgW1eHiQ==
+-----END PUBLIC KEY-----`;
+
+export default function FhirPublicationSettings() {
+  const [authType, setAuthType] = useState("BEARER_TOKEN");
+  const [pubMode, setPubMode]   = useState("SYNCHRONOUS");
+  const [toggles, setToggles]   = useState(Object.fromEntries(RESOURCES.map(r => [r.type, r.enabled])));
+  const [connStatus, setConnStatus] = useState(null);
+  const [saved, setSaved]           = useState(false);
+  const [advOpen, setAdvOpen]       = useState(false);
+
+  // Private Key JWT state
+  const [keyStatus, setKeyStatus]       = useState("NOT_CONFIGURED"); // NOT_CONFIGURED | ACTIVE
+  const [showUploadKey, setShowUploadKey] = useState(false);
+  const [keyMsg, setKeyMsg]             = useState(null); // { type: 'success'|'info'|'error', text }
+  const [keyCopied, setKeyCopied]       = useState(false);
+  const [confirmRemove, setConfirmRemove] = useState(false);
+
+  const handleGenerateKey = () => {
+    setKeyStatus("ACTIVE");
+    setShowUploadKey(false);
+    setKeyMsg({ type: "success", text: "Key pair generated. Copy the public key and register it on the HAPI FHIR server before enabling." });
+    setTimeout(() => setKeyMsg(null), 6000);
+  };
+
+  const handleUploadKey = () => {
+    setKeyStatus("ACTIVE");
+    setShowUploadKey(false);
+    setKeyMsg({ type: "success", text: "Private key uploaded and public key derived successfully." });
+    setTimeout(() => setKeyMsg(null), 6000);
+  };
+
+  const handleCopyKey = () => {
+    setKeyCopied(true);
+    setTimeout(() => setKeyCopied(false), 2500);
+  };
+
+  const handleRemoveKey = () => {
+    setKeyStatus("NOT_CONFIGURED");
+    setConfirmRemove(false);
+    setKeyMsg({ type: "info", text: "Key pair removed. FHIR outbound push has been disabled." });
+    setTimeout(() => setKeyMsg(null), 5000);
+  };
+
+  return (
+    <div style={{ fontFamily: "'IBM Plex Sans', Arial, sans-serif", background: "#f4f4f4", minHeight: "100vh", padding: "1.5rem" }}>
+      {/* Header bar */}
+      <div style={{ background: "#161616", color: "#fff", padding: "8px 1.5rem", margin: "-1.5rem -1.5rem 1.5rem", display: "flex", alignItems: "center", gap: 8 }}>
+        <span style={{ fontSize: 13, color: "#8d8d8d" }}>Admin</span>
+        <span style={{ color: "#525252" }}>/</span>
+        <span style={{ fontSize: 13, color: "#8d8d8d" }}>Integration</span>
+        <span style={{ color: "#525252" }}>/</span>
+        <span style={{ fontSize: 13 }}>FHIR Publication Settings</span>
+      </div>
+
+      <div style={{ maxWidth: 960 }}>
+        {/* Title */}
+        <div style={{ marginBottom: "1.5rem" }}>
+          <h1 style={{ fontSize: 28, fontWeight: 300, color: "#161616", margin: 0 }}>FHIR Publication Settings</h1>
+          <p style={{ fontSize: 14, color: "#525252", marginTop: 4 }}>
+            Configure how OpenELIS publishes lab results to the central FHIR repository for disease surveillance and Superset dashboards.
+          </p>
+        </div>
+
+        {saved && (
+          <div style={{ background: "#defbe6", border: "1px solid #a7f0ba", borderLeft: "4px solid #24a148", padding: "12px 16px", marginBottom: "1rem", display: "flex", alignItems: "center", gap: 8 }}>
+            <CheckCircle size={16} color="#0e6027" />
+            <span style={{ fontSize: 14, color: "#0e6027", fontWeight: 500 }}>Settings saved successfully.</span>
+          </div>
+        )}
+
+        {/* Connection */}
+        <SectionCard title="FHIR Repository Connection">
+          <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr", gap: "1rem", marginBottom: "0.75rem" }}>
+            <Field label={t("label.fhirOutbound.remoteUrl", "FHIR Repository URL")}
+              placeholder="https://hapi.nationallab.pg/fhir"
+              helper="The base URL of your central HAPI FHIR R4 server." />
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 600, color: "#525252", display: "block", marginBottom: 4 }}>
+                {t("label.fhirOutbound.authType", "Authentication Type")}
+              </label>
+              <select value={authType} onChange={e => setAuthType(e.target.value)} style={{
+                border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px 12px", fontSize: 14, width: "100%",
+              }}>
+                <option value="NONE">{t("label.fhirOutbound.authType.none", "None")}</option>
+                <option value="BEARER_TOKEN">{t("label.fhirOutbound.authType.bearer", "Bearer Token")}</option>
+                <option value="BASIC">{t("label.fhirOutbound.authType.basic", "Basic Auth")}</option>
+                <option value="PRIVATE_KEY_JWT">{t("label.fhirOutbound.authType.privateKeyJwt", "Private Key JWT (Signed Assertion)")}</option>
+              </select>
+            </div>
+          </div>
+
+          {/* Bearer / Basic credential field */}
+          {(authType === "BEARER_TOKEN" || authType === "BASIC") && (
+            <div style={{ maxWidth: 480, marginBottom: "0.75rem" }}>
+              <Field label={authType === "BASIC"
+                  ? t("label.fhirOutbound.authUsername", "Username : Password")
+                  : t("label.fhirOutbound.authToken", "Bearer Token")}
+                type="password" placeholder="••••••••"
+                helper="Stored encrypted at rest. Not shown after saving." />
+            </div>
+          )}
+
+          {/* ── Private Key JWT section ── */}
+          {authType === "PRIVATE_KEY_JWT" && (
+            <div style={{ border: "1px solid #c6c6c6", borderRadius: 2, padding: "1rem", background: "#f4f4f4", marginBottom: "0.75rem" }}>
+
+              {/* Key status row */}
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "0.75rem" }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                  <Key size={14} color="#525252" />
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "#161616" }}>
+                    {t("heading.fhirOutbound.keyManagement", "Key Management")}
+                  </span>
+                  {keyStatus === "ACTIVE"
+                    ? <Tag color="green"><ShieldCheck size={10} /> {t("label.fhirOutbound.keyStatus.active", "Active")}</Tag>
+                    : <Tag color="red">{t("label.fhirOutbound.keyStatus.notConfigured", "Not Configured")}</Tag>}
+                </div>
+                {keyStatus === "ACTIVE" && !confirmRemove && (
+                  <button onClick={() => setConfirmRemove(true)} style={{
+                    background: "transparent", border: "1px solid #da1e28", color: "#da1e28",
+                    borderRadius: 2, padding: "4px 10px", fontSize: 12, cursor: "pointer",
+                    display: "flex", alignItems: "center", gap: 4,
+                  }}>
+                    <Trash2 size={11} /> {t("button.fhirOutbound.removeKey", "Remove Key")}
+                  </button>
+                )}
+                {confirmRemove && (
+                  <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                    <span style={{ fontSize: 12, color: "#da1e28" }}>Remove key and disable push?</span>
+                    <button onClick={handleRemoveKey} style={{ background: "#da1e28", color: "#fff", border: "none", borderRadius: 2, padding: "4px 10px", fontSize: 12, cursor: "pointer" }}>Confirm</button>
+                    <button onClick={() => setConfirmRemove(false)} style={{ background: "transparent", border: "1px solid #8d8d8d", color: "#525252", borderRadius: 2, padding: "4px 10px", fontSize: 12, cursor: "pointer" }}>Cancel</button>
+                  </div>
+                )}
+              </div>
+
+              {/* Active key details */}
+              {keyStatus === "ACTIVE" && (
+                <div style={{ display: "flex", gap: "2rem", fontSize: 12, color: "#525252", marginBottom: "0.75rem", background: "#fff", border: "1px solid #e0e0e0", borderRadius: 2, padding: "8px 12px" }}>
+                  <span><strong>{t("label.fhirOutbound.keyAlgorithm", "Algorithm")}:</strong> RSA-2048</span>
+                  <span><strong>{t("label.fhirOutbound.keyFingerprint", "Fingerprint")}:</strong> SHA256:a3b4c5d6e7f8a9b0</span>
+                  <span><strong>{t("label.fhirOutbound.keyCreatedAt", "Generated")}:</strong> 2026-03-24 09:00</span>
+                </div>
+              )}
+
+              {/* Key feedback notification */}
+              {keyMsg && (
+                <div style={{
+                  marginBottom: "0.75rem", padding: "8px 12px", borderRadius: 2, fontSize: 13,
+                  display: "flex", alignItems: "center", gap: 8,
+                  background: keyMsg.type === "success" ? "#defbe6" : keyMsg.type === "info" ? "#edf5ff" : "#fff1f1",
+                  border: `1px solid ${keyMsg.type === "success" ? "#a7f0ba" : keyMsg.type === "info" ? "#a6c8ff" : "#ffb3b8"}`,
+                  color: keyMsg.type === "success" ? "#0e6027" : keyMsg.type === "info" ? "#0043ce" : "#a2191f",
+                }}>
+                  <CheckCircle size={14} />
+                  {keyMsg.text}
+                </div>
+              )}
+
+              {/* Generate + Upload buttons */}
+              <div style={{ display: "flex", gap: 8, marginBottom: "0.75rem" }}>
+                <button onClick={handleGenerateKey} style={{
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                  background: "#0f62fe", color: "#fff", border: "none",
+                  borderRadius: 2, padding: "7px 14px", fontSize: 13, cursor: "pointer",
+                }}>
+                  <Key size={13} /> {t("button.fhirOutbound.generateKeyPair", "Generate New Key Pair")}
+                </button>
+                <button onClick={() => setShowUploadKey(p => !p)} style={{
+                  display: "inline-flex", alignItems: "center", gap: 6,
+                  background: "transparent", color: "#0f62fe", border: "1px solid #0f62fe",
+                  borderRadius: 2, padding: "7px 14px", fontSize: 13, cursor: "pointer",
+                }}>
+                  <Upload size={13} /> {t("button.fhirOutbound.uploadKey", "Upload Private Key (PEM)")}
+                  {showUploadKey ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+                </button>
+              </div>
+
+              {/* Upload accordion */}
+              {showUploadKey && (
+                <div style={{ background: "#fff", border: "1px solid #e0e0e0", borderRadius: 2, padding: "0.75rem", marginBottom: "0.75rem" }}>
+                  <div style={{ fontSize: 12, fontWeight: 600, color: "#525252", marginBottom: 4 }}>
+                    Private Key (PKCS8 or PKCS1 PEM)
+                  </div>
+                  <textarea rows={5} placeholder={"-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"} style={{
+                    width: "100%", fontFamily: "monospace", fontSize: 12,
+                    border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px",
+                    boxSizing: "border-box", resize: "vertical", color: "#161616",
+                  }} />
+                  <div style={{ marginTop: "0.5rem" }}>
+                    <button onClick={handleUploadKey} style={{
+                      background: "#393939", color: "#fff", border: "none",
+                      borderRadius: 2, padding: "6px 14px", fontSize: 13, cursor: "pointer",
+                    }}>
+                      {t("button.fhirOutbound.uploadKey", "Upload Key")}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {/* Public key display */}
+              {keyStatus === "ACTIVE" && (
+                <div style={{ marginBottom: "0.75rem" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                    <label style={{ fontSize: 12, fontWeight: 600, color: "#525252" }}>
+                      {t("label.fhirOutbound.publicKeyPem", "Public Key (PEM)")} — register this on the HAPI FHIR server
+                    </label>
+                    <button onClick={handleCopyKey} style={{
+                      display: "inline-flex", alignItems: "center", gap: 5,
+                      background: "transparent", color: keyCopied ? "#24a148" : "#0f62fe",
+                      border: `1px solid ${keyCopied ? "#24a148" : "#0f62fe"}`,
+                      borderRadius: 2, padding: "4px 10px", fontSize: 12, cursor: "pointer",
+                    }}>
+                      <Copy size={11} />
+                      {keyCopied ? t("message.fhirOutbound.keyCopied", "Copied!") : t("button.fhirOutbound.copyPublicKey", "Copy Public Key")}
+                    </button>
+                  </div>
+                  <textarea readOnly rows={5} value={SAMPLE_PUBLIC_KEY} style={{
+                    width: "100%", fontFamily: "monospace", fontSize: 11,
+                    border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px",
+                    background: "#f4f4f4", resize: "none", boxSizing: "border-box", color: "#161616",
+                  }} />
+                </div>
+              )}
+
+              {/* JWT configuration fields */}
+              <div style={{ display: "grid", gridTemplateColumns: "2fr 2fr 1fr", gap: "0.75rem", marginBottom: "0.75rem" }}>
+                <Field label={t("label.fhirOutbound.jwtIssuerId", "Issuer ID (iss / sub claim)")}
+                  placeholder="png-site-portmoresby-lab"
+                  helper="Must match the HAPI FHIR interceptor trusted-issuers table." />
+                <Field label={t("label.fhirOutbound.jwtAudience", "JWT Audience (aud claim)")}
+                  placeholder="https://hapi.nationallab.pg/fhir"
+                  helper="Defaults to Remote FHIR Base URL if left blank." />
+                <Field label={t("label.fhirOutbound.jwtExpiry", "Token Expiry (minutes)")}
+                  value="10" helper="1–60 min. Default: 10." />
+              </div>
+
+              {/* Setup instruction callout */}
+              <div style={{ background: "#edf5ff", border: "1px solid #a6c8ff", borderRadius: 2, padding: "10px 14px", fontSize: 13, color: "#0043ce", display: "flex", gap: 8 }}>
+                <ShieldCheck size={14} style={{ flexShrink: 0, marginTop: 1 }} />
+                <span>
+                  <strong>HAPI FHIR server setup required:</strong> Copy the public key above and register it in the HAPI FHIR server's <code style={{ background: "#dde1ff", padding: "1px 4px", borderRadius: 2 }}>fhir_trusted_issuers</code> table using the Issuer ID as the lookup key. See FRS Appendix B for full configuration instructions.
+                </span>
+              </div>
+            </div>
+          )}
+
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <Button ghost icon={Wifi} onClick={() => setConnStatus("success")}>
+              {t("button.fhirOutbound.testConnection", "Test Connection")}
+            </Button>
+            {connStatus === "success" && (
+              <div style={{ display: "flex", alignItems: "center", gap: 6, background: "#defbe6", border: "1px solid #a7f0ba", borderRadius: 2, padding: "6px 12px" }}>
+                <CheckCircle size={14} color="#24a148" />
+                <span style={{ fontSize: 13, color: "#0e6027" }}>
+                  {t("message.fhirOutbound.testSuccess", "Connection successful — FHIR R4 CapabilityStatement received")}
+                </span>
+              </div>
+            )}
+          </div>
+        </SectionCard>
+
+        {/* Publication Mode */}
+        <SectionCard title="Publication Mode">
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
+            <div>
+              <label style={{ fontSize: 12, fontWeight: 600, color: "#525252", display: "block", marginBottom: 4 }}>Publication Mode</label>
+              <select value={pubMode} onChange={e => setPubMode(e.target.value)} style={{
+                border: "1px solid #8d8d8d", borderRadius: 2, padding: "8px 12px", fontSize: 14, width: "100%",
+              }}>
+                <option value="SYNCHRONOUS">Synchronous (on result validation)</option>
+                <option value="ASYNC_BATCH">Batch (scheduled interval)</option>
+              </select>
+            </div>
+            {pubMode === "ASYNC_BATCH" && (
+              <Field label="Batch Interval (minutes)" placeholder="15" helper="1–1440 minutes" />
+            )}
+          </div>
+          {/* Retry Policy accordion */}
+          <div style={{ marginTop: "1rem", border: "1px solid #e0e0e0", borderRadius: 2 }}>
+            <button onClick={() => setAdvOpen(p => !p)} style={{
+              width: "100%", background: "#f4f4f4", border: "none", padding: "10px 16px",
+              display: "flex", justifyContent: "space-between", alignItems: "center",
+              cursor: "pointer", fontSize: 13, fontWeight: 500, color: "#525252",
+            }}>
+              Advanced: Retry Policy
+              {advOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+            </button>
+            {advOpen && (
+              <div style={{ padding: "1rem", display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1rem" }}>
+                <Field label="Retry Attempts" value="3" helper="0–10 retries on publish failure" />
+                <Field label="Retry Interval (minutes)" value="5" helper="1–60 minutes between retries" />
+              </div>
+            )}
+          </div>
+        </SectionCard>
+
+        {/* Resource Status Table */}
+        <SectionCard title="Resource Publication Status">
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14 }}>
+            <thead>
+              <tr style={{ background: "#f4f4f4" }}>
+                {["Resource Type", "Publish", "Last Published", "Records (24h)", "Errors (24h)"].map(h => (
+                  <th key={h} style={{ padding: "8px 12px", textAlign: "left", fontWeight: 600, color: "#525252", fontSize: 12, borderBottom: "1px solid #e0e0e0" }}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {RESOURCES.map((r, i) => (
+                <tr key={r.type} style={{ background: i % 2 === 0 ? "#fff" : "#f4f4f4" }}>
+                  <td style={{ padding: "10px 12px", fontWeight: 500 }}>{r.type}</td>
+                  <td style={{ padding: "10px 12px" }}>
+                    <Toggle on={toggles[r.type]} onToggle={() => setToggles(p => ({ ...p, [r.type]: !p[r.type] }))} />
+                  </td>
+                  <td style={{ padding: "10px 12px", color: "#525252", fontSize: 13 }}>{r.lastPublished}</td>
+                  <td style={{ padding: "10px 12px" }}>{r.count.toLocaleString()}</td>
+                  <td style={{ padding: "10px 12px" }}>
+                    {r.errors > 0
+                      ? <Tag color="red"><AlertCircle size={10} /> {r.errors} errors</Tag>
+                      : <Tag color="green"><CheckCircle size={10} /> OK</Tag>}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div style={{ marginTop: "0.75rem" }}>
+            <Button ghost icon={RefreshCw} small>Publish Now</Button>
+          </div>
+        </SectionCard>
+
+        {/* Dashboard Links */}
+        <SectionCard title="Dashboard Links">
+          <p style={{ fontSize: 13, color: "#525252", marginBottom: "1rem" }}>
+            The Superset URL will appear as a <strong>"Dashboards"</strong> entry in the OpenELIS side navigation for users with the <code style={{ background: "#f4f4f4", padding: "1px 4px", borderRadius: 2 }}>dashboard.navigate</code> permission.
+          </p>
+          <div style={{ display: "grid", gridTemplateColumns: "1fr", gap: "1rem", maxWidth: 600 }}>
+            <Field label="Superset Dashboard URL" placeholder="https://superset.your-program.org"
+              helper="Opens in a new tab from the OpenELIS navigation menu." />
+            <Field label="DHIS2 FHIR Push URL" placeholder="https://dhis2.ministry.gov/api/fhir/R4"
+              helper="External DHIS2 instance. Receives FHIR bundle on each batch run." />
+          </div>
+          {/* Nav preview */}
+          <div style={{ marginTop: "1rem", background: "#f4f4f4", border: "1px solid #e0e0e0", borderRadius: 2, padding: "0.75rem 1rem", display: "inline-flex", alignItems: "center", gap: 8 }}>
+            <ExternalLink size={13} color="#0f62fe" />
+            <span style={{ fontSize: 13, color: "#0f62fe", fontWeight: 500 }}>Dashboards</span>
+            <span style={{ fontSize: 12, color: "#6f6f6f" }}>— will appear in side nav under Reports</span>
+          </div>
+        </SectionCard>
+
+        {/* Save Bar */}
+        <div style={{ display: "flex", gap: 8, paddingBottom: "2rem" }}>
+          <Button primary icon={Save} onClick={() => { setSaved(true); setTimeout(() => setSaved(false), 3000); }}>Save Settings</Button>
+          <Button ghost>Cancel</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/designs/vector-surveillance/vector-surveillance-reporting-fhir-considerations.md
+++ b/designs/vector-surveillance/vector-surveillance-reporting-fhir-considerations.md
@@ -1,0 +1,189 @@
+# V-04 Vector Surveillance Reporting — FHIR Considerations
+**For review by:** Piotr  
+**Related spec:** V-04 FRS (OGC-TBD) — Vector Surveillance Reporting  
+**Related story:** [OGC-527 Epic](https://uwdigi.atlassian.net/browse/OGC-527)  
+**Last updated:** 2026-04-20  
+**Status:** Draft — awaiting architectural review
+
+---
+
+## 1. Scope and Intent
+
+The V-04 pipeline pushes OpenELIS vector surveillance data to HAPI FHIR R4, which the Google Open Health Stack (OHS) SQL-on-FHIR ETL then flattens into Postgres analytics views for Superset to query. The current implementation is **OpenELIS-only** — no multi-LIS federation is planned. FHIR is functioning as a structured ETL transport rather than an interoperability layer.
+
+That said, the intent is to align extension design with the **WHO Vector Surveillance Digital Adaptation Kit (DAK) / FHIR Implementation Guide**, currently in early development under the SMART Guidelines programme. This doc should be revisited when that IG reaches ballot status. All custom extension URLs and CodeSystem URIs are namespaced under `https://openelis-global.org/fhir/` so they can be migrated or aliased when WHO guidance is finalized.
+
+---
+
+## 2. FHIR R4 Coverage Assessment
+
+FHIR R4 was designed for clinical patient data. Vector surveillance spans environmental monitoring, entomological field data, and public health — none of which are first-class FHIR domains. Coverage of V-04 data points breaks down as follows:
+
+| Data category | Native R4 coverage | Gap description |
+|---|---|---|
+| Pathogen test results | ~70% | `pool_size` has no standard element (see §3.1) |
+| Species identification | ~50% | Taxonomy CodeSystem, lifecycle stage, sex, ID method all need extensions |
+| Collection lot / trap deployment | ~40% | Trap type, GPS on trap, trap-nights duration, pooling strategy need extensions |
+| Aggregated indices (MIR, catch rate) | 0% | Derived values — live entirely in OHS Postgres, no FHIR equivalent |
+| Environmental conditions | ~20% | Temperature, humidity, rainfall have no Specimen home; need Observation extensions |
+
+**Overall: approximately 45–50% of V-04 data points have direct or close FHIR R4 mappings without extensions.**
+
+The OHS ETL bears the weight of the extension-heavy fields. If extension definitions drift from what the ETL expects, views silently return NULLs. Formal StructureDefinition profiles mitigate this risk (see §5).
+
+---
+
+## 3. Issues in the Current FRS Mapping
+
+### 3.1 `specimenCount` and `poolFlag` mapped to `Specimen.note`
+
+The existing FRS maps `specimenCount` to `Specimen.note[0].text` as the string `"specimenCount:{n}"` and `poolFlag` to `Specimen.note[1].text`. This is fragile:
+
+- `Specimen.note` is a free-text annotation field. The OHS ETL would need a regex or string parse to extract the value — not a reliable extraction path.
+- Array position (`note[0]`, `note[1]`) is not guaranteed if other code paths add notes.
+- `specimenCount` is the denominator in the MIR formula. If this extraction fails, every MIR row in `vector_mir_weekly` silently returns NULL.
+
+**Recommended fix:** Replace both with formal extensions (see §4 below).
+
+### 3.2 Trap-nights not captured
+
+The V-04 analytics require `trap_nights` (duration of deployment) for the `vector_trap_catch_daily` catch rate view. The current FRS maps `collectionDate` to `Specimen.collection.collectedDateTime` but does not map the trap deployment start date. There is no `Specimen.collection.deployedDateTime` element in R4.
+
+The `vector_trap_catch_daily` view therefore cannot compute catch rate (`specimens ÷ trap-nights`) from the FHIR data as currently specified. Either:
+- **Option A:** Add a `deployedDateTime` extension to the Specimen push and update the OHS view to use `collected - deployed` as trap-nights.
+- **Option B:** Compute trap-nights in OpenELIS at collection time, push as a decimal extension directly.
+- **Option C:** Source trap-nights from the OpenELIS database directly in the OHS ETL (bypassing FHIR for this field).
+
+Option A is preferred for consistency. Option C is a pragmatic fallback if Piotr determines the ETL can query the OpenELIS DB directly.
+
+### 3.3 GPS coordinates not captured
+
+Trap GPS latitude/longitude (set on the CollectionLot in V-02) are not in the FRS FHIR mapping. The `vector_trap_catch_daily` and `vector_collection_lots` views don't include coordinates, so Superset cannot render a map chart or do geographic filtering. This is a V-04 gap unless added now.
+
+The closest R4 path would be `Specimen.collection.bodySite` (designed for anatomical site, not geographic coordinates — a semantic mismatch). A dedicated extension is cleaner.
+
+### 3.4 Species taxonomy CodeSystem coverage
+
+The FRS uses `https://openelis-global.org/vector-species` as the coding system for species. This is fine for internal use, but SNOMED CT does have codes for some of the V-01 seed species (e.g., Aedes aegypti = SNOMED 60904002). If WHO IG alignment is the goal, the Observation should carry both the OpenELIS internal code and the SNOMED CT code as a second `coding[]` entry where SNOMED coverage exists.
+
+Approximately 18 of the 40 V-01 seed species have SNOMED CT codes. The remaining 22 (mostly subspecies-level entries) would remain OpenELIS-only codes. Dual coding costs nothing at push time and improves alignment.
+
+### 3.5 Pool deconvolution parent chain
+
+The current mapping pushes a deconvolution outcome as a `Task` resource (FR-V04-FHIR-004). This captures the aggregate outcome (positive count, outcome percentage) but does not link individual positive child specimens back to their parent pool via `Specimen.parent`. Without this chain, the OHS ETL cannot trace which specific individual was positive — it can only know the pool was positive.
+
+For MIR calculation this is acceptable (MIR uses pool-level positive counts). For any future individual-level epidemiological analysis it would be a gap. Recommend flagging this as a known limitation in the FRS rather than solving it now.
+
+---
+
+## 4. Recommended Extensions
+
+All extensions should be defined as FHIR StructureDefinitions published at `https://openelis-global.org/fhir/StructureDefinition/`. This allows the OHS ETL to reference them by URL for reliable extraction.
+
+### 4.1 Specimen extensions (CollectionLot)
+
+| Extension name | URL suffix | Type | Replaces |
+|---|---|---|---|
+| `poolSize` | `vector-pool-size` | `integer` | `Specimen.note[0]` hack |
+| `poolFlag` | `vector-pool-flag` | `boolean` | `Specimen.note[1]` hack |
+| `poolingStrategy` | `vector-pooling-strategy` | `code` (INDIVIDUAL / POOL_FIXED / POOL_VARIABLE) | Not currently mapped |
+| `trapNights` | `vector-trap-nights` | `decimal` | Not currently mapped |
+| `deployedDateTime` | `vector-deployed-date-time` | `dateTime` | Not currently mapped |
+| `trapGpsLatitude` | `vector-trap-gps-latitude` | `decimal` | Not currently mapped |
+| `trapGpsLongitude` | `vector-trap-gps-longitude` | `decimal` | Not currently mapped |
+
+### 4.2 Observation extensions (VectorSpecimenIdentification)
+
+| Extension name | URL suffix | Type | Notes |
+|---|---|---|---|
+| `lifecycleStage` | `vector-lifecycle-stage` | `code` (LARVA / PUPA / ADULT) | Not currently mapped |
+| `sex` | `vector-sex` | `code` (MALE / FEMALE / UNKNOWN) | Not currently mapped |
+| `identificationMethod` | `vector-identification-method` | `code` (MORPHOLOGICAL / MOLECULAR / BOTH) | Currently mapped to `Observation.method` — OK, but extension gives cleaner OHS path |
+
+### 4.3 DiagnosticReport extensions (Pathogen result)
+
+| Extension name | URL suffix | Type | Notes |
+|---|---|---|---|
+| `poolPositive` | `vector-pool-positive` | `boolean` | Already in FRS as custom extension — just needs formal StructureDefinition |
+| `poolSize` | `vector-pool-size` | `integer` | Needed on DiagnosticReport as well as Specimen for MIR view |
+
+---
+
+## 5. Custom CodeSystems Required
+
+These should be defined as FHIR `CodeSystem` resources and published alongside the extensions:
+
+| CodeSystem name | URI | Values |
+|---|---|---|
+| Vector Organism Group | `https://openelis-global.org/fhir/CodeSystem/vector-organism-group` | MOSQUITO, TICK, RODENT, OTHER_ARTHROPOD, OTHER_ANIMAL |
+| Vector Trap Type | `https://openelis-global.org/fhir/CodeSystem/vector-trap-type` | BG_SENTINEL, CDC_LIGHT_TRAP, GRAVID_TRAP, OVITRAP, STICKY_TRAP, etc. (mirrors V-01 seed) |
+| Vector Species | `https://openelis-global.org/fhir/CodeSystem/vector-species` | Full V-01 seed taxonomy (~40 entries); dual-coded with SNOMED CT where available |
+| Pooling Strategy | `https://openelis-global.org/fhir/CodeSystem/vector-pooling-strategy` | INDIVIDUAL, POOL_FIXED, POOL_VARIABLE |
+| Identification Method | `https://openelis-global.org/fhir/CodeSystem/vector-identification-method` | MORPHOLOGICAL, MOLECULAR, BOTH |
+
+---
+
+## 6. OHS ETL Implications
+
+The OHS SQL-on-FHIR engine generates the analytics views by running SQL against HAPI FHIR's internal Postgres tables. Extension values are stored in HAPI as JSON within a `myValueJson` column on the extension table, keyed by URL. The ETL SQL for each view needs a JOIN against the extension table for each custom extension.
+
+Example extraction pattern for `poolSize`:
+```sql
+-- Extension value extraction in HAPI FHIR JPA schema
+LEFT JOIN hfj_res_link ext_pool_size
+  ON ext_pool_size.src_resource_id = s.res_id
+  AND ext_pool_size.src_path = 'Specimen.extension'
+  AND ext_pool_size.target_resource_url =
+      'https://openelis-global.org/fhir/StructureDefinition/vector-pool-size'
+```
+
+The current FRS OHS view SQL uses column names like `s.pool_size` which implies the ETL abstracts this — verify with Piotr whether the OHS config layer handles this or whether raw HAPI JPA SQL is being used. If raw JPA, all views in §8 of the FRS need the extension JOIN pattern added for each unmapped field.
+
+---
+
+## 7. WHO Vector Surveillance IG Alignment
+
+The WHO SMART Guidelines programme includes a planned Digital Adaptation Kit (DAK) for Vector Surveillance, which will eventually produce a FHIR Implementation Guide. As of early 2025 this was in early development stages.
+
+**Alignment approach for V-04:**
+
+1. Namespace all extensions and CodeSystems under `https://openelis-global.org/fhir/` now. When the WHO IG is published, migration is a namespace swap plus any semantic reconciliation — no data model changes.
+2. Use SNOMED CT dual-coding on `Observation.valueCodeableConcept` for species where codes exist (approximately 18 of 40 V-01 seed species).
+3. Monitor WHO IG progress. When it reaches ballot, schedule a sprint to align OpenELIS StructureDefinitions with the IG profiles. This is an addendum to V-04, not a blocker.
+4. Consider publishing the OpenELIS vector surveillance extensions as a lightweight public IG on `https://openelis-global.org/fhir/` — this costs little effort at definition time and allows other OpenELIS deployments to reuse the profiles.
+
+The V-04 FRS should be updated to add a conformance note: *"Extension definitions SHOULD align with the WHO Vector Surveillance FHIR IG when published. Until that IG is available, this FRS serves as the normative extension definition for OpenELIS vector surveillance FHIR resources."*
+
+---
+
+## 8. Questions for Piotr
+
+The following decisions require architectural input before the V-04 FHIR implementation sprint begins:
+
+1. **OHS ETL implementation:** Is the OHS ETL using the Google OHS `sql-on-fhir` library (which has its own extraction DSL) or raw SQL against the HAPI JPA Postgres schema? This determines whether extension extraction is configured declaratively or written as custom JOINs. The current FRS §8 view SQL assumes direct Postgres access — confirm this is correct.
+
+2. **Trap-nights gap (§3.2):** Which option is preferred — `deployedDateTime` extension (Option A), push computed value directly (Option B), or source from OpenELIS DB in ETL (Option C)?
+
+3. **`Specimen.note` hack (§3.1):** Confirm whether to replace with formal extensions before implementation begins. Changing this post-deployment requires a data migration of existing HAPI Specimen resources.
+
+4. **Lifecycle stage and sex (§3.2, §4.2):** These are V-01/V-03 data points not currently pushed. Should they be added to the Observation push in V-04, or deferred to a future spec?
+
+5. **StructureDefinition publication:** Should OpenELIS formally publish the extension StructureDefinitions as a FHIR IG, or keep them as internal definitions documented in this spec? Publication is low-effort and enables WHO IG alignment later.
+
+6. **SNOMED dual-coding (§5):** Approved as an approach? If yes, a mapping table of V-01 species → SNOMED codes is needed. I can draft this as part of the V-04 implementation notes.
+
+7. **Pool deconvolution chain (§3.5):** Confirmed acceptable to leave individual specimen → pool parent linkage as a known gap for V-04?
+
+---
+
+## 9. Summary of FRS Changes Needed
+
+Once Piotr has reviewed, the V-04 FRS (§6.2 and §7) should be updated to:
+
+- Replace the `Specimen.note` mappings for `specimenCount` and `poolFlag` with formal extension paths (§3.1)
+- Add `deployedDateTime`, `trapNights`, `trapGpsLatitude`, `trapGpsLongitude` to the §7.1 mapping table (§3.2, §3.3)
+- Add `lifecycleStage`, `sex` to the §7.2 mapping table if approved (§4.2)
+- Add `poolSize` extension to the §7.3 DiagnosticReport mapping (§4.3)
+- Add a WHO IG alignment conformance note to §7 (§7 above)
+- Add extension StructureDefinition URLs to the §8 OHS view SQL for custom fields
+- Add a "Known FHIR Limitations" subsection noting pool deconvolution chain gap and aggregated index gap

--- a/designs/vector-surveillance/vector-surveillance-reporting.html
+++ b/designs/vector-surveillance/vector-surveillance-reporting.html
@@ -401,9 +401,9 @@
           <!-- 2×2 charts -->
           <div class="chart-grid">
 
-            <!-- 1: Collection density trend (renamed from Trap Catch Rate per V-04 v1.1; trap-type stratification deferred to §17.2) -->
+            <!-- 1: Trap catch trend -->
             <div class="chart-tile">
-              <p class="chart-title">Collection Density — Trend (organisms per collection event)</p>
+              <p class="chart-title">Trap Catch Rate — Trend (specimens / trap-night)</p>
               <svg width="100%" height="120" viewBox="0 0 400 120" preserveAspectRatio="none">
                 <line x1="0" y1="20"  x2="400" y2="20"  stroke="#e0e0e0" stroke-width="1"/>
                 <line x1="0" y1="55"  x2="400" y2="55"  stroke="#e0e0e0" stroke-width="1"/>
@@ -431,7 +431,7 @@
                 <span class="legend-item"><span class="legend-dot" style="background:#0f62fe"></span>BPP-01</span>
                 <span class="legend-item"><span class="legend-dot" style="background:#007d79;border-radius:0"></span>BPP-02</span>
               </div>
-              <p class="chart-source">Superset line chart · vector_collection_density_daily</p>
+              <p class="chart-source">Superset line chart · vector_trap_catch_daily</p>
             </div>
 
             <!-- 2: Species distribution donut -->
@@ -473,25 +473,11 @@
               <p class="chart-source">Superset donut · vector_specimen_ids</p>
             </div>
 
-            <!-- 3: Infection Rate heatmap (V-04 v1.3 — two metrics, toggleable, with resolution diagnostic) -->
+            <!-- 3: MIR heatmap -->
             <div class="chart-tile">
-              <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;gap:12px;">
-                <p class="chart-title" style="margin-bottom:0;">Infection Rate × Species (per 1,000 organisms)</p>
-                <!-- Carbon ContentSwitcher pattern — toggle between two metrics -->
-                <div role="tablist" style="display:inline-flex;border:1px solid #c6c6c6;border-radius:0;font-size:11px;font-weight:500;line-height:1;">
-                  <button id="mir-tab-observed" role="tab" aria-selected="true"
-                          style="padding:6px 10px;background:#161616;color:#fff;border:none;cursor:pointer;">Observed (default)</button>
-                  <button id="mir-tab-classic" role="tab" aria-selected="false"
-                          style="padding:6px 10px;background:#fff;color:#161616;border:none;border-left:1px solid #c6c6c6;cursor:pointer;">Classical MIR</button>
-                </div>
-              </div>
+              <p class="chart-title">Minimum Infection Rate × Species (per 1,000 specimens)</p>
               <table class="heatmap-table" id="mir-table"><!-- populated by JS --></table>
-              <!-- Partial resolution warning glyph — surfaces when positive_resolution_pct < 100 (per FR-V04 / Item 5) -->
-              <div id="mir-resolution-warning" style="display:flex;align-items:center;gap:6px;font-size:11px;color:#a67f00;margin-top:6px;">
-                <span style="display:inline-block;width:14px;height:14px;background:#f1c21b;border-radius:50%;color:#161616;font-weight:700;text-align:center;line-height:14px;font-size:10px;">!</span>
-                <span>Partial resolution: 67% of positive pools deconvoluted this period. Observed metric uses classical fallback for the remainder.</span>
-              </div>
-              <p class="chart-source">Superset heatmap · vector_mir_weekly &nbsp;·&nbsp; <strong>Observed</strong>: exact descendant positive count for resolved pools, classical fallback (1 per pool) when unresolved &nbsp;·&nbsp; <strong>Classical</strong>: (positive pools ÷ total organisms) × 1,000 &nbsp;·&nbsp; CONFIRMED results only · QC excluded</p>
+              <p class="chart-source">Superset table/heatmap · vector_mir_weekly &nbsp;·&nbsp; MIR = (positive pools ÷ total specimens) × 1,000 &nbsp;·&nbsp; CONFIRMED results only</p>
             </div>
 
             <!-- 4: Pathogen positivity -->
@@ -556,87 +542,6 @@
             </div>
 
           </div><!-- /chart-grid -->
-
-          <!-- ═══ Quality Control section (V-04 v1.2 — Dashboard #7) ═══ -->
-          <!-- Visually separated from surveillance charts to avoid implying QC samples flow into MIR/density -->
-          <div style="border-top:8px solid #f4f4f4;padding:18px 0 6px 0;margin-top:18px;">
-            <div style="display:flex;align-items:center;gap:8px;padding:0 4px 12px 4px;">
-              <span style="display:inline-block;width:10px;height:10px;background:#0f62fe;border-radius:50%;"></span>
-              <span style="font-size:13px;font-weight:600;color:#161616;letter-spacing:0.16px;text-transform:uppercase;">Quality Control</span>
-              <span style="font-size:11px;color:#525252;">QC samples are excluded from surveillance aggregates above (per BR-V04-008).</span>
-            </div>
-
-            <div class="chart-tile">
-              <p class="chart-title">QC Pass Rate (per QA event type · last 8 weeks)</p>
-
-              <!-- 95% reference line + bars per QA event type, stacked by site -->
-              <div style="position:relative;padding:8px 0 22px 0;">
-
-                <!-- 95% threshold reference line annotation -->
-                <div style="position:absolute;top:6px;right:0;font-size:10px;color:#525252;">
-                  Threshold: <strong style="color:#198038;">≥ 95%</strong>
-                </div>
-
-                <div class="pos-block" style="margin-top:14px;">
-                  <div class="pos-block-label">Positive Control (expected POS)</div>
-                  <div class="pos-bars">
-                    <div class="pos-bar-col"><div class="pos-bar-outer">
-                      <div class="pos-bar-fill" style="width:96%;background:#198038"></div>
-                      <span class="pos-bar-val on-color">96%</span>
-                    </div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer">
-                      <div class="pos-bar-fill" style="width:100%;background:#198038"></div>
-                      <span class="pos-bar-val on-color">100%</span>
-                    </div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer">
-                      <div class="pos-bar-fill" style="width:92%;background:#f1c21b"></div>
-                      <span class="pos-bar-val">92% ⚠</span>
-                    </div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer">
-                      <div class="pos-bar-fill" style="width:100%;background:#198038"></div>
-                      <span class="pos-bar-val on-color">100%</span>
-                    </div></div>
-                  </div>
-                  <div class="pos-week-labels">
-                    <span class="pos-week-label">W13</span><span class="pos-week-label">W14</span>
-                    <span class="pos-week-label">W15 ⚠</span><span class="pos-week-label">W16</span>
-                  </div>
-                </div>
-
-                <div class="pos-block">
-                  <div class="pos-block-label">Negative Control (expected NEG)</div>
-                  <div class="pos-bars">
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                  </div>
-                  <div class="pos-week-labels">
-                    <span class="pos-week-label">W13</span><span class="pos-week-label">W14</span>
-                    <span class="pos-week-label">W15</span><span class="pos-week-label">W16</span>
-                  </div>
-                </div>
-
-                <div class="pos-block" style="margin-bottom:0">
-                  <div class="pos-block-label">Blank (expected NEG)</div>
-                  <div class="pos-bars">
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:88%;background:#da1e28"></div><span class="pos-bar-val on-color">88% ⚠</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                    <div class="pos-bar-col"><div class="pos-bar-outer"><div class="pos-bar-fill" style="width:100%;background:#198038"></div><span class="pos-bar-val on-color">100%</span></div></div>
-                  </div>
-                  <div class="pos-week-labels">
-                    <span class="pos-week-label">W13</span><span class="pos-week-label">W14 ⚠</span>
-                    <span class="pos-week-label">W15</span><span class="pos-week-label">W16</span>
-                  </div>
-                </div>
-
-              </div>
-              <p class="chart-source">Superset bar chart · vector_qc_monitoring &nbsp;·&nbsp; pass = result matches expectation (POS for Positive Control, NEG for Negative Control / Blank); Duplicate concordance computed downstream</p>
-            </div>
-          </div>
-          <!-- ═══ /Quality Control section ═══ -->
-
         </div><!-- /iframe-sim -->
       </div><!-- /superset-wrap -->
 
@@ -660,49 +565,31 @@
 const SITE_DATA = {
   all: {
     kpi: [
-      { label: 'Total Samples',         value: '312',   sub: '↑ 18 this week',        alert: false },
-      { label: 'Total Organisms',       value: '4,820', sub: '↑ 240 this week',       alert: false },
+      { label: 'Total Collection Lots', value: '312',   sub: '↑ 18 this week',        alert: false },
+      { label: 'Total Specimens',       value: '4,820', sub: '↑ 240 this week',       alert: false },
       { label: 'Active Sites',          value: '5',     sub: 'of 7 reporting',        alert: false, neutral: true },
       { label: 'Highest MIR (W16)',     value: '12.4',  sub: 'BPP-01 · Ae. aegypti', alert: true  },
     ],
-    // V-04 v1.3 — two metrics, both per-thousand-organisms.
-    // observed = exact descendant positive count when deconvolution is COMPLETE; classical fallback otherwise (1 per positive pool).
-    // classic  = (positive pools / total organisms) × 1000 — every positive pool counted as 1.
-    mirObserved: [
-      { species: 'Ae. aegypti',          vals: [2.1, 4.8, 9.6, 14.2] },
-      { species: 'Cx. quinquefasciatus', vals: [0,   1.2, 2.0,  3.1] },
-      { species: 'An. barbirostris',     vals: [0,   0,   0.8,  1.5] },
-    ],
-    mirClassic: [
+    mir: [
       { species: 'Ae. aegypti',          vals: [2.1, 4.8, 8.3, 12.4] },
       { species: 'Cx. quinquefasciatus', vals: [0,   1.2, 2.0,  3.1] },
       { species: 'An. barbirostris',     vals: [0,   0,   0.8,  1.5] },
     ],
-    positiveResolutionPct: 67,  // % of positive pools deconvoluted in this period
   },
   'BPP-01': {
     kpi: [
-      { label: 'Total Samples',         value: '87',    sub: '↑ 6 this week',          alert: false },
-      { label: 'Total Organisms',       value: '1,340', sub: '↑ 80 this week',         alert: false },
+      { label: 'Total Collection Lots', value: '87',    sub: '↑ 6 this week',          alert: false },
+      { label: 'Total Specimens',       value: '1,340', sub: '↑ 80 this week',         alert: false },
       { label: 'Active Sites',          value: '1',     sub: 'Bojongsoang',            alert: false, neutral: true },
       { label: 'Highest MIR (W16)',     value: '12.4',  sub: 'Ae. aegypti · NS1',      alert: true  },
     ],
-    mirObserved: [
-      { species: 'Ae. aegypti',          vals: [3.1, 6.2, 11.4, 14.2] },
-      { species: 'Cx. quinquefasciatus', vals: [0,   0.8,  1.2,  2.0] },
-      { species: 'An. barbirostris',     vals: [0,   0,    0,    0.5] },
-    ],
-    mirClassic: [
+    mir: [
       { species: 'Ae. aegypti',          vals: [3.1, 6.2,  9.8, 12.4] },
       { species: 'Cx. quinquefasciatus', vals: [0,   0.8,  1.2,  2.0] },
       { species: 'An. barbirostris',     vals: [0,   0,    0,    0.5] },
     ],
-    positiveResolutionPct: 80,
   },
 };
-
-// Active metric mode for the heatmap toggle (FR Item 5 / Dashboard #4)
-let mirMode = 'observed';  // 'observed' | 'classic'
 
 function getD(site) { return SITE_DATA[site] || SITE_DATA['all']; }
 
@@ -722,15 +609,10 @@ function renderKPI(site) {
 function renderMIR(site) {
   const d = getD(site);
   const weeks = ['W13','W14','W15','W16'];
-  // Active series depending on toggle (V-04 v1.3 / Dashboard #4)
-  const activeRows  = mirMode === 'classic' ? d.mirClassic : d.mirObserved;
-  const compareRows = mirMode === 'classic' ? d.mirObserved : d.mirClassic;
-
   let html = `<thead><tr><th>Species / Panel</th>${weeks.map(w=>`<th>${w}</th>`).join('')}</tr></thead><tbody>`;
-  activeRows.forEach((row, ri) => {
+  d.mir.forEach(row => {
     html += `<tr><td>${row.species}</td>`;
-    row.vals.forEach((v, ci) => {
-      const compareV = compareRows[ri].vals[ci];
+    row.vals.forEach(v => {
       const intensity = Math.min(v / 15, 1);
       let bg, color;
       if (v === 0) {
@@ -740,52 +622,12 @@ function renderMIR(site) {
       } else {
         bg = `rgba(218,30,40,${(0.3 + intensity * 0.7).toFixed(2)})`; color = v > 8 ? '#fff' : '#161616';
       }
-      // Tooltip shows BOTH metrics + resolution % per Item 5 acceptance criteria
-      const tooltip = mirMode === 'classic'
-        ? `Classical: ${v}\nObserved: ${compareV}\nResolution: ${d.positiveResolutionPct}%`
-        : `Observed: ${v}\nClassical: ${compareV}\nResolution: ${d.positiveResolutionPct}%`;
-      html += `<td style="background:${bg};color:${color};font-weight:600" title="${tooltip}">${v || '—'}</td>`;
+      html += `<td style="background:${bg};color:${color};font-weight:600">${v || '—'}</td>`;
     });
     html += `</tr>`;
   });
   html += `</tbody>`;
   document.getElementById('mir-table').innerHTML = html;
-
-  // Toggle the partial-resolution warning glyph based on resolution %
-  const warn = document.getElementById('mir-resolution-warning');
-  if (warn) {
-    if (d.positiveResolutionPct < 100) {
-      warn.style.display = 'flex';
-      warn.querySelector('span:last-child').textContent =
-        `Partial resolution: ${d.positiveResolutionPct}% of positive pools deconvoluted this period. ` +
-        `${mirMode === 'observed' ? 'Observed metric uses classical fallback for the remainder.' : 'Switch to Observed for exact counts where resolved.'}`;
-    } else {
-      warn.style.display = 'none';
-    }
-  }
-}
-
-function setMirMode(mode) {
-  mirMode = mode;
-  const obsTab = document.getElementById('mir-tab-observed');
-  const claTab = document.getElementById('mir-tab-classic');
-  if (obsTab && claTab) {
-    const activeStyle = 'padding:6px 10px;background:#161616;color:#fff;border:none;cursor:pointer;';
-    const inactiveStyle = 'padding:6px 10px;background:#fff;color:#161616;border:none;cursor:pointer;';
-    if (mode === 'observed') {
-      obsTab.setAttribute('style', activeStyle);
-      claTab.setAttribute('style', inactiveStyle + 'border-left:1px solid #c6c6c6;');
-      obsTab.setAttribute('aria-selected', 'true');
-      claTab.setAttribute('aria-selected', 'false');
-    } else {
-      obsTab.setAttribute('style', inactiveStyle);
-      claTab.setAttribute('style', activeStyle + 'border-left:1px solid #c6c6c6;');
-      obsTab.setAttribute('aria-selected', 'false');
-      claTab.setAttribute('aria-selected', 'true');
-    }
-  }
-  const site = document.getElementById('site-select').value;
-  renderMIR(site);
 }
 
 function updateMeta() {
@@ -855,23 +697,10 @@ function navAlert(msg) {
 
 // ═══ INIT ════════════════════════════════════
 
-// Wire up MIR metric toggle (Dashboard #4 ContentSwitcher)
-document.addEventListener('DOMContentLoaded', () => {
-  const obsTab = document.getElementById('mir-tab-observed');
-  const claTab = document.getElementById('mir-tab-classic');
-  if (obsTab) obsTab.addEventListener('click', () => setMirMode('observed'));
-  if (claTab) claTab.addEventListener('click', () => setMirMode('classic'));
-});
-
 setState('loading');
 setTimeout(() => {
   renderKPI('all'); renderMIR('all'); updateMeta();
   setState('connected');
-  // Also wire up tabs in case DOMContentLoaded already fired
-  const obsTab = document.getElementById('mir-tab-observed');
-  const claTab = document.getElementById('mir-tab-classic');
-  if (obsTab && !obsTab._wired) { obsTab._wired = true; obsTab.addEventListener('click', () => setMirMode('observed')); }
-  if (claTab && !claTab._wired) { claTab._wired = true; claTab.addEventListener('click', () => setMirMode('classic')); }
 }, 1200);
 </script>
 </body>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -97,13 +97,16 @@ export const MOCKUP_REGISTRY = [
   },
   {
     name: 'Test Catalog',
-    category: 'vector-surveillance',
+    category: 'admin-config',
     component: React.lazy(() => import('@designs/admin-config/test-catalog.jsx')),
-    description: 'Comprehensive test catalog management',
+    description: 'Admin surface where lab managers define all tests offered — 14-section routed editor covering identity, result types, ranges, sample storage, panels, analyzers, alerts, AMR mapping, regulatory compliance thresholds, LOINC/SNOMED/CIEL/OCL terminology, and order entry configuration. Replaces five separate admin pages (Test, Section, Panel, Method, Reagent). v2.3: JSX–FRS reconciliation pass, Terminology Mappings section, Sample & Results Configuration, click-to-open row interaction, 226 i18n keys.',
     specPath: 'designs/admin-config/test-catalog.md',
+    htmlUrl: 'designs/admin-config/test-catalog.html',
+    added: '2026-04-27',
+    status: 'draft',
     githubIssue: 8,
     jira: ['OGC-173'],
-    tags: ['test-catalog', 'tests', 'admin', 'configuration', 'environmental', 'vector'],
+    tags: ['test-catalog', 'tests', 'admin', 'configuration', 'environmental', 'vector', 'LOINC', 'SNOMED'],
   },
 
   {
@@ -996,7 +999,18 @@ export const MOCKUP_REGISTRY = [
     status: 'draft',
     githubIssue: 62,
     jira: ['OGC-446'],
+    relatedTo: ['FHIR Publication Settings'],
     tags: ['FHIR', 'interoperability', 'outbound', 'hub', 'integration'],
+  },
+  {
+    name: 'FHIR Publication Settings',
+    category: 'system',
+    component: React.lazy(() => import('@designs/system/fhir-publication-settings.jsx')),
+    description: 'Admin configuration page for FHIR R4 outbound publication — endpoint URL, per-resource toggles (DiagnosticReport, Observation, ServiceRequest, Device, Organization), authentication modes (API key, OAuth 2.0, Basic auth, Private Key JWT with public key upload), DHIS2 push URL, and live connection test. Companion admin UI for the FHIR Outbound Push pipeline (OGC-446).',
+    added: '2026-04-27',
+    status: 'draft',
+    relatedTo: ['FHIR Outbound Push'],
+    tags: ['FHIR', 'interoperability', 'outbound', 'admin', 'configuration', 'integration'],
   },
   {
     name: 'Storage Disposition FHIR',


### PR DESCRIPTION
## Changes

**Test Catalog v2.3** (upgrade from v2.1)
- FRS `test-catalog.md` updated to v2.3 — Terminology Mappings section, Sample & Results Configuration, click-to-open row interaction, Alert Rules taxonomy reconciled, 226 i18n keys
- Mockup `test-catalog.jsx` updated to v2.3
- New HTML preview `test-catalog.html`
- App.jsx: fixed category `vector-surveillance` → `admin-config`; updated description and added htmlUrl

**FHIR Publication Settings** (new)
- New `designs/system/fhir-publication-settings.jsx` — admin config UI for FHIR endpoint URL, per-resource toggles, auth modes (API key, OAuth 2.0, Basic, Private Key JWT), DHIS2 push, connection test
- New App.jsx entry in system category; bidirectional relatedTo with FHIR Outbound Push

**V-04 Vector Surveillance Reporting**
- Updated `vector-surveillance-reporting.html` preview
- New companion doc `vector-surveillance-reporting-fhir-considerations.md` (for Piotr review)

**EQA V1 Crosswalk** — minor update (Q1 lifecycle description expanded)

## Tests

206 / 206 pass