### PR TITLE
feat(reporting-ranges): full FRS v2 — Methods admin + per-method range grid + result-entry lookup

### DIFF
--- a/designs/admin-config/reporting-ranges-by-method.html
+++ b/designs/admin-config/reporting-ranges-by-method.html
@@ -182,13 +182,30 @@
 
 <script>
 // ---------- Mock data ----------
+//
+// `code` is persisted in the data model but NEVER displayed in the admin UI.
+// USER methods get a server-assigned 'METH-NNN' code (zero-padded, monotonic).
+// PLUGIN methods carry the plugin-supplied code as part of the integration contract.
+// MANUAL is the literal 'MANUAL'. The code is used only for stable identifiers in
+// CSV import/export, audit trails, and plugin namespacing.
 const METHODS = [
-  { id: 'm1', code: 'MANUAL',       name: 'Manual / microscopy', source: 'MANUAL', analyzerId: null, analyzerName: null, active: true },
-  { id: 'm2', code: 'HUMASTAR-300', name: 'HumaStar 300SR',      source: 'PLUGIN', analyzerId: 'a-humastar', analyzerName: 'HumaStar 300SR', active: true },
-  { id: 'm3', code: 'SYSMEX-XN350', name: 'Sysmex XN-350',       source: 'PLUGIN', analyzerId: 'a-sysmex',   analyzerName: 'Sysmex XN-350', active: true },
-  { id: 'm4', code: 'GXPT-MTB',     name: 'GeneXpert MTB/RIF',   source: 'PLUGIN', analyzerId: 'a-genexpert',analyzerName: 'GeneXpert', active: true },
-  { id: 'm5', code: 'HPLC',         name: 'HPLC',                source: 'USER',   analyzerId: null, analyzerName: null, active: true },
+  { id: 'm1', code: 'MANUAL',       name: 'Manual / microscopy', description: 'System default — always available on every test.',                          source: 'MANUAL', analyzerId: null, analyzerName: null, active: true },
+  { id: 'm2', code: 'HUMASTAR-300', name: 'HumaStar 300SR',      description: 'Random-access clinical chemistry analyzer.',                                source: 'PLUGIN', analyzerId: 'a-humastar', analyzerName: 'HumaStar 300SR', active: true },
+  { id: 'm3', code: 'SYSMEX-XN350', name: 'Sysmex XN-350',       description: 'Compact 5-part diff hematology analyzer.',                                  source: 'PLUGIN', analyzerId: 'a-sysmex',   analyzerName: 'Sysmex XN-350', active: true },
+  { id: 'm4', code: 'GXPT-MTB',     name: 'GeneXpert MTB/RIF',   description: 'Cartridge-based NAAT for TB and rifampicin resistance.',                    source: 'PLUGIN', analyzerId: 'a-genexpert',analyzerName: 'GeneXpert', active: true },
+  { id: 'm5', code: 'METH-001',     name: 'HPLC',                description: 'High-performance liquid chromatography. Used for HbA1c when the Sysmex is offline.', source: 'USER', analyzerId: null, analyzerName: null, active: true },
 ];
+
+// Server-assigned next code for new USER methods. In production this comes from
+// the API response — the UI never previews or reserves a value.
+function nextUserMethodCode() {
+  const used = METHODS
+    .map(m => /^METH-(\d+)$/.exec(m.code))
+    .filter(Boolean)
+    .map(match => parseInt(match[1], 10));
+  const next = (used.length === 0 ? 0 : Math.max(...used)) + 1;
+  return `METH-${String(next).padStart(3, '0')}`;
+}
 
 const TESTS = [
   {
@@ -267,7 +284,8 @@ function renderMethods() {
     if (methodsFilter.source === 'plugin' && methodsFilter.analyzer !== 'all' && method.analyzerId !== methodsFilter.analyzer) return false;
     if (methodsFilter.search) {
       const q = methodsFilter.search.toLowerCase();
-      if (!method.code.toLowerCase().includes(q) && !method.name.toLowerCase().includes(q)) return false;
+      // Search by Name only — `code` is internal and not displayed to admins.
+      if (!method.name.toLowerCase().includes(q)) return false;
     }
     return true;
   });
@@ -297,7 +315,7 @@ function renderMethods() {
             </select>
           </div>` : ''}
         <div class="filter-col"><label>Search</label>
-          <input type="text" placeholder="Code or name" value="${methodsFilter.search}" oninput="setMethodsFilter('search', this.value)" />
+          <input type="text" placeholder="Name" value="${methodsFilter.search}" oninput="setMethodsFilter('search', this.value)" />
         </div>
         <div class="right">
           ${canManage ? `<button class="btn primary" onclick="openAddMethodModal()">+ Add method</button>` : ''}
@@ -312,7 +330,7 @@ function renderMethods() {
       <table class="t">
         <thead><tr>
           <th style="width:3rem"></th>
-          <th>Code</th><th>Name</th><th>Source</th><th>Used by</th><th>Status</th>
+          <th>Name</th><th>Source</th><th>Used by</th><th>Status</th>
         </tr></thead>
         <tbody>
           ${filtered.map(method => {
@@ -321,13 +339,12 @@ function renderMethods() {
             return `
               <tr class="${expanded ? 'expanded' : ''}">
                 <td><button class="expand-btn" onclick="toggleMethod('${method.id}')">${expanded ? '▴' : '▾'}</button></td>
-                <td><strong>${method.code}</strong></td>
-                <td>${method.name}</td>
+                <td><strong>${method.name}</strong></td>
                 <td>${sourceTagHtml(method)}</td>
                 <td>${used}</td>
                 <td><span class="tag tag-green">${method.active ? 'Active' : 'Inactive'}</span></td>
               </tr>
-              ${expanded ? `<tr><td colspan="6"><div class="expand-panel">${renderMethodExpand(method, used)}</div></td></tr>` : ''}
+              ${expanded ? `<tr><td colspan="5"><div class="expand-panel">${renderMethodExpand(method, used)}</div></td></tr>` : ''}
             `;
           }).join('')}
         </tbody>
@@ -337,15 +354,23 @@ function renderMethods() {
 }
 
 function renderMethodExpand(method, used) {
+  const descBlock = method.description
+    ? `<div style="margin-top:0.5rem;">
+         <strong style="font-size:0.8125rem;">Description</strong>
+         <p style="margin:0.25rem 0 0; white-space:pre-wrap; font-size:0.8125rem;">${method.description}</p>
+       </div>`
+    : '';
+
   if (method.source === 'MANUAL') {
-    return `<p class="hint"><em>System-provided default — always available on every test.</em></p>`;
+    return `<p class="hint"><em>System-provided default — always available on every test.</em></p>${descBlock}`;
   }
   if (method.source === 'PLUGIN') {
     const usingTests = TESTS.filter(tt => tt.testMethods.some(tm => tm.methodId === method.id));
     return `
       <p class="hint"><em>Registered by the ${method.analyzerName} analyzer plugin.</em></p>
+      ${descBlock}
       ${usingTests.length > 0 ? `
-        <h5>Tests currently using this method</h5>
+        <h5 style="margin-top:0.75rem;">Tests currently using this method</h5>
         <ul style="margin:0.25rem 0 0 1rem; font-size:0.8125rem;">
           ${usingTests.slice(0, 10).map(tt => `<li><strong>${tt.code}</strong> — ${tt.name}</li>`).join('')}
         </ul>` : ''}
@@ -353,12 +378,7 @@ function renderMethodExpand(method, used) {
   }
   const blockDelete = used > 0;
   return `
-    <div style="display:grid; grid-template-columns:1fr 1fr 1fr; gap:1rem; max-width:720px;">
-      <div>
-        <label style="font-size:0.75rem;color:var(--text-muted)">Code</label>
-        <input type="text" value="${method.code}" disabled style="width:100%;padding:0.5rem 0.75rem;border:1px solid var(--border-subtle);background:#f4f4f4;" />
-        <div class="pm-helper">Codes can't be changed after creation.</div>
-      </div>
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:1rem; max-width:720px;">
       <div>
         <label style="font-size:0.75rem;color:var(--text-muted)">Name</label>
         <input id="name-${method.id}" type="text" value="${method.name}" ${canManage ? '' : 'disabled'}
@@ -371,12 +391,18 @@ function renderMethodExpand(method, used) {
                  onchange="toggleMethodActive('${method.id}', this.checked)" /> ${method.active ? 'Active' : 'Inactive'}
         </div>
       </div>
+      <div style="grid-column: 1 / -1;">
+        <label style="font-size:0.75rem;color:var(--text-muted)">Description <span style="color:var(--text-muted); font-weight:400;">(optional, max 500 chars)</span></label>
+        <textarea id="description-${method.id}" rows="3" ${canManage ? '' : 'disabled'} maxlength="500"
+                  style="width:100%;padding:0.5rem 0.75rem;border:1px solid var(--border-subtle); font-family:inherit; font-size:0.875rem;">${method.description || ''}</textarea>
+        <div class="pm-helper">What this method does, when to use it. Shown when picking a method on a test.</div>
+      </div>
     </div>
     ${canManage ? `
       <div style="margin-top:1rem; display:flex; gap:0.5rem; justify-content:flex-end; align-items:center;">
         <button class="btn danger" ${blockDelete ? 'disabled' : ''} onclick="confirmDeleteMethod('${method.id}')">Delete</button>
         ${blockDelete ? `<span class="pm-helper">Used by ${used} tests — remove from each test first.</span>` : ''}
-        <button class="btn primary sm" onclick="saveMethodName('${method.id}')">Save</button>
+        <button class="btn primary sm" onclick="saveMethodEdits('${method.id}')">Save</button>
       </div>` : ''}
   `;
 }
@@ -436,9 +462,12 @@ function renderTestExpand(test) {
           ${test.testMethods.map(tm => {
             const method = m(tm.methodId);
             const canDel = tm.source === 'USER_ADDED' && canManage;
+            const desc = method.description
+              ? `<div style="font-size:0.75rem;color:var(--text-muted);margin-top:0.125rem;">${method.description.length > 120 ? method.description.slice(0, 120) + '…' : method.description}</div>`
+              : '';
             return `
               <tr>
-                <td><strong>${method.code}</strong> — ${method.name}</td>
+                <td><strong>${method.name}</strong>${desc}</td>
                 <td>${testMethodSourceTag(tm)}</td>
                 <td>${tm.addedOn}</td>
                 <td>
@@ -474,7 +503,7 @@ function renderTestExpand(test) {
             const applyDisabled = !lowFilled || !highFilled || invalid;
             return `
               <tr>
-                <td><strong>${method.code}</strong></td>
+                <td><strong>${method.name}</strong></td>
                 <td><input type="number" class="${invalid ? 'inline-invalid' : ''}" value="${row.low ?? ''}" ${canManage ? '' : 'disabled'}
                            onchange="updateRangeValue('${test.id}','${tm.methodId}','low',this.value)" /></td>
                 <td><input type="number" class="${invalid ? 'inline-invalid' : ''}" value="${row.high ?? ''}" ${canManage ? '' : 'disabled'}
@@ -505,14 +534,14 @@ function renderResultEntry() {
   const methodRange = test.methodRanges.find(r => r.methodId === method.id);
   const hasMethodRange = methodRange && (methodRange.low != null || methodRange.high != null);
   const resolved = hasMethodRange
-    ? { low: methodRange.low, high: methodRange.high, units: methodRange.units, label: `Method range (${method.code})` }
+    ? { low: methodRange.low, high: methodRange.high, units: methodRange.units, label: `Method range (${method.name})` }
     : { low: test.testLevelLow, high: test.testLevelHigh, units: test.units, label: 'Test-level range' };
 
   const n = Number(reState.value);
   const out = (resolved.low != null && n < Number(resolved.low)) || (resolved.high != null && n > Number(resolved.high));
 
   const testOptions = TESTS.map(tt => `<option value="${tt.id}" ${reState.testId===tt.id?'selected':''}>${tt.code} — ${tt.name}</option>`).join('');
-  const methodOptions = allowed.map(x => `<option value="${x.id}" ${reState.methodId===x.id?'selected':''}>${x.code} — ${x.name}</option>`).join('');
+  const methodOptions = allowed.map(x => `<option value="${x.id}" ${reState.methodId===x.id?'selected':''}>${x.name}</option>`).join('');
 
   const resolvedCopy = (resolved.low == null && resolved.high == null)
     ? `${resolved.label}: not configured — no warning can fire.`
@@ -683,38 +712,41 @@ function closeModal() {
   document.getElementById('modal-bg').classList.remove('open');
 }
 
-let addMethodDraft = { code: '', name: '', active: true };
+let addMethodDraft = { name: '', description: '', active: true };
 function openAddMethodModal() {
-  addMethodDraft = { code: '', name: '', active: true };
+  addMethodDraft = { name: '', description: '', active: true };
   renderAddMethodModal();
 }
 function renderAddMethodModal() {
-  const codeErr = !addMethodDraft.code ? null
-                : !/^[A-Z0-9-]{2,16}$/.test(addMethodDraft.code) ? 'Code must be 2–16 uppercase letters, digits, or hyphens.'
-                : METHODS.some(x => x.code === addMethodDraft.code) ? 'This code is already in use.'
-                : null;
-  const nameErr = !addMethodDraft.name ? 'Name is required.' : null;
-  const canSave = !codeErr && !nameErr && addMethodDraft.code && addMethodDraft.name;
+  const nameErr = !addMethodDraft.name ? 'Name is required.'
+                : METHODS.some(x => x.source === 'USER' && x.name.trim().toLowerCase() === addMethodDraft.name.trim().toLowerCase())
+                  ? 'A method with this name already exists.'
+                  : null;
+  const descErr = (addMethodDraft.description || '').length > 500 ? 'Description must be 500 characters or fewer.' : null;
+  const canSave = !nameErr && !descErr && addMethodDraft.name;
   openModal(`
     <div class="modal-header">Add method</div>
     <div class="modal-body">
       <div class="form-row">
-        <label>Code</label>
-        <input type="text" value="${addMethodDraft.code}" placeholder="e.g. HPLC"
-               oninput="addMethodDraft.code=this.value.toUpperCase(); renderAddMethodModal();" />
-        ${codeErr ? `<div class="field-error">${codeErr}</div>` : ''}
+        <label>Name</label>
+        <input type="text" value="${addMethodDraft.name}" placeholder="e.g. HPLC"
+               oninput="addMethodDraft.name=this.value; renderAddMethodModal();" />
+        ${(addMethodDraft.name && nameErr) ? `<div class="field-error">${nameErr}</div>` : ''}
       </div>
       <div class="form-row">
-        <label>Name</label>
-        <input type="text" value="${addMethodDraft.name}"
-               oninput="addMethodDraft.name=this.value; renderAddMethodModal();" />
-        ${(addMethodDraft.code && nameErr) ? `<div class="field-error">${nameErr}</div>` : ''}
+        <label>Description <span style="color:var(--text-muted); font-weight:400;">(optional, max 500 chars)</span></label>
+        <textarea rows="3" maxlength="500"
+                  style="width:100%;padding:0.5rem 0.75rem;border:1px solid var(--border-subtle); font-family:inherit; font-size:0.875rem;"
+                  oninput="addMethodDraft.description=this.value; renderAddMethodModal();">${addMethodDraft.description}</textarea>
+        <div class="pm-helper">What this method does, when to use it. Shown when picking a method on a test.</div>
+        ${descErr ? `<div class="field-error">${descErr}</div>` : ''}
       </div>
       <div class="form-row">
         <label>Active</label>
         <div><input type="checkbox" ${addMethodDraft.active?'checked':''}
                onchange="addMethodDraft.active=this.checked; renderAddMethodModal();" /> ${addMethodDraft.active?'Active':'Inactive'}</div>
       </div>
+      <p style="font-size:0.75rem;color:var(--text-muted);margin:0;">A code is assigned automatically when you save. Methods are identified by Name everywhere in the admin.</p>
     </div>
     <div class="modal-footer">
       <button class="btn ghost" onclick="closeModal()">Cancel</button>
@@ -723,9 +755,13 @@ function renderAddMethodModal() {
   `);
 }
 function saveNewMethod() {
+  // Server assigns the code; UI never previews it. Mimicking server behavior here.
+  const assignedCode = nextUserMethodCode();
   const newMethod = {
     id: `m${METHODS.length + 1}`,
-    code: addMethodDraft.code, name: addMethodDraft.name,
+    code: assignedCode,
+    name: addMethodDraft.name,
+    description: addMethodDraft.description || null,
     source: 'USER', analyzerId: null, analyzerName: null, active: addMethodDraft.active,
   };
   METHODS.push(newMethod);
@@ -735,7 +771,7 @@ function saveNewMethod() {
 function confirmDeleteMethod(id) {
   const method = m(id);
   openModal(`
-    <div class="modal-header">Delete method ${method.code}?</div>
+    <div class="modal-header">Delete method "${method.name}"?</div>
     <div class="modal-body"><p>This action cannot be undone.</p></div>
     <div class="modal-footer">
       <button class="btn ghost" onclick="closeModal()">Cancel</button>
@@ -748,11 +784,13 @@ function deleteMethod(id) {
   if (idx >= 0) METHODS.splice(idx, 1);
   render();
 }
-function saveMethodName(id) {
-  const nameEl = document.getElementById(`name-${id}`);
-  if (!nameEl) return;
+function saveMethodEdits(id) {
   const method = m(id);
-  method.name = nameEl.value;
+  if (!method) return;
+  const nameEl = document.getElementById(`name-${id}`);
+  const descEl = document.getElementById(`description-${id}`);
+  if (nameEl) method.name = nameEl.value;
+  if (descEl) method.description = descEl.value || null;
   render();
 }
 function toggleMethodActive(id, checked) {
@@ -761,9 +799,9 @@ function toggleMethodActive(id, checked) {
   render();
 }
 
-let addToTestDraft = { testId: null, mode: 'pick', pickedId: '', newCode: '', newName: '' };
+let addToTestDraft = { testId: null, mode: 'pick', pickedId: '', newName: '', newDescription: '' };
 function openAddMethodToTestModal(testId) {
-  addToTestDraft = { testId, mode: 'pick', pickedId: '', newCode: '', newName: '' };
+  addToTestDraft = { testId, mode: 'pick', pickedId: '', newName: '', newDescription: '' };
   renderAddMethodToTestModal();
 }
 function renderAddMethodToTestModal() {
@@ -779,11 +817,13 @@ function renderAddMethodToTestModal() {
     if (x.source === 'PLUGIN') return mappedAnalyzerIds.has(x.analyzerId);
     return true;
   });
-  const newCodeErr = addToTestDraft.newCode && !/^[A-Z0-9-]{2,16}$/.test(addToTestDraft.newCode)
-    ? 'Code must be 2–16 uppercase letters, digits, or hyphens.' : null;
+  const newNameErr = addToTestDraft.newName &&
+    METHODS.some(x => x.source === 'USER' && x.name.trim().toLowerCase() === addToTestDraft.newName.trim().toLowerCase())
+      ? 'A method with this name already exists.' : null;
+  const newDescErr = (addToTestDraft.newDescription || '').length > 500 ? 'Description must be 500 characters or fewer.' : null;
   const canSave = addToTestDraft.mode === 'pick'
     ? !!addToTestDraft.pickedId
-    : (!newCodeErr && addToTestDraft.newCode && addToTestDraft.newName);
+    : (!newNameErr && !newDescErr && addToTestDraft.newName);
 
   openModal(`
     <div class="modal-header">Add method to ${test.code}</div>
@@ -799,21 +839,27 @@ function renderAddMethodToTestModal() {
             <option value="">— choose —</option>
             ${pickable.map(x => {
               const suffix = x.source === 'PLUGIN' ? ` — ${x.analyzerName}` : x.source === 'USER' ? ' — user' : '';
-              return `<option value="${x.id}" ${addToTestDraft.pickedId===x.id?'selected':''}>${x.code} — ${x.name}${suffix}</option>`;
+              const descSnippet = x.description
+                ? ` · ${x.description.length > 80 ? x.description.slice(0, 80) + '…' : x.description}`
+                : '';
+              return `<option value="${x.id}" ${addToTestDraft.pickedId===x.id?'selected':''}>${x.name}${suffix}${descSnippet}</option>`;
             }).join('')}
           </select>
           ${pickable.length === 0 ? '<div class="pm-helper">No methods are available to add here. Map an analyzer to this test, or create a new method.</div>' : ''}
         </div>` : `
         <div class="form-row">
-          <label>Code</label>
-          <input type="text" value="${addToTestDraft.newCode}" oninput="addToTestDraft.newCode=this.value.toUpperCase(); renderAddMethodToTestModal();" />
-          ${newCodeErr ? `<div class="field-error">${newCodeErr}</div>` : ''}
-        </div>
-        <div class="form-row">
           <label>Name</label>
           <input type="text" value="${addToTestDraft.newName}" oninput="addToTestDraft.newName=this.value; renderAddMethodToTestModal();" />
+          ${newNameErr ? `<div class="field-error">${newNameErr}</div>` : ''}
         </div>
-        <p style="font-size:0.75rem;color:var(--text-muted);margin:0;">The new method is created in the master catalog and added to this test in one step.</p>
+        <div class="form-row">
+          <label>Description <span style="color:var(--text-muted); font-weight:400;">(optional, max 500 chars)</span></label>
+          <textarea rows="3" maxlength="500"
+                    style="width:100%;padding:0.5rem 0.75rem;border:1px solid var(--border-subtle); font-family:inherit; font-size:0.875rem;"
+                    oninput="addToTestDraft.newDescription=this.value; renderAddMethodToTestModal();">${addToTestDraft.newDescription}</textarea>
+          ${newDescErr ? `<div class="field-error">${newDescErr}</div>` : ''}
+        </div>
+        <p style="font-size:0.75rem;color:var(--text-muted);margin:0;">The new method is created in the master catalog and added to this test in one step. A code is assigned automatically.</p>
       `}
     </div>
     <div class="modal-footer">
@@ -830,8 +876,13 @@ function saveAddMethodToTest() {
     const mId = addToTestDraft.pickedId;
     test.testMethods.push({ id: `tm-${test.id}-${mId}-${Date.now()}`, methodId: mId, source: 'USER_ADDED', addedOn: new Date().toISOString().slice(0,10) });
   } else {
-    const newM = { id: `m${METHODS.length + 1}`, code: addToTestDraft.newCode, name: addToTestDraft.newName,
-                   source: 'USER', analyzerId: null, analyzerName: null, active: true };
+    const newM = {
+      id: `m${METHODS.length + 1}`,
+      code: nextUserMethodCode(),
+      name: addToTestDraft.newName,
+      description: addToTestDraft.newDescription || null,
+      source: 'USER', analyzerId: null, analyzerName: null, active: true,
+    };
     METHODS.push(newM);
     test.testMethods.push({ id: `tm-${test.id}-${newM.id}`, methodId: newM.id, source: 'USER_ADDED', addedOn: new Date().toISOString().slice(0,10) });
   }

--- a/designs/admin-config/reporting-ranges-by-method.jsx
+++ b/designs/admin-config/reporting-ranges-by-method.jsx
@@ -34,7 +34,7 @@ import {
   Grid, Column, Stack,
   DataTable, TableContainer, Table, TableHead, TableRow, TableHeader,
   TableBody, TableCell, TableToolbar, TableToolbarContent, TableToolbarSearch,
-  TextInput, Select, SelectItem, ComboBox, NumberInput, Toggle,
+  TextInput, TextArea, Select, SelectItem, ComboBox, NumberInput, Toggle,
   Button, Tag, Tile, InlineNotification, Modal,
   RadioButtonGroup, RadioButton,
 } from '@carbon/react';
@@ -48,13 +48,30 @@ const t = (key, fallback) => fallback || key;
 
 // Master method catalog — three sources: MANUAL (seeded), USER (admin-created),
 // PLUGIN (registered by an analyzer's init hook).
+//
+// `code` is persisted in the data model but NEVER displayed in the admin UI.
+// USER methods get a server-assigned 'METH-NNN' code (zero-padded, monotonic).
+// PLUGIN methods carry the plugin-supplied code as part of the integration contract.
+// MANUAL is the literal 'MANUAL'. The code is used only for stable identifiers in
+// CSV import/export, audit trails, and plugin namespacing.
 const initialMethods = [
-  { id: 'm1', code: 'MANUAL',       name: 'Manual / microscopy', source: 'MANUAL', pluginId: null, analyzerId: null, analyzerName: null, active: true },
-  { id: 'm2', code: 'HUMASTAR-300', name: 'HumaStar 300SR',      source: 'PLUGIN', pluginId: 'humastar-plugin', analyzerId: 'a-humastar', analyzerName: 'HumaStar 300SR', active: true },
-  { id: 'm3', code: 'SYSMEX-XN350', name: 'Sysmex XN-350',       source: 'PLUGIN', pluginId: 'sysmex-plugin',   analyzerId: 'a-sysmex',   analyzerName: 'Sysmex XN-350', active: true },
-  { id: 'm4', code: 'GXPT-MTB',     name: 'GeneXpert MTB/RIF',   source: 'PLUGIN', pluginId: 'genexpert-plugin',analyzerId: 'a-genexpert',analyzerName: 'GeneXpert',     active: true },
-  { id: 'm5', code: 'HPLC',         name: 'HPLC',                source: 'USER',   pluginId: null, analyzerId: null, analyzerName: null, active: true },
+  { id: 'm1', code: 'MANUAL',       name: 'Manual / microscopy', description: 'System default — always available on every test.', source: 'MANUAL', pluginId: null, analyzerId: null, analyzerName: null, active: true },
+  { id: 'm2', code: 'HUMASTAR-300', name: 'HumaStar 300SR',      description: 'Random-access clinical chemistry analyzer.', source: 'PLUGIN', pluginId: 'humastar-plugin', analyzerId: 'a-humastar', analyzerName: 'HumaStar 300SR', active: true },
+  { id: 'm3', code: 'SYSMEX-XN350', name: 'Sysmex XN-350',       description: 'Compact 5-part diff hematology analyzer.', source: 'PLUGIN', pluginId: 'sysmex-plugin',   analyzerId: 'a-sysmex',   analyzerName: 'Sysmex XN-350', active: true },
+  { id: 'm4', code: 'GXPT-MTB',     name: 'GeneXpert MTB/RIF',   description: 'Cartridge-based NAAT for TB and rifampicin resistance.', source: 'PLUGIN', pluginId: 'genexpert-plugin',analyzerId: 'a-genexpert',analyzerName: 'GeneXpert',     active: true },
+  { id: 'm5', code: 'METH-001',     name: 'HPLC',                description: 'High-performance liquid chromatography. Used for HbA1c when the Sysmex is offline.', source: 'USER',   pluginId: null, analyzerId: null, analyzerName: null, active: true },
 ];
+
+// Server-assigned next code for new USER methods. In production this comes from
+// the API response — the UI never previews or reserves a value.
+const nextUserMethodCode = (methods) => {
+  const used = methods
+    .map(m => /^METH-(\d+)$/.exec(m.code))
+    .filter(Boolean)
+    .map(match => parseInt(match[1], 10));
+  const next = (used.length === 0 ? 0 : Math.max(...used)) + 1;
+  return `METH-${String(next).padStart(3, '0')}`;
+};
 
 // Tests. Each carries an explicit allowed-methods list (test_method rows) and a
 // per-method ranges table (test_method_range rows). In addition every test
@@ -136,7 +153,8 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
     if (sourceFilter === 'plugin' && pluginAnalyzerFilter !== 'all' && m.analyzerId !== pluginAnalyzerFilter) return false;
     if (search) {
       const q = search.toLowerCase();
-      if (!m.code.toLowerCase().includes(q) && !m.name.toLowerCase().includes(q)) return false;
+      // Search by Name only — `code` is internal and not displayed to admins.
+      if (!m.name.toLowerCase().includes(q)) return false;
     }
     return true;
   });
@@ -204,7 +222,6 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
             <TableHead>
               <TableRow>
                 <TableHeader style={{ width: '3rem' }} />
-                <TableHeader>{t('admin.testCatalog.methods.col.code', 'Code')}</TableHeader>
                 <TableHeader>{t('admin.testCatalog.methods.col.name', 'Name')}</TableHeader>
                 <TableHeader>{t('admin.testCatalog.methods.col.source', 'Source')}</TableHeader>
                 <TableHeader>{t('admin.testCatalog.methods.col.usedBy', 'Used by')}</TableHeader>
@@ -223,8 +240,7 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
                           iconDescription={expanded ? 'Collapse' : 'Expand'}
                           onClick={() => setExpandedId(expanded ? null : m.id)} />
                       </TableCell>
-                      <TableCell><strong>{m.code}</strong></TableCell>
-                      <TableCell>{m.name}</TableCell>
+                      <TableCell><strong>{m.name}</strong></TableCell>
                       <TableCell>{sourceTag(m)}</TableCell>
                       <TableCell>{usedBy}</TableCell>
                       <TableCell>
@@ -233,7 +249,7 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
                     </TableRow>
                     {expanded && (
                       <TableRow>
-                        <TableCell colSpan={6} style={{ background: 'var(--cds-layer-01)' }}>
+                        <TableCell colSpan={5} style={{ background: 'var(--cds-layer-01)' }}>
                           <MethodRowExpand method={m} usedBy={usedBy} tests={tests}
                             canManage={canManage}
                             onEdit={(next) => {
@@ -257,27 +273,31 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
         <AddMethodModal methods={methods}
           onClose={() => setShowAddModal(false)}
           onSave={(draft) => {
+            // Server assigns the code; UI never previews it. We mimic the
+            // server behavior here for the mockup so demo state stays valid.
+            const assignedCode = nextUserMethodCode(methods);
             const newMethod = {
               id: `m${methods.length + 1}`,
-              code: draft.code.toUpperCase(),
+              code: assignedCode,
               name: draft.name,
+              description: draft.description || null,
               source: 'USER', pluginId: null, analyzerId: null, analyzerName: null,
               active: draft.active,
             };
             setMethods([...methods, newMethod]);
             setShowAddModal(false);
-            setToast({ kind: 'success', title: `Added method ${newMethod.code}` });
+            setToast({ kind: 'success', title: `Added method "${newMethod.name}"` });
           }} />
       )}
 
       {deleteCandidate && (
-        <Modal open modalHeading={`Delete method ${deleteCandidate.code}?`}
+        <Modal open modalHeading={`Delete method "${deleteCandidate.name}"?`}
           primaryButtonText="Delete" secondaryButtonText="Cancel"
           danger
           onRequestClose={() => setDeleteCandidate(null)}
           onRequestSubmit={() => {
             setMethods(methods.filter(x => x.id !== deleteCandidate.id));
-            setToast({ kind: 'success', title: `Deleted method ${deleteCandidate.code}` });
+            setToast({ kind: 'success', title: `Deleted method "${deleteCandidate.name}"` });
             setDeleteCandidate(null);
           }}>
           <p>This action cannot be undone.</p>
@@ -288,12 +308,22 @@ function MethodsAdminPage({ methods, setMethods, tests, canManage }) {
 }
 
 function MethodRowExpand({ method, usedBy, tests, canManage, onEdit, onRequestDelete }) {
-  const [draft, setDraft] = useState({ name: method.name, active: method.active });
+  const [draft, setDraft] = useState({
+    name: method.name,
+    description: method.description || '',
+    active: method.active,
+  });
 
   if (method.source === 'MANUAL') {
     return (
       <Stack gap={3}>
         <p><em>{t('admin.testCatalog.methods.readOnly.manual', 'System-provided default — always available on every test.')}</em></p>
+        {method.description && (
+          <div>
+            <strong>{t('admin.testCatalog.methods.field.description', 'Description')}</strong>
+            <p style={{ margin: '0.25rem 0 0', whiteSpace: 'pre-wrap' }}>{method.description}</p>
+          </div>
+        )}
       </Stack>
     );
   }
@@ -303,6 +333,12 @@ function MethodRowExpand({ method, usedBy, tests, canManage, onEdit, onRequestDe
     return (
       <Stack gap={3}>
         <p><em>{t('admin.testCatalog.methods.readOnly.plugin', `Registered by the ${method.analyzerName} analyzer plugin.`)}</em></p>
+        {method.description && (
+          <div>
+            <strong>{t('admin.testCatalog.methods.field.description', 'Description')}</strong>
+            <p style={{ margin: '0.25rem 0 0', whiteSpace: 'pre-wrap' }}>{method.description}</p>
+          </div>
+        )}
         {usingTests.length > 0 && (
           <div>
             <strong>Tests currently using this method:</strong>
@@ -317,22 +353,35 @@ function MethodRowExpand({ method, usedBy, tests, canManage, onEdit, onRequestDe
 
   // USER method
   const blockDelete = usedBy > 0;
+  const descLen = (draft.description || '').length;
+  const descError = descLen > 500 ? 'Description must be 500 characters or fewer.' : null;
+  const nameError = !draft.name ? 'Name is required.' : null;
+  const canSave = !descError && !nameError;
   return (
     <Stack gap={4}>
       <Grid narrow>
-        <Column sm={4} md={4} lg={4}>
-          <TextInput id={`code-${method.id}`} labelText={t('admin.testCatalog.methods.field.code', 'Code')} value={method.code} disabled
-            helperText={t('admin.testCatalog.methods.field.codeImmutableHelp', "Codes can't be changed after creation.")} />
-        </Column>
-        <Column sm={4} md={4} lg={4}>
+        <Column sm={4} md={4} lg={6}>
           <TextInput id={`name-${method.id}`} labelText={t('admin.testCatalog.methods.field.name', 'Name')}
             value={draft.name} onChange={e => setDraft({ ...draft, name: e.target.value })}
-            disabled={!canManage} />
+            disabled={!canManage}
+            invalid={!!nameError} invalidText={nameError || ''} />
         </Column>
-        <Column sm={4} md={4} lg={4}>
+        <Column sm={4} md={4} lg={2}>
           <Toggle id={`active-${method.id}`} labelText={t('admin.testCatalog.methods.field.active', 'Active')}
             toggled={draft.active} onToggle={v => setDraft({ ...draft, active: v })}
             disabled={!canManage} />
+        </Column>
+        <Column sm={4} md={8} lg={8}>
+          <TextArea id={`description-${method.id}`}
+            labelText={t('admin.testCatalog.methods.field.description', 'Description')}
+            helperText={t('admin.testCatalog.methods.field.descriptionHelp', 'What this method does, when to use it. Shown when picking a method on a test.')}
+            value={draft.description}
+            onChange={e => setDraft({ ...draft, description: e.target.value })}
+            disabled={!canManage}
+            rows={3}
+            maxCount={500}
+            enableCounter
+            invalid={!!descError} invalidText={descError || ''} />
         </Column>
       </Grid>
       {canManage && (
@@ -347,7 +396,7 @@ function MethodRowExpand({ method, usedBy, tests, canManage, onEdit, onRequestDe
               {t('admin.testCatalog.methods.deleteBlockedUsage', `Used by ${usedBy} tests — remove from each test first.`)}
             </span>
           )}
-          <Button kind="primary" renderIcon={Save} onClick={() => onEdit(draft)}>Save</Button>
+          <Button kind="primary" renderIcon={Save} onClick={() => onEdit(draft)} disabled={!canSave}>Save</Button>
         </div>
       )}
     </Stack>
@@ -355,15 +404,14 @@ function MethodRowExpand({ method, usedBy, tests, canManage, onEdit, onRequestDe
 }
 
 function AddMethodModal({ methods, onClose, onSave }) {
-  const [draft, setDraft] = useState({ code: '', name: '', active: true });
-  const codeError = useMemo(() => {
-    if (!draft.code) return null;
-    if (!/^[A-Z0-9-]{2,16}$/.test(draft.code)) return 'Code must be 2–16 uppercase letters, digits, or hyphens.';
-    if (methods.some(m => m.code === draft.code)) return 'This code is already in use.';
-    return null;
-  }, [draft.code, methods]);
-  const nameError = !draft.name ? 'Name is required.' : null;
-  const canSave = !codeError && !nameError && draft.code && draft.name;
+  const [draft, setDraft] = useState({ name: '', description: '', active: true });
+  const [touched, setTouched] = useState({ name: false });
+
+  const nameError = !draft.name ? 'Name is required.' :
+    methods.some(m => m.source === 'USER' && m.name.trim().toLowerCase() === draft.name.trim().toLowerCase())
+      ? 'A method with this name already exists.' : null;
+  const descError = (draft.description || '').length > 500 ? 'Description must be 500 characters or fewer.' : null;
+  const canSave = !nameError && !descError && draft.name;
 
   return (
     <Modal open modalHeading={t('admin.testCatalog.methods.addCta', 'Add method')}
@@ -372,17 +420,26 @@ function AddMethodModal({ methods, onClose, onSave }) {
       onRequestClose={onClose}
       onRequestSubmit={() => onSave(draft)}>
       <Stack gap={4}>
-        <TextInput id="new-code" labelText={t('admin.testCatalog.methods.field.code', 'Code')}
-          placeholder="e.g. HPLC"
-          value={draft.code}
-          onChange={e => setDraft({ ...draft, code: e.target.value.toUpperCase() })}
-          invalid={!!codeError} invalidText={codeError || ''} />
         <TextInput id="new-name" labelText={t('admin.testCatalog.methods.field.name', 'Name')}
+          placeholder="e.g. HPLC"
           value={draft.name}
+          onBlur={() => setTouched({ ...touched, name: true })}
           onChange={e => setDraft({ ...draft, name: e.target.value })}
-          invalid={!!nameError && draft.code.length > 0} invalidText={nameError || ''} />
+          invalid={!!nameError && touched.name} invalidText={nameError || ''} />
+        <TextArea id="new-description"
+          labelText={t('admin.testCatalog.methods.field.description', 'Description')}
+          helperText={t('admin.testCatalog.methods.field.descriptionHelp', 'What this method does, when to use it. Shown when picking a method on a test.')}
+          value={draft.description}
+          onChange={e => setDraft({ ...draft, description: e.target.value })}
+          rows={3}
+          maxCount={500}
+          enableCounter
+          invalid={!!descError} invalidText={descError || ''} />
         <Toggle id="new-active" labelText={t('admin.testCatalog.methods.field.active', 'Active')}
           toggled={draft.active} onToggle={v => setDraft({ ...draft, active: v })} />
+        <p style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)', margin: 0 }}>
+          A code is assigned automatically when you save. Methods are identified by Name everywhere in the admin.
+        </p>
       </Stack>
     </Modal>
   );
@@ -581,7 +638,14 @@ function TestRowExpand({ test, methods, canManage, onChange }) {
                                                  <Tag type="cyan"       size="sm">User</Tag>;
               return (
                 <TableRow key={tm.id}>
-                  <TableCell><strong>{m?.code}</strong> — {m?.name}</TableCell>
+                  <TableCell>
+                    <div><strong>{m?.name}</strong></div>
+                    {m?.description && (
+                      <div style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)', marginTop: '0.125rem', maxWidth: '36rem' }}>
+                        {m.description.length > 120 ? `${m.description.slice(0, 120)}…` : m.description}
+                      </div>
+                    )}
+                  </TableCell>
                   <TableCell>{sourceTag}</TableCell>
                   <TableCell>{tm.addedOn}</TableCell>
                   <TableCell>
@@ -628,7 +692,7 @@ function TestRowExpand({ test, methods, canManage, onChange }) {
               const canApply = row.low != null && row.high != null && !error;
               return (
                 <TableRow key={`r-${tm.methodId}`}>
-                  <TableCell><strong>{m?.code}</strong></TableCell>
+                  <TableCell><strong>{m?.name}</strong></TableCell>
                   <TableCell>
                     <NumberInput id={`low-${tm.methodId}`} label="" hideLabel value={row.low ?? ''}
                       onChange={(_, { value }) => saveRangeRow(tm.methodId, { low: value === '' ? null : Number(value) })}
@@ -706,7 +770,7 @@ function TestRowExpand({ test, methods, canManage, onChange }) {
 function AddMethodToTestModal({ test, methods, onClose, onPickExisting, onCreateNew }) {
   const [mode, setMode] = useState('pick');
   const [pickedId, setPickedId] = useState('');
-  const [newDraft, setNewDraft] = useState({ code: '', name: '' });
+  const [newDraft, setNewDraft] = useState({ name: '', description: '' });
 
   const existingOnTest = new Set(test.testMethods.map(tm => tm.methodId));
   const pickable = methods.filter(m => {
@@ -727,8 +791,11 @@ function AddMethodToTestModal({ test, methods, onClose, onPickExisting, onCreate
   });
 
   const canSavePick = !!pickedId;
-  const newCodeError = newDraft.code && !/^[A-Z0-9-]{2,16}$/.test(newDraft.code) ? 'Code must be 2–16 uppercase letters, digits, or hyphens.' : null;
-  const canSaveNew = !newCodeError && newDraft.code && newDraft.name;
+  const newDescError = (newDraft.description || '').length > 500 ? 'Description must be 500 characters or fewer.' : null;
+  const newNameError = !newDraft.name ? null :
+    methods.some(m => m.source === 'USER' && m.name.trim().toLowerCase() === newDraft.name.trim().toLowerCase())
+      ? 'A method with this name already exists.' : null;
+  const canSaveNew = !newDescError && !newNameError && newDraft.name;
 
   return (
     <Modal open modalHeading={t('admin.testCatalog.test.methods.addCta', 'Add method')}
@@ -748,27 +815,37 @@ function AddMethodToTestModal({ test, methods, onClose, onPickExisting, onCreate
         </RadioButtonGroup>
 
         {mode === 'pick' && (
-          <ComboBox id="pick-method" titleText="Pick a method" placeholder="Search"
+          <ComboBox id="pick-method" titleText="Pick a method" placeholder="Search by name"
             items={pickable.map(m => m.id)}
             itemToString={(id) => {
               const m = methods.find(x => x.id === id);
               if (!m) return '';
               const suffix = m.source === 'PLUGIN' ? ` — ${m.analyzerName}` : m.source === 'USER' ? ' — user' : '';
-              return `${m.code} — ${m.name}${suffix}`;
+              const descSnippet = m.description
+                ? ` · ${m.description.length > 80 ? `${m.description.slice(0, 80)}…` : m.description}`
+                : '';
+              return `${m.name}${suffix}${descSnippet}`;
             }}
             onChange={({ selectedItem }) => setPickedId(selectedItem || '')} />
         )}
 
         {mode === 'create' && (
           <Stack gap={3}>
-            <TextInput id="new-method-code" labelText="Code"
-              value={newDraft.code}
-              onChange={e => setNewDraft({ ...newDraft, code: e.target.value.toUpperCase() })}
-              invalid={!!newCodeError} invalidText={newCodeError || ''} />
             <TextInput id="new-method-name" labelText="Name"
-              value={newDraft.name} onChange={e => setNewDraft({ ...newDraft, name: e.target.value })} />
+              value={newDraft.name} onChange={e => setNewDraft({ ...newDraft, name: e.target.value })}
+              invalid={!!newNameError} invalidText={newNameError || ''} />
+            <TextArea id="new-method-description"
+              labelText="Description"
+              helperText="Optional. What this method does, when to use it."
+              value={newDraft.description}
+              onChange={e => setNewDraft({ ...newDraft, description: e.target.value })}
+              rows={3}
+              maxCount={500}
+              enableCounter
+              invalid={!!newDescError} invalidText={newDescError || ''} />
             <p style={{ fontSize: '0.75rem', color: 'var(--cds-text-secondary)' }}>
               The new method is created in the master catalog and added to this test in one step.
+              A code is assigned automatically.
             </p>
           </Stack>
         )}
@@ -791,7 +868,7 @@ function ResultEntryPreview({ tests, methods }) {
 
   const methodRange = test.methodRanges.find(r => r.methodId === methodForLookup?.id);
   const resolved = methodRange && (methodRange.low != null || methodRange.high != null)
-    ? { low: methodRange.low, high: methodRange.high, units: methodRange.units, source: 'method', label: `Method range (${methodForLookup.code})` }
+    ? { low: methodRange.low, high: methodRange.high, units: methodRange.units, source: 'method', label: `Method range (${methodForLookup.name})` }
     : { low: test.testLevelLow, high: test.testLevelHigh, units: test.units, source: 'test', label: 'Test-level range' };
 
   const numericValue = Number(value);
@@ -823,7 +900,7 @@ function ResultEntryPreview({ tests, methods }) {
             <Select id="re-method" labelText="Method"
               value={methodForLookup?.id || ''}
               onChange={e => setSelectedMethodId(e.target.value)}>
-              {allowedMethods.map(m => <SelectItem key={m.id} value={m.id} text={`${m.code} — ${m.name}`} />)}
+              {allowedMethods.map(m => <SelectItem key={m.id} value={m.id} text={m.name} />)}
             </Select>
           </Column>
           <Column sm={4} md={4} lg={4}>

--- a/designs/admin-config/reporting-ranges-by-method.md
+++ b/designs/admin-config/reporting-ranges-by-method.md
@@ -37,8 +37,19 @@ There is **no new fallback layer**. If a method has no reporting range configure
 ```
 method                                            -- master catalog
   id                (pk)
-  code              VARCHAR UNIQUE NOT NULL      -- immutable after create
-  name              VARCHAR NOT NULL
+  code              VARCHAR UNIQUE NOT NULL      -- immutable after create. System-generated
+                                                 --   for USER methods as 'METH-NNN' (zero-padded
+                                                 --   to 3 digits, monotonic per-instance).
+                                                 --   Plugin-supplied for PLUGIN methods.
+                                                 --   Literal 'MANUAL' for the seeded Manual row.
+                                                 --   Never displayed in the admin UI; used only
+                                                 --   for stable identifiers in CSV import/export,
+                                                 --   audit trails, and plugin namespacing.
+  name              VARCHAR NOT NULL              -- 1–120 chars. Primary identifier shown in the UI.
+  description       TEXT NULL                     -- optional, 0–500 chars. Free text describing
+                                                 --   what the method does and when to use it.
+                                                 --   Shown in row-expand and in the per-test
+                                                 --   method picker. Plugins MAY supply on register.
   source            VARCHAR NOT NULL              -- enum: 'MANUAL' | 'USER' | 'PLUGIN'
   plugin_id         VARCHAR NULL                  -- set only when source = 'PLUGIN'
   analyzer_id       FK NULL                       -- set only when source = 'PLUGIN', points to
@@ -80,12 +91,12 @@ Route: `/admin/test-catalog/methods`. SideNav: a new submenu item **"Methods"** 
 
 | # | Requirement |
 |---|---|
-| FR-1 | P-01 Admin Table with columns: **Code · Name · Source · Used by N tests · Status**. Sortable on Code, Name, Source, Used by, Status. |
+| FR-1 | P-01 Admin Table with columns: **Name · Source · Used by N tests · Status**. Sortable on Name, Source, Used by, Status. The internal `method.code` is **not displayed** in this admin surface (see §3.1). |
 | FR-2 | Source is rendered as a Carbon `Tag` — `Manual` (gray), `User` (cyan), `<Analyzer name>` (warm) — based on `method.source` and (for PLUGIN) the registering analyzer's name. |
-| FR-3 | Toolbar primary action **"Add method"** (P-03 Create modal): fields Code (2–16 chars `[A-Z0-9-]+`, immutable after create), Name (1–120 chars), Active (Toggle, default ON). The created method has `source = 'USER'`. |
-| FR-4 | P-02 Inline row-expand edit on USER rows. On MANUAL and PLUGIN rows, the row-expand is **read-only** — shows the row, explains the source (`"Registered by GeneXpert analyzer plugin"` or `"System-provided default"`), and displays which tests currently use the method. No editable fields. |
+| FR-3 | Toolbar primary action **"Add method"** (P-03 Create modal): fields Name (1–120 chars, required), Description (0–500 chars, optional, Carbon `TextArea`), Active (Toggle, default ON). The server auto-assigns `method.code` as `METH-NNN` (zero-padded, monotonic) at create — the field is not entered, displayed, or editable in the UI. The created method has `source = 'USER'`. |
+| FR-4 | P-02 Inline row-expand edit on USER rows — Name, Description, Active. On MANUAL and PLUGIN rows, the row-expand is **read-only** — shows the row, explains the source (`"Registered by GeneXpert analyzer plugin"` or `"System-provided default"`), renders any Description (read-only) supplied by plugin registration or seed migration, and displays which tests currently use the method. No editable fields on MANUAL or PLUGIN rows. |
 | FR-5 | Delete (P-04 Confirm) is offered **only** on USER rows with `Used by = 0`. MANUAL and PLUGIN rows are never deletable. USER rows with usage show the delete button disabled with a tooltip identifying the blocking tests (`"Used by N tests — remove from each test first"`). |
-| FR-6 | Filter bar: filter by Source (All / Manual / User / Plugin — with a sub-select for specific plugin/analyzer). Search by code/name substring. Empty state P-06. |
+| FR-6 | Filter bar: filter by Source (All / Manual / User / Plugin — with a sub-select for specific plugin/analyzer). Search by name substring. Empty state P-06. |
 | FR-7 | Writes gated behind `TEST_CATALOG_MANAGE` (P-13). Users without the scope see the table read-only. |
 
 ### 3.3 Test row-expand — Methods section *(Sub-3)*
@@ -95,7 +106,7 @@ Location: inside the existing Test admin row-expand (Test Catalog → Test Manag
 | # | Requirement |
 |---|---|
 | FR-8 | New section **"Methods"** sits above the existing reporting range controls. A Carbon `DataTable` with columns: **Method · Source · Added on · actions**. Manual and analyzer-auto rows show their source Tag and no delete affordance. User-added rows show a Delete button (P-04 Confirm). |
-| FR-9 | Toolbar inside the Methods section — a single primary button **"Add method"** opens a modal with two stacked options: (a) **Pick existing** (a Carbon `ComboBox` filtered to methods not already on this test, excluding analyzer-scoped methods whose analyzer isn't mapped to this test); (b) **Create new** — inline form for Code / Name, creates a method with `source = 'USER'` and adds it to this test as `source = 'USER_ADDED'` in one action. |
+| FR-9 | Toolbar inside the Methods section — a single primary button **"Add method"** opens a modal with two stacked options: (a) **Pick existing** (a Carbon `ComboBox` filtered to methods not already on this test, excluding analyzer-scoped methods whose analyzer isn't mapped to this test; the picker shows method **Name** and the first ~80 chars of Description as secondary text); (b) **Create new** — inline form for Name (required) and Description (optional, 0–500 chars), creates a method with `source = 'USER'` and a server-assigned `code = 'METH-NNN'` and adds it to this test as `source = 'USER_ADDED'` in one action. |
 | FR-10 | Attempting to delete a row with `source = 'ANALYZER_AUTO'` is **blocked** with an inline banner: `"This method is provided by the [Analyzer name] analyzer mapping. To remove it, un-map the analyzer from this test."` (FR from directive answer C.ii) |
 | FR-11 | Attempting to delete a row with `source = 'MANUAL_DEFAULT'` is **blocked** with an inline banner: `"Manual is always available and cannot be removed."` |
 | FR-12 | When an analyzer mapping is added or removed from a test (elsewhere in Test admin), the Methods section reflects the change on next render: analyzer methods appear / disappear accordingly, along with their `test_method_range` rows (range rows follow the allowed-methods row lifecycle — removing an analyzer removes its range entries for this test). |
@@ -126,7 +137,7 @@ Location: inside the existing Test admin row-expand (Test Catalog → Test Manag
 | # | Requirement |
 |---|---|
 | FR-24 | When an analyzer plugin is enabled (analyzer configured for the instance), the analyzer's init hook calls a `MethodRegistry.register(analyzer, methods[])` service that upserts one `method` row per declared method, with `source = 'PLUGIN'`, `plugin_id = <plugin id>`, `analyzer_id = <analyzer id>`. |
-| FR-25 | Re-registration (same analyzer upgraded or re-initialized) updates name/active but never changes `code`. If a plugin removes a method in a new release, the `method` row is set to `active = false`, **not** deleted, to preserve history on existing tests. |
+| FR-25 | Re-registration (same analyzer upgraded or re-initialized) updates name, description, and active but never changes `code`. Plugin-supplied codes are persisted as-is (not re-mapped to the `METH-NNN` namespace) so analyzers that ship method codes as part of their integration contract remain stable. If a plugin removes a method in a new release, the `method` row is set to `active = false`, **not** deleted, to preserve history on existing tests. |
 | FR-26 | When an analyzer is mapped to a test (existing `test_analyzer_mapping` flow), the mapping service must insert one `test_method` row per `PLUGIN`-sourced method registered by that analyzer, with `source = 'ANALYZER_AUTO'`, `analyzer_mapping_id = <mapping id>`. |
 | FR-27 | When an analyzer is un-mapped from a test, cascade-remove the `ANALYZER_AUTO` rows with that `analyzer_mapping_id`. The corresponding `test_method_range` rows are removed in the same transaction. |
 
@@ -135,7 +146,7 @@ Location: inside the existing Test admin row-expand (Test Catalog → Test Manag
 | # | Requirement |
 |---|---|
 | FR-28 | The existing Test Catalog CSV import must be extended to carry methods assigned to each test and reporting ranges per method. Exact column schema is **deferred to build** (owner: Reagan — existing maintainer of the CSV importer; confirm with him during Sub-1 kickoff). |
-| FR-29 | Plugin-sourced methods in the CSV are accepted as an explicit assignment only if the referenced analyzer is currently mapped to the test; otherwise the row is rejected with a clear error. USER methods referenced by an unknown code are auto-created by the importer only if an optional `auto_create_methods` flag is passed; otherwise rejected. |
+| FR-29 | Plugin-sourced methods in the CSV are referenced by their plugin-supplied `method.code` and are accepted as an explicit assignment only if the referenced analyzer is currently mapped to the test; otherwise the row is rejected with a clear error. USER methods are referenced by `method.code` (`METH-NNN`) for round-trip stability — but because end users do not see codes in the admin UI, the importer SHOULD also accept a USER method by `name` (case-insensitive, exact match against `method.name` filtered to `source = 'USER'`) and reject ambiguous matches with a clear error. USER methods referenced by an unknown identifier are auto-created by the importer only if an optional `auto_create_methods` flag is passed (the new `method` row gets a server-assigned `METH-NNN` code); otherwise rejected. |
 | FR-30 | Export mirrors import. |
 
 ## 4. Out of Scope
@@ -192,11 +203,14 @@ All writes in §3.2–§3.4 and §3.7 require `TEST_CATALOG_MANAGE`. No new perm
 | `admin.testCatalog.methods.heading` | "Methods" |
 | `admin.testCatalog.methods.desc` | "Master catalog of methods used by this lab. Plugin-registered methods are read-only; create and manage your own methods here." |
 | `admin.testCatalog.methods.addCta` | "Add method" |
-| `admin.testCatalog.methods.col.code` | "Code" |
 | `admin.testCatalog.methods.col.name` | "Name" |
 | `admin.testCatalog.methods.col.source` | "Source" |
 | `admin.testCatalog.methods.col.usedBy` | "Used by" |
 | `admin.testCatalog.methods.col.status` | "Status" |
+| `admin.testCatalog.methods.field.name` | "Name" |
+| `admin.testCatalog.methods.field.description` | "Description" |
+| `admin.testCatalog.methods.field.descriptionHelp` | "What this method does, when to use it. Shown when picking a method on a test." |
+| `admin.testCatalog.methods.field.active` | "Active" |
 | `admin.testCatalog.methods.source.manual` | "Manual" |
 | `admin.testCatalog.methods.source.user` | "User" |
 | `admin.testCatalog.methods.source.plugin` | "Plugin: [analyzer]" |

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -227,7 +227,7 @@ export const MOCKUP_REGISTRY = [
     name: 'Reporting Ranges by Method',
     category: 'admin-config',
     component: React.lazy(() => import('@designs/admin-config/reporting-ranges-by-method.jsx')),
-    description: 'Per-method reporting ranges for Test Catalog — allowed-methods model per test, Methods admin page (P-01 table pattern), per-method range editor (inline row-expand), and CSV import extension. FRS v2.',
+    description: 'Per-method reporting ranges for Test Catalog (FRS v2, full spec). Methods as first-class concepts: master Methods admin page (MANUAL/USER/PLUGIN sources, P-01 table pattern), per-method reporting range grid in test row-expand (Sub-2 + Sub-3), method-aware range lookup in result entry (Sub-4). CSV import extension. Covers full epic scope across all three sub-issues.',
     specPath: 'designs/admin-config/reporting-ranges-by-method.md',
     htmlUrl: 'designs/admin-config/reporting-ranges-by-method.html',
     added: '2026-04-24',


### PR DESCRIPTION
## Changes

Promotes Reporting Ranges by Method from stub to full FRS v2, covering all three sub-issues:

- **Sub-2** — Master Methods admin page (MANUAL/USER/PLUGIN sources, P-01 table pattern, inline row-expand edit)
- **Sub-3** — Test Management row-expand: Methods section + per-method reporting range grid with "Apply to all" shortcut
- **Sub-4** — Result-entry method-aware range lookup with test-level fallback when no method range is configured
- CSV import extension

## Tests

210 / 210 pass