### PR TITLE
feat(S-03): v2.0 Step 1 amendment — Submitter, Program, CSV intake, p…

### DIFF
--- a/designs/sample-collection/environmental-order-entry.html
+++ b/designs/sample-collection/environmental-order-entry.html
@@ -232,6 +232,51 @@
     const REFERRAL = null; // set to { name:'Lab XYZ Bandung', fhirTaskId:'task-987' } to demo referral state
     const HAS_PARENT_SPECIMENS = false;
 
+    // ─── 2026-05-01 amendment: Submitter (Organization), Program (Questionnaire), Container Types ─
+    const ORGANIZATIONS = [
+      { id:'org-001', name:'Plaza Senayan Cooling Tower Operations', address:'Jl. Asia Afrika, Senayan, Jakarta', contact:'Bapak Andi · andi@psn.co.id · +62 21 555 0042', recent:14 },
+      { id:'org-002', name:'Dinas Pendidikan DKI Jakarta — Water Safety Program', address:'Jl. Gatot Subroto, Jakarta Selatan', contact:'Ibu Lestari · lestari@dinaspendidikan.dki.go.id · +62 21 555 0193', recent:48 },
+      { id:'org-003', name:'PT Inkindo Jaya — Discharge Compliance', address:'Bekasi Industrial Park', contact:'Ibu Siti · siti@inkindo.co.id', recent:6 },
+      { id:'org-004', name:'BAPPEDA Bogor — River Monitoring', address:'Jl. Pajajaran, Bogor', contact:'Pak Hadi · hadi@bappeda.bogor.go.id', recent:23 },
+    ];
+
+    const PROGRAMS = [
+      { id:'prog-001', name:'School Water Safety Program', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'school-name', label:'School Name', type:'text', required:true },
+          { code:'building-age', label:'Building Age (years)', type:'number', required:false },
+          { code:'last-plumbing-inspection', label:'Last Plumbing Inspection', type:'date', required:false },
+          { code:'student-count', label:'Approx. student count', type:'number', required:false },
+        ]},
+      { id:'prog-002', name:'Cooling Tower Compliance', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'tower-id', label:'Tower ID', type:'text', required:true },
+          { code:'loop-name', label:'Loop / Circuit', type:'select', options:['Open recirculating','Once-through','Closed loop','Make-up'], required:true },
+          { code:'last-cleaning-date', label:'Last cleaning / disinfection date', type:'date', required:false },
+        ]},
+      { id:'prog-003', name:'Industrial Discharge Monitoring', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'discharge-point', label:'Discharge Point ID', type:'text', required:true },
+          { code:'flow-rate', label:'Flow Rate (m³/h)', type:'number', required:false },
+          { code:'permit-number', label:'Discharge Permit Number', type:'text', required:false },
+        ]},
+    ];
+
+    // Container types live in OE Test Catalog → Env subsection. Seeded list, custom allowed.
+    const CONTAINER_TYPES = [
+      'Whirl-Pak bag',
+      'Glass amber bottle (250 mL)',
+      'Glass amber bottle (1 L)',
+      'Sterile polypropylene bottle (250 mL)',
+      'Sterile polypropylene bottle (1 L)',
+      'Vacuum sample bag (Tedlar)',
+      'Composite jerry can (5 L)',
+      'Composite jerry can (10 L)',
+      'Sediment trap jar',
+      'Filter cassette (47 mm)',
+      'Sterile cooler (insulated)',
+    ];
+
     // ─── App ─────────────────────────────────────────────────────
     function App() {
       const [step, setStep] = useState(0);
@@ -244,6 +289,99 @@
       const [deselected, setDeselected] = useState(new Set());
       const [showAddType, setShowAddType] = useState(false);
       const [showSwitch, setShowSwitch] = useState(null);
+
+      // 2026-05-01: Submitter (Organization)
+      const [submitter, setSubmitter] = useState(null);
+      const [submitterSearch, setSubmitterSearch] = useState('');
+
+      // 2026-05-01: Program (FHIR Questionnaire)
+      const [program, setProgram] = useState(null);
+      const [programResponses, setProgramResponses] = useState({});
+
+      // 2026-05-01: CSV bulk upload + per-sample manifest
+      const [sampleRowsManifest, setSampleRowsManifest] = useState([]);  // per-sample rows (NEW shape)
+      const [csvPreview, setCsvPreview] = useState(null);  // null when no CSV uploaded; otherwise { rows, summary }
+      const DEMO_CSV_PREVIEW = {
+        filename:'plaza_senayan_2026-05-01.csv',
+        template:'Standard',
+        rows:[
+          { row:1, sampleType:'Cooling Water', container:'Whirl-Pak bag', gps:'-6.2249, 106.7984', loc:'Tower A — return loop', addr:'Plaza Senayan, Jl. Asia Afrika', dt:'2026-05-01 07:42', collector:'Bapak Andi', status:'VALID', mismatchField:null },
+          { row:2, sampleType:'Cooling Water', container:'Whirl-Pak bag', gps:'-6.2251, 106.7986', loc:'Tower B — return loop', addr:'Plaza Senayan, Jl. Asia Afrika', dt:'2026-05-01 07:48', collector:'Bapak Andi', status:'VALID', mismatchField:null },
+          { row:3, sampleType:'creek_water', container:'Glass bottle 1L', gps:'-6.2255, 106.7990', loc:'Make-up source', addr:'Plaza Senayan', dt:'2026-05-01 07:53', collector:'Bapak Andi', status:'MISMATCH_TYPE', mismatchField:'sampleType' },
+          { row:4, sampleType:'Cooling Water', container:'Mason jar', gps:'-6.2249, 106.7980', loc:'Tower A — supply', addr:'Plaza Senayan', dt:'2026-05-01 07:55', collector:'Bapak Andi', status:'MISMATCH_CONT', mismatchField:'container' },
+        ],
+      };
+
+      const totalCsvRows = csvPreview?.rows.length || 0;
+      const validCsvRows = csvPreview?.rows.filter(r => r.status === 'VALID').length || 0;
+      const mismatchCsvRows = csvPreview?.rows.filter(r => r.status.startsWith('MISMATCH')).length || 0;
+
+      const importValidCsv = () => {
+        if (!csvPreview) return;
+        const valid = csvPreview.rows.filter(r => r.status === 'VALID');
+        setSampleRowsManifest(prev => [
+          ...prev,
+          ...valid.map((r, i) => ({
+            id:`csv-${Date.now()}-${i}`,
+            sampleType:r.sampleType,
+            container:r.container,
+            gps:r.gps,
+            loc:r.loc,
+            addr:r.addr,
+            dt:r.dt,
+            notes:'',
+          })),
+        ]);
+        // remove valid rows from preview, leave mismatches behind
+        setCsvPreview(p => ({ ...p, rows: p.rows.filter(r => r.status !== 'VALID') }));
+      };
+      const reconcileCsvRow = (rowId, field, value) => {
+        setCsvPreview(p => ({ ...p, rows: p.rows.map(r => r.row === rowId
+          ? { ...r, [field]:value, status:'VALID', mismatchField:null }
+          : r) }));
+      };
+      const addManifestRow = () => {
+        setSampleRowsManifest(prev => [...prev, {
+          id:`m-${Date.now()}`, sampleType:'', container:'', gps:'', loc:'', addr:'', dt:'', notes:'',
+        }]);
+      };
+      // 2026-05-01 (later same day): add N rows of a suggested sample type from regulation suggestions
+      const [suggestQty, setSuggestQty] = useState({});  // { sampleTypeId: number }
+      const addSuggestedRows = (sampleType, qty) => {
+        if (qty <= 0) return;
+        setSampleRowsManifest(prev => {
+          const next = [...prev];
+          for (let k = 0; k < qty; k++) {
+            next.push({
+              id:`m-${Date.now()}-${k}`,
+              sampleType:sampleType.name, container:'', gps:'', loc:'', addr:'', dt:'', notes:'',
+            });
+          }
+          return next;
+        });
+        setSuggestQty(prev => ({ ...prev, [sampleType.id]:0 }));
+      };
+      // Suggestions = deduped union of selected regulations' applicable sample types.
+      const regulationSuggestions = useMemo(() => {
+        if (branch !== 'REGULATION_DRIVEN' || standards.length === 0) return [];
+        const ids = new Set();
+        const out = [];
+        standards.forEach(s => (s.sampleTypeIds || []).forEach(stId => {
+          if (ids.has(stId)) return;
+          ids.add(stId);
+          const st = ALL_SAMPLE_TYPES.find(x => x.id === stId);
+          if (!st) return;
+          const coveringStds = standards.filter(x => (x.sampleTypeIds || []).includes(stId));
+          out.push({ ...st, coveringStds });
+        }));
+        return out;
+      }, [branch, standards]);
+      const updateManifestRow = (id, p) => {
+        setSampleRowsManifest(rows => rows.map(r => r.id === id ? { ...r, ...p } : r));
+      };
+      const removeManifestRow = (id) => {
+        setSampleRowsManifest(rows => rows.filter(r => r.id !== id));
+      };
 
       const [collMethod, setCollMethod] = useState('');
       const [waterT, setWaterT] = useState('');
@@ -323,8 +461,17 @@
       };
       const removeRow = (sid) => setManifest(m => m.filter(r => r.sampleTypeId !== sid));
 
-      const total = useMemo(() => manifest.reduce((s,r) => s + r.quantity, 0), [manifest]);
-      const activeTypes = useMemo(() => manifest.filter(r => r.quantity > 0).map(r => r.sampleTypeId), [manifest]);
+      // 2026-05-01: derive total + active sample types from new per-sample manifest rows.
+      // Match by sample type NAME against ALL_SAMPLE_TYPES catalog, since CSV/free-text rows store names.
+      const total = useMemo(() => sampleRowsManifest.length, [sampleRowsManifest]);
+      const activeTypes = useMemo(() => {
+        const seen = new Set();
+        sampleRowsManifest.forEach(r => {
+          const st = ALL_SAMPLE_TYPES.find(x => x.name.toLowerCase() === (r.sampleType || '').toLowerCase());
+          if (st) seen.add(st.id);
+        });
+        return Array.from(seen);
+      }, [sampleRowsManifest]);
 
       // 2026-04-29 (rewritten): Branch-aware test selection
       // — Regulation-driven: pre-loaded deduped Test Plan + blocked-by-missing-sample + add-extra
@@ -472,17 +619,21 @@
         : adhocSelectedCount;
 
       // ── Step 2 handlers ──
+      // 2026-05-01: advanceTo2 reads from per-sample manifest rows directly (one-to-one).
       const advanceTo2 = () => {
         const rows = [];
         let i = 1;
-        manifest.forEach(r => {
-          const st = ALL_SAMPLE_TYPES.find(s => s.id === r.sampleTypeId);
-          for (let k = 0; k < r.quantity; k++) {
-            rows.push({
-              id:`s-${i}`, idx:i, type:st,
-              accession:`ENV-2026-0412.${String(i).padStart(3,'0')}`,
-              barcode:'', dt:'', cond:'', storage:'',
-            });
+        sampleRowsManifest.forEach(r => {
+          const st = ALL_SAMPLE_TYPES.find(s => s.name.toLowerCase() === (r.sampleType || '').toLowerCase());
+          rows.push({
+            id:`s-${i}`, idx:i, type:st || { name:r.sampleType, code:'?' },
+            container:r.container, gps:r.gps, loc:r.loc, addr:r.addr,
+            accession:`ENV-2026-0412.${String(i).padStart(3,'0')}`,
+            barcode:'', dt:r.dt || '', cond:'', storage:'',
+          });
+          i++;
+          // dummy loop boundary preserved for diff stability
+          for (let k = 0; k < 0; k++) {
             i++;
           }
         });
@@ -544,15 +695,15 @@
             </div>
           </div>
 
-          {/* ── Lab Number + Domain Badge + Referral Tag (always) ─ */}
-          <div className="tile">
-            <div className="header-row">
-              <div className="lab-no form-field">
+          {/* ── Action Bar — Lab Number + Domain Badge + Referral Tag + Report NCE button (2026-05-01) ─ */}
+          <div className="tile" style={{ position:'sticky', top:0, zIndex:10, marginBottom:'1rem' }}>
+            <div className="header-row" style={{ display:'flex', alignItems:'flex-end', gap:16 }}>
+              <div className="lab-no form-field" style={{ marginBottom:0 }}>
                 <label>Lab Number</label>
                 <input type="text" value="ENV-2026-0412" readOnly />
                 <span className="helper">Auto-generated</span>
               </div>
-              <div className="badges">
+              <div className="badges" style={{ flex:1 }}>
                 <span className={`tag ${DOMAIN_TAGS[LAB_UNIT.domain]}`} title={`This order belongs to ${LAB_UNIT.name} (${LAB_UNIT.domain})`}>
                   {LAB_UNIT.domain}
                 </span>
@@ -560,6 +711,12 @@
                   <span className="tag tag-cyan">📥 Referral: {REFERRAL.name}</span>
                 )}
               </div>
+              {/* 2026-05-01: Report NCE button — opens existing OE NCE dialog scoped to order (or sample if a row is highlighted) */}
+              <button className="btn btn-ghost"
+                      style={{ border:'1px solid #da1e28', color:'#da1e28', fontSize:13 }}
+                      onClick={() => alert('Opens existing OE NCE dialog (scope: Order or Sample). No new dialog component — wires existing infra onto Step 1.')}>
+                ⚠ Report NCE
+              </button>
             </div>
           </div>
 
@@ -587,6 +744,50 @@
                   <p className="branch-helper">ⓘ Auto-set when order arrives from referral. You can override.</p>
                 )}
               </div>
+
+              {/* ── Submitter (Organization) — NEW 2026-05-01 ───────────── */}
+              {branch && (
+                <div className="tile">
+                  <h4>Submitter</h4>
+                  <p className="step-helper">The customer or program requesting this order. Maps to the existing OE Organization entity (mirrors clinical AMAP backend).</p>
+                  {!submitter ? (
+                    <div className="form-field" style={{ position:'relative' }}>
+                      <label>Organization *</label>
+                      <input type="text"
+                             placeholder="Search organizations…"
+                             value={submitterSearch}
+                             onChange={(e) => setSubmitterSearch(e.target.value)} />
+                      {submitterSearch && (
+                        <div style={{ position:'absolute', top:'100%', left:0, right:0, background:'#fff', border:'1px solid #e0e0e0', borderTop:'none', maxHeight:200, overflowY:'auto', zIndex:5 }}>
+                          {ORGANIZATIONS.filter(o => o.name.toLowerCase().includes(submitterSearch.toLowerCase())).map(o => (
+                            <div key={o.id} style={{ padding:'8px 12px', cursor:'pointer', borderBottom:'1px solid #f4f4f4' }}
+                                 onClick={() => { setSubmitter(o); setSubmitterSearch(''); }}>
+                              <div style={{ fontWeight:500 }}>{o.name}</div>
+                              <div style={{ fontSize:12, color:'#525252' }}>{o.address}</div>
+                            </div>
+                          ))}
+                          <div style={{ padding:'8px 12px', borderTop:'1px solid #e0e0e0', background:'#f4f4f4' }}>
+                            <a href="#" style={{ color:'#0f62fe', fontSize:13 }}>+ Create new Organization</a>
+                          </div>
+                        </div>
+                      )}
+                      <span className="helper">Existing OE Organization picker — same modal as clinical AMAP for create-new.</span>
+                    </div>
+                  ) : (
+                    <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, display:'flex', gap:16 }}>
+                      <div style={{ flex:1 }}>
+                        <div style={{ fontWeight:600 }}>{submitter.name}</div>
+                        <div style={{ fontSize:12, color:'#525252', marginTop:2 }}>{submitter.address}</div>
+                        <div style={{ fontSize:12, color:'#525252', marginTop:2 }}>{submitter.contact}</div>
+                        <div style={{ fontSize:11, color:'#525252', marginTop:6 }}>
+                          <span className="tag tag-blue" style={{ fontSize:10 }}>{submitter.recent} orders in last 90 days</span>
+                        </div>
+                      </div>
+                      <button className="btn btn-ghost" onClick={() => setSubmitter(null)}>Change</button>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Sampling Site (always when branch chosen) */}
               {branch && (
@@ -619,6 +820,54 @@
                       <button className="btn btn-ghost">✕ Clear</button>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {/* ── Program (FHIR Questionnaire — Optional) — NEW 2026-05-01 ── */}
+              {branch && (
+                <div className="tile">
+                  <h4>Program <span style={{ fontWeight:400, color:'#525252', fontSize:13 }}>(optional)</span></h4>
+                  <p className="step-helper">Select a program to capture program-specific metadata. Programs are configured in Admin → Programs and scoped to the env domain.</p>
+                  <div className="form-field">
+                    <label>Program</label>
+                    <select value={program?.id || ''}
+                            onChange={(e) => {
+                              const p = PROGRAMS.find(x => x.id === e.target.value);
+                              setProgram(p || null);
+                              setProgramResponses({});
+                            }}>
+                      <option value="">— No program —</option>
+                      {PROGRAMS.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+                    </select>
+                  </div>
+                  {program && (
+                    <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, marginTop:12 }}>
+                      <div style={{ fontSize:11, color:'#525252', letterSpacing:1, marginBottom:8, textTransform:'uppercase' }}>
+                        ⓘ Rendered from FHIR Questionnaire · {program.name}
+                      </div>
+                      <div className="grid grid-2" style={{ gap:12 }}>
+                        {program.questionnaire.map(q => (
+                          <div key={q.code} className="form-field" style={{ marginBottom:0 }}>
+                            <label>{q.label}{q.required && ' *'}</label>
+                            {q.type === 'select' ? (
+                              <select value={programResponses[q.code] || ''}
+                                      onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))}>
+                                <option value="">Select…</option>
+                                {q.options.map(o => <option key={o} value={o}>{o}</option>)}
+                              </select>
+                            ) : q.type === 'date' ? (
+                              <input type="date" value={programResponses[q.code] || ''}
+                                     onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))} />
+                            ) : (
+                              <input type={q.type === 'number' ? 'number' : 'text'}
+                                     value={programResponses[q.code] || ''}
+                                     onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))} />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -703,80 +952,227 @@
                 </div>
               )}
 
-              {/* Sample Manifest */}
+              {/* ── Sample Intake — CSV Bulk Upload + Per-Sample Manifest (rewritten 2026-05-01) ── */}
               {branch && (
                 <div className="tile">
-                  <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom:'1rem' }}>
-                    <h4 style={{ flex:1, marginBottom:0 }}>Sample Manifest</h4>
-                    <span className="file-uploader-stub">📎 Upload CSV manifest</span>
+                  <h4>Sample Intake</h4>
+                  <p className="step-helper">Upload a CSV of pre-collected samples (primary path), or add rows manually below. One row = one physical sample. Each row carries Container Type, GPS, Location Details, Address.</p>
+
+                  {/* ─ A. CSV Bulk Upload ─ */}
+                  <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, marginBottom:'1rem' }}>
+                    <div style={{ fontWeight:600, marginBottom:8 }}>A. CSV Bulk Upload</div>
+                    <div style={{ display:'flex', gap:16, marginBottom:12 }}>
+                      <div style={{ flex:1, padding:16, background:'#fff', border:'2px dashed #c6c6c6', textAlign:'center', borderRadius:4 }}>
+                        <div style={{ fontSize:13, fontWeight:500, marginBottom:6 }}>⬇ Download CSV Template</div>
+                        <div style={{ fontSize:11, color:'#525252', marginBottom:10 }}>Pre-formatted env columns (sample type, container type, GPS, location, address, collection date/time, collector, notes).</div>
+                        <div style={{ display:'flex', gap:6, justifyContent:'center', flexWrap:'wrap' }}>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #0f62fe' }}>Standard</button>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #c6c6c6', color:'#525252' }}>10×10 Box</button>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #c6c6c6', color:'#525252' }}>96-Well Plate</button>
+                        </div>
+                      </div>
+                      <div style={{ flex:1, padding:16, background:'#edf5ff', border:'2px dashed #0f62fe', textAlign:'center', borderRadius:4, cursor:'pointer' }}
+                           onClick={() => setCsvPreview(DEMO_CSV_PREVIEW)}>
+                        <div style={{ fontSize:13, fontWeight:500, marginBottom:6, color:'#0f62fe' }}>⬆ Upload CSV File</div>
+                        <div style={{ fontSize:11, color:'#525252' }}>Drag &amp; drop or click to browse.<br/>.csv up to 5 MB.</div>
+                        {!csvPreview && <div style={{ fontSize:10, color:'#525252', marginTop:8, fontStyle:'italic' }}>(click to load demo preview)</div>}
+                      </div>
+                    </div>
+
+                    {/* CSV Preview Table */}
+                    {csvPreview && (
+                      <div style={{ background:'#fff', border:'1px solid #e0e0e0', borderRadius:4 }}>
+                        <div style={{ padding:'10px 14px', background:'#f4f4f4', borderBottom:'1px solid #e0e0e0', display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+                          <div style={{ display:'flex', alignItems:'center', gap:8, fontSize:13 }}>
+                            <span style={{ fontWeight:500 }}>Preview: {csvPreview.filename}</span>
+                            <span className="tag tag-blue" style={{ fontSize:10 }}>{totalCsvRows} parsed</span>
+                            <span className="tag" style={{ background:'#defbe6', color:'#0e6027', fontSize:10 }}>{validCsvRows} valid</span>
+                            {mismatchCsvRows > 0 && <span className="tag" style={{ background:'#fcf4d6', color:'#684e00', fontSize:10 }}>{mismatchCsvRows} need attention</span>}
+                          </div>
+                          <button className="btn btn-ghost" style={{ fontSize:12 }} onClick={() => setCsvPreview(null)}>Clear</button>
+                        </div>
+                        {/* Bulk-apply banner for repeat mismatches */}
+                        {mismatchCsvRows > 0 && (
+                          <div style={{ padding:'8px 14px', background:'#fff8e1', borderBottom:'1px solid #f1c21b', fontSize:12, color:'#525252' }}>
+                            ⚡ <strong>Bulk fix:</strong> if multiple rows share the same unknown value, fix one and apply to all.
+                          </div>
+                        )}
+                        <div style={{ overflowX:'auto' }}>
+                          <table style={{ fontSize:11 }}>
+                            <thead>
+                              <tr>
+                                <th>#</th><th>Sample Type</th><th>Container</th><th>GPS</th><th>Location</th><th>Address</th><th>Status</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {csvPreview.rows.map(r => (
+                                <tr key={r.row} style={r.status !== 'VALID' ? { background:'#fff8e1' } : {}}>
+                                  <td>{r.row}</td>
+                                  <td>
+                                    {r.mismatchField === 'sampleType' ? (
+                                      <select style={{ border:'1px solid #da1e28', background:'#fff8e1', fontSize:11 }}
+                                              value=""
+                                              onChange={(e) => reconcileCsvRow(r.row, 'sampleType', e.target.value)}>
+                                        <option value="" disabled>⚠ {r.sampleType} — pick…</option>
+                                        <optgroup label="Suggested by selected regulation(s)">
+                                          {standards.flatMap(s => s.sampleTypeIds || []).filter((v,i,a) => a.indexOf(v) === i).map(stId => {
+                                            const st = ALL_SAMPLE_TYPES.find(x => x.id === stId);
+                                            return st ? <option key={stId} value={st.name}>{st.name}</option> : null;
+                                          })}
+                                        </optgroup>
+                                        <optgroup label="Or pick from full Test Catalog">
+                                          {ALL_SAMPLE_TYPES.map(st => <option key={st.id} value={st.name}>{st.name}</option>)}
+                                        </optgroup>
+                                      </select>
+                                    ) : r.sampleType}
+                                  </td>
+                                  <td>
+                                    {r.mismatchField === 'container' ? (
+                                      <select style={{ border:'1px solid #da1e28', background:'#fff8e1', fontSize:11 }}
+                                              value=""
+                                              onChange={(e) => reconcileCsvRow(r.row, 'container', e.target.value)}>
+                                        <option value="" disabled>⚠ {r.container} — pick…</option>
+                                        <optgroup label="OE Test Catalog → Env subsection">
+                                          {CONTAINER_TYPES.map(c => <option key={c} value={c}>{c}</option>)}
+                                        </optgroup>
+                                      </select>
+                                    ) : r.container}
+                                  </td>
+                                  <td><code style={{ fontSize:10 }}>{r.gps}</code></td>
+                                  <td>{r.loc}</td>
+                                  <td style={{ maxWidth:140, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{r.addr}</td>
+                                  <td>
+                                    {r.status === 'VALID' && <span style={{ color:'#0e6027' }}>✓ Valid</span>}
+                                    {r.status === 'MISMATCH_TYPE' && <span style={{ color:'#684e00' }}>⚠ Unknown type</span>}
+                                    {r.status === 'MISMATCH_CONT' && <span style={{ color:'#684e00' }}>⚠ Unknown container</span>}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                        <div style={{ padding:'10px 14px', borderTop:'1px solid #e0e0e0', display:'flex', gap:10, justifyContent:'flex-end' }}>
+                          <button className="btn btn-ghost" style={{ fontSize:12 }}>Fix Issues</button>
+                          <button className="btn btn-primary" style={{ fontSize:12 }}
+                                  onClick={importValidCsv}
+                                  disabled={validCsvRows === 0}>
+                            Import {validCsvRows} Valid Sample{validCsvRows === 1 ? '' : 's'}
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
 
-                  {manifest.length > 0 ? (
-                    <table>
-                      <thead>
-                        <tr>
-                          <th style={{ width:30 }}></th>
-                          <th>Sample Type</th>
-                          <th>Code</th>
-                          <th style={{ width:120 }}>Quantity</th>
-                          <th></th>
-                          <th style={{ width:30 }}></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {manifest.map(row => {
-                          const st = ALL_SAMPLE_TYPES.find(s => s.id === row.sampleTypeId);
+                  {/* ─ B. Per-Sample Manifest Table ─ */}
+                  <div style={{ fontWeight:600, marginBottom:8 }}>B. Per-Sample Manifest <span style={{ fontWeight:400, color:'#525252', fontSize:13 }}>(one row = one physical sample)</span></div>
+
+                  {/* 2026-05-01: Quick-add strip — regulation-suggested sample types with per-suggestion qty stepper.
+                      Pre-loaded; no click needed to reveal. Type a number, hit Add, and N rows appear below. */}
+                  {branch === 'REGULATION_DRIVEN' && regulationSuggestions.length > 0 && (
+                    <div style={{ background:'#f4f4f4', padding:'10px 14px', borderRadius:4, marginBottom:12 }}>
+                      <div style={{ fontSize:12, color:'#525252', marginBottom:8, letterSpacing:0.5 }}>
+                        ⚡ <strong>Quick-add from regulation suggestions</strong> · {standards.map(s => s.reg).join(' + ')} · type a count, hit Add to create N rows
+                      </div>
+                      <div style={{ display:'flex', flexWrap:'wrap', gap:8 }}>
+                        {regulationSuggestions.map(st => {
+                          const qty = suggestQty[st.id] || 0;
                           return (
-                            <tr key={row.sampleTypeId}>
-                              <td>
-                                <input type="checkbox" checked={row.quantity > 0}
-                                       onChange={(e) => setQty(row.sampleTypeId, e.target.checked ? (row.quantity || 1) : 0)} />
-                              </td>
-                              <td>{st?.name}</td>
-                              <td><code>{st?.code}</code></td>
-                              <td>
-                                <input type="number" min={0} max={999}
-                                       value={row.quantity}
-                                       onChange={(e) => setQty(row.sampleTypeId, e.target.value)} />
-                              </td>
-                              <td>
-                                {/* 2026-04-28: per-row coverage tags showing which standards include this sample type */}
-                                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-                                  {row.coverageStandardIds && row.coverageStandardIds.map(stdId => {
-                                    const std = STANDARDS.find(s => s.id === stdId);
-                                    return std ? <span key={stdId} className="tag tag-purple">{std.reg}</span> : null;
-                                  })}
-                                  {row.isOverride && <span className="tag tag-warm-gray">Not in any selected standard</span>}
-                                </div>
-                              </td>
-                              <td>
-                                <button className="btn-icon" title="Remove" onClick={() => removeRow(row.sampleTypeId)}>🗑</button>
-                              </td>
-                            </tr>
+                            <div key={st.id}
+                                 style={{ display:'flex', alignItems:'center', gap:6,
+                                          background:'#fff', border:'1px solid #e0e0e0', borderRadius:4,
+                                          padding:'6px 10px', fontSize:12 }}>
+                              <span style={{ fontWeight:500 }}>{st.name}</span>
+                              <div style={{ display:'flex', gap:2 }}>
+                                {st.coveringStds.map(s => (
+                                  <span key={s.id} className="tag tag-purple" style={{ fontSize:10, padding:'1px 6px' }}>{s.reg}</span>
+                                ))}
+                              </div>
+                              <input type="number" min={0} max={99}
+                                     value={qty}
+                                     onChange={(e) => setSuggestQty(p => ({ ...p, [st.id]:Math.max(0, parseInt(e.target.value) || 0) }))}
+                                     style={{ width:50, padding:'2px 6px', fontSize:12 }}
+                                     placeholder="0" />
+                              <button className="btn btn-ghost"
+                                      style={{ fontSize:11, padding:'2px 8px',
+                                               color: qty > 0 ? '#0f62fe' : '#a8a8a8',
+                                               border:'1px solid ' + (qty > 0 ? '#0f62fe' : '#e0e0e0') }}
+                                      onClick={() => addSuggestedRows(st, qty)}
+                                      disabled={qty <= 0}>
+                                + Add {qty || ''}
+                              </button>
+                            </div>
                           );
                         })}
-                      </tbody>
-                    </table>
-                  ) : (
-                    <p className="step-helper">
-                      {branch === 'REGULATION_DRIVEN'
-                        ? 'Select one or more compliance standards above to pre-populate sample types (union, deduplicated).'
-                        : 'Add sample types to begin.'}
-                    </p>
+                      </div>
+                    </div>
                   )}
 
+                  {sampleRowsManifest.length === 0 ? (
+                    <p className="step-helper" style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4 }}>
+                      No samples yet. Upload a CSV above, or click <strong>+ Add sample row</strong> below to start manually.
+                    </p>
+                  ) : (
+                    <div style={{ overflowX:'auto', border:'1px solid #e0e0e0', borderRadius:4 }}>
+                      <table style={{ fontSize:12 }}>
+                        <thead>
+                          <tr>
+                            <th>#</th><th>Sample Type</th><th>Container</th><th>GPS</th><th>Location Details</th><th>Address</th><th>Collected</th><th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sampleRowsManifest.map((r, i) => (
+                            <tr key={r.id}>
+                              <td>{i + 1}</td>
+                              <td>
+                                <input type="text" value={r.sampleType}
+                                       onChange={(e) => updateManifestRow(r.id, { sampleType:e.target.value })}
+                                       list="sample-types-list" style={{ width:140, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.container}
+                                       onChange={(e) => updateManifestRow(r.id, { container:e.target.value })}
+                                       list="container-types-list" style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.gps}
+                                       onChange={(e) => updateManifestRow(r.id, { gps:e.target.value })}
+                                       placeholder="lat, lon" style={{ width:130, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.loc}
+                                       onChange={(e) => updateManifestRow(r.id, { loc:e.target.value })}
+                                       style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.addr}
+                                       onChange={(e) => updateManifestRow(r.id, { addr:e.target.value })}
+                                       style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.dt}
+                                       onChange={(e) => updateManifestRow(r.id, { dt:e.target.value })}
+                                       placeholder="YYYY-MM-DD HH:mm" style={{ width:130, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <button className="btn-icon" title="Remove" onClick={() => removeManifestRow(r.id)}>🗑</button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      {/* datalists for type-ahead */}
+                      <datalist id="sample-types-list">
+                        {ALL_SAMPLE_TYPES.map(st => <option key={st.id} value={st.name} />)}
+                      </datalist>
+                      <datalist id="container-types-list">
+                        {CONTAINER_TYPES.map(c => <option key={c} value={c} />)}
+                      </datalist>
+                    </div>
+                  )}
                   <div style={{ display:'flex', alignItems:'center', gap:12, marginTop:'1rem' }}>
-                    {showAddType ? (
-                      <select onChange={(e) => e.target.value && addType(e.target.value)} defaultValue="">
-                        <option value="" disabled>Pick a sample type to add…</option>
-                        {ALL_SAMPLE_TYPES.filter(st => !manifest.find(m => m.sampleTypeId === st.id))
-                                         .map(st => <option key={st.id} value={st.id}>{st.name} ({st.code})</option>)}
-                      </select>
-                    ) : (
-                      <button className="btn btn-ghost" onClick={() => setShowAddType(true)}>+ Add Other Sample Type</button>
-                    )}
+                    <button className="btn btn-ghost" onClick={addManifestRow}>+ Add sample row</button>
                     <span style={{ flex:1 }} />
-                    <span className="total-samples"><strong>Total: {total} samples in this batch</strong></span>
+                    <span className="total-samples"><strong>Total: {sampleRowsManifest.length} sample{sampleRowsManifest.length === 1 ? '' : 's'} in this batch</strong></span>
                   </div>
                 </div>
               )}
@@ -784,12 +1180,12 @@
               {/* Test Selection — 2026-04-29 (rewritten): Branch-aware UX
                   Regulation: pre-loaded deduped Test Plan + blocked-by-missing-sample + add-extra
                   Ad-hoc: existing OE Panels + Tests two-stack
-                  Both gated behind ≥1 manifest row with quantity > 0 */}
-              {branch && activeTypes.length === 0 && manifest.length > 0 && (
+                  Both gated behind ≥1 per-sample manifest row with a recognized sample type (2026-05-01 amendment) */}
+              {branch && activeTypes.length === 0 && sampleRowsManifest.length > 0 && (
                 <div className="tile">
                   <h4>Test Selection</h4>
                   <p className="step-helper">
-                    Add a sample type with quantity ≥ 1 to the manifest above to choose tests.
+                    Add a sample row with a recognized Sample Type in the Sample Intake table above to choose tests.
                   </p>
                 </div>
               )}

--- a/designs/sample-collection/environmental-order-entry.jsx
+++ b/designs/sample-collection/environmental-order-entry.jsx
@@ -130,6 +130,66 @@ const BLANK_SUBTYPES = ['Field', 'Trip', 'Equipment', 'Method', 'Other'];
 
 const MOCK_STORAGE_LOCATIONS = ['Fridge A — Shelf 1', 'Fridge A — Shelf 2', 'Freezer B — Rack 3', 'Ambient Shelf C-12'];
 
+// 2026-05-01 amendment: Submitter (Organization) — mirrors clinical AMAP backend mapping.
+const MOCK_ORGANIZATIONS = [
+  { id: 'org-001', name: 'Plaza Senayan Cooling Tower Operations', address: 'Jl. Asia Afrika, Senayan, Jakarta', contact: 'Bapak Andi · andi@psn.co.id · +62 21 555 0042', recentOrderCount: 14 },
+  { id: 'org-002', name: 'Dinas Pendidikan DKI Jakarta — Water Safety Program', address: 'Jl. Gatot Subroto, Jakarta Selatan', contact: 'Ibu Lestari · lestari@dinaspendidikan.dki.go.id · +62 21 555 0193', recentOrderCount: 48 },
+  { id: 'org-003', name: 'PT Inkindo Jaya — Discharge Compliance', address: 'Bekasi Industrial Park', contact: 'Ibu Siti · siti@inkindo.co.id', recentOrderCount: 6 },
+  { id: 'org-004', name: 'BAPPEDA Bogor — River Monitoring', address: 'Jl. Pajajaran, Bogor', contact: 'Pak Hadi · hadi@bappeda.bogor.go.id', recentOrderCount: 23 },
+];
+
+// 2026-05-01 amendment: Programs are FHIR Questionnaire-driven optional dynamic field sets.
+// The Program admin (existing OE) gains a domain picker; this list filters to env-domain programs.
+const MOCK_PROGRAMS = [
+  { id: 'prog-001', name: 'School Water Safety Program', domain: 'ENVIRONMENTAL',
+    questionnaire: [
+      { code: 'school-name', label: 'School Name', type: 'text', required: true },
+      { code: 'building-age', label: 'Building Age (years)', type: 'number', required: false },
+      { code: 'last-plumbing-inspection', label: 'Last Plumbing Inspection', type: 'date', required: false },
+      { code: 'student-count', label: 'Approx. student count', type: 'number', required: false },
+    ]},
+  { id: 'prog-002', name: 'Cooling Tower Compliance', domain: 'ENVIRONMENTAL',
+    questionnaire: [
+      { code: 'tower-id', label: 'Tower ID', type: 'text', required: true },
+      { code: 'loop-name', label: 'Loop / Circuit', type: 'select', options: ['Open recirculating', 'Once-through', 'Closed loop', 'Make-up'], required: true },
+      { code: 'last-cleaning-date', label: 'Last cleaning / disinfection date', type: 'date', required: false },
+    ]},
+  { id: 'prog-003', name: 'Industrial Discharge Monitoring', domain: 'ENVIRONMENTAL',
+    questionnaire: [
+      { code: 'discharge-point', label: 'Discharge Point ID', type: 'text', required: true },
+      { code: 'flow-rate', label: 'Flow Rate (m³/h)', type: 'number', required: false },
+      { code: 'permit-number', label: 'Discharge Permit Number', type: 'text', required: false },
+    ]},
+];
+
+// 2026-05-01 amendment: Container Types live in OE Test Catalog → Env subsection.
+// Seeded list; admin can edit via Test Catalog admin; custom values flagged for review.
+const MOCK_CONTAINER_TYPES = [
+  'Whirl-Pak bag',
+  'Glass amber bottle (250 mL)',
+  'Glass amber bottle (1 L)',
+  'Sterile polypropylene bottle (250 mL)',
+  'Sterile polypropylene bottle (1 L)',
+  'Vacuum sample bag (Tedlar)',
+  'Composite jerry can (5 L)',
+  'Composite jerry can (10 L)',
+  'Sediment trap jar',
+  'Filter cassette (47 mm)',
+  'Sterile cooler (insulated)',
+];
+
+// 2026-05-01: demo CSV preview payload (rendered when user clicks "Upload CSV File")
+const DEMO_CSV_PREVIEW = {
+  filename: 'plaza_senayan_2026-05-01.csv',
+  template: 'Standard',
+  rows: [
+    { row: 1, sampleType: 'Cooling Water', container: 'Whirl-Pak bag', gps: '-6.2249, 106.7984', loc: 'Tower A — return loop', addr: 'Plaza Senayan, Jl. Asia Afrika', dt: '2026-05-01 07:42', collector: 'Bapak Andi', status: 'VALID', mismatchField: null },
+    { row: 2, sampleType: 'Cooling Water', container: 'Whirl-Pak bag', gps: '-6.2251, 106.7986', loc: 'Tower B — return loop', addr: 'Plaza Senayan, Jl. Asia Afrika', dt: '2026-05-01 07:48', collector: 'Bapak Andi', status: 'VALID', mismatchField: null },
+    { row: 3, sampleType: 'creek_water', container: 'Glass bottle 1L', gps: '-6.2255, 106.7990', loc: 'Make-up source', addr: 'Plaza Senayan', dt: '2026-05-01 07:53', collector: 'Bapak Andi', status: 'MISMATCH_TYPE', mismatchField: 'sampleType' },
+    { row: 4, sampleType: 'Cooling Water', container: 'Mason jar', gps: '-6.2249, 106.7980', loc: 'Tower A — supply', addr: 'Plaza Senayan', dt: '2026-05-01 07:55', collector: 'Bapak Andi', status: 'MISMATCH_CONT', mismatchField: 'container' },
+  ],
+};
+
 // Lab unit context (would come from session/lab config)
 const LAB_UNIT = { name: 'Env Lab — Jakarta', domain: 'Environmental' };
 
@@ -194,6 +254,24 @@ export default function EnvironmentalOrderEntryV2({
   const [manifest, setManifest] = useState([]);   // [{ sampleTypeId, quantity, coverageStandardIds: [], isOverride }]
   const [deselectedTestIds, setDeselectedTestIds] = useState(new Set());
   const [showAddSampleType, setShowAddSampleType] = useState(false);
+
+  // 2026-05-01 amendment: Submitter (Organization)
+  const [submitter, setSubmitter] = useState(null);
+
+  // 2026-05-01 amendment: Program (FHIR Questionnaire) — optional
+  const [program, setProgram] = useState(null);
+  const [programResponses, setProgramResponses] = useState({});
+
+  // 2026-05-01 amendment: per-sample manifest rows (replaces aggregate quantity table)
+  // Each row = one physical sample with Container Type, GPS, Location Details, Address
+  const [sampleRowsManifest, setSampleRowsManifest] = useState([]);
+  // [{ id, sampleType, container, gps, loc, addr, dt, notes }]
+
+  // 2026-05-01 amendment: CSV bulk upload preview state
+  const [csvPreview, setCsvPreview] = useState(null);  // null | { filename, template, rows }
+
+  // 2026-05-01 amendment: per-suggestion quick-add quantities (regulation-driven branch)
+  const [suggestQty, setSuggestQty] = useState({});  // { sampleTypeId: number }
 
   // Default collection conditions
   const [collectionMethod, setCollectionMethod] = useState('');
@@ -309,16 +387,21 @@ export default function EnvironmentalOrderEntryV2({
     setManifest(prev => prev.filter(r => r.sampleTypeId !== sampleTypeId));
   }, []);
 
+  // 2026-05-01: derived from new per-sample manifest (sampleRowsManifest).
+  // `totalSamples` = number of rows; `activeManifestSampleTypes` = unique sample type IDs found in the rows.
   const totalSamples = useMemo(
-    () => manifest.reduce((sum, r) => sum + (r.quantity || 0), 0),
-    [manifest],
+    () => sampleRowsManifest.length,
+    [sampleRowsManifest],
   );
 
-  // ── Suggested tests (regulation-driven) ──────────────────────────
-  const activeManifestSampleTypes = useMemo(
-    () => manifest.filter(r => r.quantity > 0).map(r => r.sampleTypeId),
-    [manifest],
-  );
+  const activeManifestSampleTypes = useMemo(() => {
+    const seen = new Set();
+    sampleRowsManifest.forEach(r => {
+      const st = ALL_SAMPLE_TYPES.find(x => x.name.toLowerCase() === (r.sampleType || '').toLowerCase());
+      if (st) seen.add(st.id);
+    });
+    return Array.from(seen);
+  }, [sampleRowsManifest]);
 
   // 2026-04-28 amendment: union + dedup tests across selectedStandards.
   // Each test in the result carries `coverageStandardIds: [stdId, ...]` showing which standards govern it.
@@ -360,34 +443,110 @@ export default function EnvironmentalOrderEntryV2({
     return n;
   }, [suggestedTestGroups, deselectedTestIds]);
 
-  // ── Step 2: generate sample rows from manifest ────────────────────
+  // ── Step 2: generate sample rows from per-sample manifest (2026-05-01) ───
+  // One manifest row → one Step 2 sample row (no aggregate quantity expansion).
+  // Per-sample fields (container, gps, loc, addr) carry forward.
   const generateSampleRows = useCallback(() => {
-    const rows = [];
-    let idx = 1;
-    manifest.forEach(r => {
-      const sampleType = ALL_SAMPLE_TYPES.find(st => st.id === r.sampleTypeId);
-      for (let i = 0; i < r.quantity; i++) {
-        rows.push({
-          id: `s-${idx}`,
-          rowIndex: idx,
-          sampleType,
-          accession: `ENV-2026-0412.${String(idx).padStart(3, '0')}`,
-          barcode: '',
-          collectionDateTime: '',
-          receiptCondition: '',
-          storageLocation: '',
-          notes: '',
-        });
-        idx++;
-      }
+    const rows = sampleRowsManifest.map((r, i) => {
+      const sampleType = ALL_SAMPLE_TYPES.find(st => st.name.toLowerCase() === (r.sampleType || '').toLowerCase())
+        || { id: 'unk', code: '?', name: r.sampleType };
+      return {
+        id: `s-${i + 1}`,
+        rowIndex: i + 1,
+        sampleType,
+        containerType: r.container,
+        gpsRaw: r.gps,
+        locationDetails: r.loc,
+        address: r.addr,
+        accession: `ENV-2026-0412.${String(i + 1).padStart(3, '0')}`,
+        barcode: '',
+        collectionDateTime: r.dt || '',
+        receiptCondition: '',
+        storageLocation: '',
+        notes: r.notes || '',
+      };
     });
     setSampleRows(rows);
-  }, [manifest]);
+  }, [sampleRowsManifest]);
 
   const advanceToStep2 = useCallback(() => {
     generateSampleRows();
     setCurrentStep(1);
   }, [generateSampleRows]);
+
+  // ── 2026-05-01 amendment handlers ────────────────────────────────
+  // Per-sample manifest add/update/remove
+  const addManifestRow = useCallback(() => {
+    setSampleRowsManifest(prev => [...prev, {
+      id: `m-${Date.now()}`, sampleType: '', container: '', gps: '', loc: '', addr: '', dt: '', notes: '',
+    }]);
+  }, []);
+  const updateManifestRow = useCallback((id, patch) => {
+    setSampleRowsManifest(prev => prev.map(r => r.id === id ? { ...r, ...patch } : r));
+  }, []);
+  const removeManifestRow = useCallback((id) => {
+    setSampleRowsManifest(prev => prev.filter(r => r.id !== id));
+  }, []);
+
+  // Quick-add: append N rows of a suggested sample type to the per-sample manifest
+  const addSuggestedRows = useCallback((sampleType, qty) => {
+    if (qty <= 0) return;
+    setSampleRowsManifest(prev => {
+      const next = [...prev];
+      for (let k = 0; k < qty; k++) {
+        next.push({
+          id: `m-${Date.now()}-${k}`,
+          sampleType: sampleType.name, container: '', gps: '', loc: '', addr: '', dt: '', notes: '',
+        });
+      }
+      return next;
+    });
+    setSuggestQty(prev => ({ ...prev, [sampleType.id]: 0 }));
+  }, []);
+
+  // CSV import: promote ✓ Valid rows into per-sample manifest; mismatches stay in preview
+  const importValidCsv = useCallback(() => {
+    if (!csvPreview) return;
+    const valid = csvPreview.rows.filter(r => r.status === 'VALID');
+    setSampleRowsManifest(prev => [
+      ...prev,
+      ...valid.map((r, i) => ({
+        id: `csv-${Date.now()}-${i}`,
+        sampleType: r.sampleType, container: r.container,
+        gps: r.gps, loc: r.loc, addr: r.addr,
+        dt: r.dt, notes: '',
+      })),
+    ]);
+    setCsvPreview(p => ({ ...p, rows: p.rows.filter(r => r.status !== 'VALID') }));
+  }, [csvPreview]);
+  const reconcileCsvRow = useCallback((rowId, field, value) => {
+    setCsvPreview(p => ({ ...p, rows: p.rows.map(r => r.row === rowId
+      ? { ...r, [field]: value, status: 'VALID', mismatchField: null }
+      : r) }));
+  }, []);
+
+  // Suggestions = deduped union of selected regulations' applicable sample types
+  const regulationSuggestions = useMemo(() => {
+    if (branch !== 'REGULATION_DRIVEN' || selectedStandards.length === 0) return [];
+    const seen = new Set();
+    const out = [];
+    selectedStandards.forEach(s => (s.applicableSampleTypes || s.sampleTypeIds || []).forEach(stId => {
+      if (seen.has(stId)) return;
+      seen.add(stId);
+      const st = ALL_SAMPLE_TYPES.find(x => x.id === stId);
+      if (!st) return;
+      const coveringStds = selectedStandards.filter(x => (x.applicableSampleTypes || x.sampleTypeIds || []).includes(stId));
+      out.push({ ...st, coveringStds });
+    }));
+    return out;
+  }, [branch, selectedStandards]);
+
+  // Report NCE click handler — opens existing OE NCE dialog (mocked here as alert)
+  const openReportNceDialog = useCallback(() => {
+    // Production: open the existing OE NCE dialog with scope = Sample (if a row is highlighted) or Order
+    // eslint-disable-next-line no-alert
+    alert('Opens existing OE NCE dialog (scope: Order, or Sample if a manifest row is highlighted). No new dialog component — wires existing infra onto Step 1.');
+  }, []);
 
   const updateSampleRow = useCallback((id, patch) => {
     setSampleRows(prev => prev.map(r => r.id === id ? { ...r, ...patch } : r));
@@ -469,8 +628,8 @@ export default function EnvironmentalOrderEntryV2({
         </ProgressIndicator>
       </Tile>
 
-      {/* ── Lab Number + Domain Badge + Referral Tag (always visible) ─ */}
-      <Tile style={{ marginBottom: 'var(--cds-spacing-05)' }}>
+      {/* ── Action Bar — Lab Number + Domain Badge + Referral Tag + Report NCE button (sticky, 2026-05-01) ─ */}
+      <Tile style={{ marginBottom: 'var(--cds-spacing-05)', position: 'sticky', top: 0, zIndex: 10 }}>
         <Grid>
           <Column lg={4} md={4} sm={4}>
             <TextInput
@@ -481,7 +640,7 @@ export default function EnvironmentalOrderEntryV2({
               helperText={t('label.order.labNumber.helper', 'Auto-generated')}
             />
           </Column>
-          <Column lg={4} md={4} sm={4} style={{ display: 'flex', alignItems: 'flex-end', gap: 'var(--cds-spacing-03)' }}>
+          <Column lg={8} md={4} sm={4} style={{ display: 'flex', alignItems: 'flex-end', gap: 'var(--cds-spacing-03)' }}>
             <Tag
               type={domainStyle.tagType}
               size="md"
@@ -494,6 +653,16 @@ export default function EnvironmentalOrderEntryV2({
                 {t('tag.order.referral', `Referral: ${referralSource.name}`)}
               </Tag>
             )}
+            <span style={{ flex: 1 }} />
+            {/* 2026-05-01: Report NCE — opens existing OE NCE dialog scoped to order (or sample if row highlighted) */}
+            <Button
+              kind="danger--ghost"
+              size="sm"
+              renderIcon={Warning}
+              onClick={openReportNceDialog}
+            >
+              {t('button.order.reportNce', 'Report NCE')}
+            </Button>
           </Column>
         </Grid>
       </Tile>
@@ -554,6 +723,47 @@ export default function EnvironmentalOrderEntryV2({
             )}
           </Tile>
 
+          {/* ── Submitter (Organization) — NEW 2026-05-01 ──────────────── */}
+          {branch && (
+            <Tile>
+              <h4 style={{ marginBottom: 'var(--cds-spacing-04)' }}>
+                {t('heading.order.submitter', 'Submitter')}
+              </h4>
+              <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-04)' }}>
+                {t('label.order.submitter.helper', 'The customer or program requesting this order. Maps to the existing OE Organization entity (mirrors clinical AMAP backend).')}
+              </p>
+              {!submitter ? (
+                <Stack gap={3}>
+                  <ComboBox
+                    id="submitter-org"
+                    titleText={t('label.order.submitter.org', 'Organization *')}
+                    placeholder={t('placeholder.submitter.org', 'Search organizations…')}
+                    items={MOCK_ORGANIZATIONS}
+                    itemToString={(o) => o ? o.name : ''}
+                    onChange={({ selectedItem }) => setSubmitter(selectedItem)}
+                  />
+                  <Button kind="ghost" size="sm" renderIcon={Add}>
+                    {t('button.submitter.create', '+ Create new Organization')}
+                  </Button>
+                </Stack>
+              ) : (
+                <Tile light style={{ padding: 'var(--cds-spacing-05)', display: 'flex', gap: 'var(--cds-spacing-04)' }}>
+                  <div style={{ flex: 1 }}>
+                    <p style={{ fontWeight: 600 }}>{submitter.name}</p>
+                    <p style={{ fontSize: '12px', color: 'var(--cds-text-secondary)', marginTop: 4 }}>{submitter.address}</p>
+                    <p style={{ fontSize: '12px', color: 'var(--cds-text-secondary)' }}>{submitter.contact}</p>
+                    <Tag type="blue" size="sm" style={{ marginTop: 6 }}>
+                      {submitter.recentOrderCount} orders in last 90 days
+                    </Tag>
+                  </div>
+                  <Button kind="ghost" size="sm" onClick={() => setSubmitter(null)}>
+                    {t('button.submitter.change', 'Change')}
+                  </Button>
+                </Tile>
+              )}
+            </Tile>
+          )}
+
           {/* ── Sampling Site (always) ───────────────────────────────── */}
           {branch && (
             <Tile>
@@ -594,6 +804,84 @@ export default function EnvironmentalOrderEntryV2({
                 </Tile>
               ) : (
                 <Button kind="tertiary" renderIcon={Search}>{t('button.site.search', 'Search for Site')}</Button>
+              )}
+            </Tile>
+          )}
+
+          {/* ── Program (FHIR Questionnaire — Optional) — NEW 2026-05-01 ──────── */}
+          {branch && (
+            <Tile>
+              <h4 style={{ marginBottom: 'var(--cds-spacing-04)' }}>
+                {t('heading.order.program', 'Program')}{' '}
+                <span style={{ fontWeight: 400, color: 'var(--cds-text-secondary)', fontSize: 13 }}>
+                  ({t('label.order.program.optional', 'optional')})
+                </span>
+              </h4>
+              <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-04)' }}>
+                {t('label.order.program.helper', 'Select a program to capture program-specific metadata. Programs are configured in Admin → Programs and scoped to the env domain.')}
+              </p>
+              <Select
+                id="program-picker"
+                labelText={t('label.order.program.label', 'Program')}
+                value={program?.id || ''}
+                onChange={(e) => {
+                  const p = MOCK_PROGRAMS.find(x => x.id === e.target.value);
+                  setProgram(p || null);
+                  setProgramResponses({});
+                }}
+              >
+                <SelectItem value="" text={t('placeholder.program.none', '— No program —')} />
+                {MOCK_PROGRAMS.map(p => <SelectItem key={p.id} value={p.id} text={p.name} />)}
+              </Select>
+              {program && (
+                <Tile light style={{ marginTop: 'var(--cds-spacing-04)', padding: 'var(--cds-spacing-05)' }}>
+                  <p style={{ fontSize: '11px', color: 'var(--cds-text-secondary)', letterSpacing: 1, marginBottom: 'var(--cds-spacing-04)', textTransform: 'uppercase' }}>
+                    <Information size={12} style={{ verticalAlign: 'middle' }} />{' '}
+                    {t('label.program.fhirQuestionnaire', `Rendered from FHIR Questionnaire · ${program.name}`)}
+                  </p>
+                  <Grid>
+                    {program.questionnaire.map(q => (
+                      <Column key={q.code} lg={8} md={4} sm={4} style={{ marginBottom: 'var(--cds-spacing-03)' }}>
+                        {q.type === 'select' ? (
+                          <Select
+                            id={`prog-q-${q.code}`}
+                            labelText={`${q.label}${q.required ? ' *' : ''}`}
+                            value={programResponses[q.code] || ''}
+                            onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]: e.target.value }))}
+                          >
+                            <SelectItem value="" text="Select…" />
+                            {q.options.map(o => <SelectItem key={o} value={o} text={o} />)}
+                          </Select>
+                        ) : q.type === 'date' ? (
+                          <DatePicker datePickerType="single" dateFormat="Y-m-d"
+                            value={programResponses[q.code] || ''}
+                            onChange={([d]) => setProgramResponses(r => ({ ...r, [q.code]: d ? d.toISOString().slice(0,10) : '' }))}>
+                            <DatePickerInput
+                              id={`prog-q-${q.code}`}
+                              labelText={`${q.label}${q.required ? ' *' : ''}`}
+                              placeholder="yyyy-mm-dd"
+                            />
+                          </DatePicker>
+                        ) : q.type === 'number' ? (
+                          <NumberInput
+                            id={`prog-q-${q.code}`}
+                            label={`${q.label}${q.required ? ' *' : ''}`}
+                            min={0}
+                            value={programResponses[q.code] || ''}
+                            onChange={(_, { value }) => setProgramResponses(r => ({ ...r, [q.code]: value }))}
+                          />
+                        ) : (
+                          <TextInput
+                            id={`prog-q-${q.code}`}
+                            labelText={`${q.label}${q.required ? ' *' : ''}`}
+                            value={programResponses[q.code] || ''}
+                            onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]: e.target.value }))}
+                          />
+                        )}
+                      </Column>
+                    ))}
+                  </Grid>
+                </Tile>
               )}
             </Tile>
           )}
@@ -692,110 +980,322 @@ export default function EnvironmentalOrderEntryV2({
             </Tile>
           )}
 
-          {/* ── Sample Manifest (always when branch chosen) ──────────── */}
+          {/* ── Sample Intake — CSV Bulk Upload + Per-Sample Manifest (rewritten 2026-05-01) ── */}
           {branch && (
             <Tile>
-              <Stack orientation="horizontal" gap={3} style={{ alignItems: 'center', marginBottom: 'var(--cds-spacing-04)' }}>
-                <h4 style={{ flex: 1 }}>{t('heading.order.sampleManifest', 'Sample Manifest')}</h4>
-                <FileUploader
-                  size="sm"
-                  buttonLabel={t('label.order.manifest.csvUpload', 'Upload CSV manifest')}
-                  accept={['.csv']}
-                  filenameStatus="edit"
-                />
-              </Stack>
+              <h4 style={{ marginBottom: 'var(--cds-spacing-03)' }}>
+                {t('heading.order.sampleIntake', 'Sample Intake')}
+              </h4>
+              <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-05)' }}>
+                {t('label.order.intake.helper', 'Upload a CSV of pre-collected samples (primary path), or add rows manually below. One row = one physical sample. Each row carries Container Type, GPS, Location Details, Address.')}
+              </p>
 
-              {manifest.length > 0 ? (
-                <Table size="md">
+              {/* ─ A. CSV Bulk Upload ─ */}
+              <Tile light style={{ marginBottom: 'var(--cds-spacing-05)', padding: 'var(--cds-spacing-05)' }}>
+                <p style={{ fontWeight: 600, marginBottom: 'var(--cds-spacing-03)' }}>
+                  {t('heading.intake.csvUpload', 'A. CSV Bulk Upload')}
+                </p>
+                <Grid style={{ marginBottom: 'var(--cds-spacing-04)' }}>
+                  <Column lg={8} md={4} sm={4}>
+                    <Tile light style={{ border: '2px dashed var(--cds-border-subtle)', textAlign: 'center', padding: 'var(--cds-spacing-05)' }}>
+                      <p style={{ fontSize: '14px', fontWeight: 500, marginBottom: 'var(--cds-spacing-02)' }}>
+                        ⬇ {t('label.intake.downloadTemplate', 'Download CSV Template')}
+                      </p>
+                      <p style={{ fontSize: '12px', color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-04)' }}>
+                        {t('label.intake.downloadTemplate.helper', 'Pre-formatted env columns: sample type, container type, GPS, location, address, collection date/time, collector, notes.')}
+                      </p>
+                      <Stack orientation="horizontal" gap={2} style={{ justifyContent: 'center', flexWrap: 'wrap' }}>
+                        <Button kind="tertiary" size="sm">{t('button.intake.template.standard', 'Standard')}</Button>
+                        <Button kind="ghost" size="sm">{t('button.intake.template.box', '10×10 Box')}</Button>
+                        <Button kind="ghost" size="sm">{t('button.intake.template.plate', '96-Well Plate')}</Button>
+                      </Stack>
+                    </Tile>
+                  </Column>
+                  <Column lg={8} md={4} sm={4}>
+                    <Tile light
+                      style={{ border: '2px dashed var(--cds-link-primary)', background: '#edf5ff', textAlign: 'center', padding: 'var(--cds-spacing-05)', cursor: 'pointer' }}
+                      onClick={() => setCsvPreview(DEMO_CSV_PREVIEW)}
+                    >
+                      <p style={{ fontSize: '14px', fontWeight: 500, marginBottom: 'var(--cds-spacing-02)', color: 'var(--cds-link-primary)' }}>
+                        ⬆ {t('label.intake.uploadCsv', 'Upload CSV File')}
+                      </p>
+                      <p style={{ fontSize: '12px', color: 'var(--cds-text-secondary)' }}>
+                        {t('label.intake.uploadCsv.helper', 'Drag & drop or click to browse. .csv up to 5 MB.')}
+                      </p>
+                      {!csvPreview && (
+                        <p style={{ fontSize: '11px', color: 'var(--cds-text-secondary)', marginTop: 8, fontStyle: 'italic' }}>
+                          (click to load demo preview)
+                        </p>
+                      )}
+                    </Tile>
+                  </Column>
+                </Grid>
+
+                {/* CSV Preview Table */}
+                {csvPreview && (() => {
+                  const valid = csvPreview.rows.filter(r => r.status === 'VALID').length;
+                  const mismatch = csvPreview.rows.filter(r => r.status.startsWith('MISMATCH')).length;
+                  return (
+                    <Tile light style={{ padding: 0, border: '1px solid var(--cds-border-subtle)' }}>
+                      <Stack orientation="horizontal" gap={2} style={{ alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--cds-border-subtle)', background: 'var(--cds-layer-accent)' }}>
+                        <p style={{ fontWeight: 500, fontSize: 13 }}>{t('label.intake.preview', `Preview: ${csvPreview.filename}`)}</p>
+                        <Tag type="blue" size="sm">{csvPreview.rows.length} parsed</Tag>
+                        <Tag type="green" size="sm">{valid} valid</Tag>
+                        {mismatch > 0 && <Tag type="warm-gray" size="sm">{mismatch} need attention</Tag>}
+                        <span style={{ flex: 1 }} />
+                        <Button kind="ghost" size="sm" onClick={() => setCsvPreview(null)}>Clear</Button>
+                      </Stack>
+                      {mismatch > 0 && (
+                        <InlineNotification
+                          kind="warning"
+                          lowContrast
+                          hideCloseButton
+                          title={t('label.intake.bulkFix.title', 'Bulk fix:')}
+                          subtitle={t('label.intake.bulkFix.subtitle', 'If multiple rows share the same unknown value, fix one and apply the same value to all matching rows.')}
+                          style={{ width: '100%', maxWidth: '100%' }}
+                        />
+                      )}
+                      <Table size="sm">
+                        <TableHead>
+                          <TableRow>
+                            <TableHeader>#</TableHeader>
+                            <TableHeader>Sample Type</TableHeader>
+                            <TableHeader>Container</TableHeader>
+                            <TableHeader>GPS</TableHeader>
+                            <TableHeader>Location</TableHeader>
+                            <TableHeader>Address</TableHeader>
+                            <TableHeader>Status</TableHeader>
+                          </TableRow>
+                        </TableHead>
+                        <TableBody>
+                          {csvPreview.rows.map(r => (
+                            <TableRow key={r.row} style={r.status !== 'VALID' ? { background: '#fff8e1' } : {}}>
+                              <TableCell>{r.row}</TableCell>
+                              <TableCell>
+                                {r.mismatchField === 'sampleType' ? (
+                                  <Select
+                                    id={`csv-type-${r.row}`}
+                                    labelText=""
+                                    hideLabel
+                                    size="sm"
+                                    invalid
+                                    invalidText={`⚠ Unknown: ${r.sampleType}`}
+                                    onChange={(e) => e.target.value && reconcileCsvRow(r.row, 'sampleType', e.target.value)}
+                                  >
+                                    <SelectItem value="" text={`⚠ ${r.sampleType} — pick…`} />
+                                    {ALL_SAMPLE_TYPES.map(st => <SelectItem key={st.id} value={st.name} text={st.name} />)}
+                                  </Select>
+                                ) : r.sampleType}
+                              </TableCell>
+                              <TableCell>
+                                {r.mismatchField === 'container' ? (
+                                  <Select
+                                    id={`csv-cont-${r.row}`}
+                                    labelText=""
+                                    hideLabel
+                                    size="sm"
+                                    invalid
+                                    invalidText={`⚠ Unknown: ${r.container}`}
+                                    onChange={(e) => e.target.value && reconcileCsvRow(r.row, 'container', e.target.value)}
+                                  >
+                                    <SelectItem value="" text={`⚠ ${r.container} — pick…`} />
+                                    {MOCK_CONTAINER_TYPES.map(c => <SelectItem key={c} value={c} text={c} />)}
+                                  </Select>
+                                ) : r.container}
+                              </TableCell>
+                              <TableCell><code style={{ fontSize: 11 }}>{r.gps}</code></TableCell>
+                              <TableCell>{r.loc}</TableCell>
+                              <TableCell style={{ maxWidth: 160, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.addr}</TableCell>
+                              <TableCell>
+                                {r.status === 'VALID' && <Tag type="green" size="sm">✓ Valid</Tag>}
+                                {r.status === 'MISMATCH_TYPE' && <Tag type="warm-gray" size="sm">⚠ Unknown type</Tag>}
+                                {r.status === 'MISMATCH_CONT' && <Tag type="warm-gray" size="sm">⚠ Unknown container</Tag>}
+                              </TableCell>
+                            </TableRow>
+                          ))}
+                        </TableBody>
+                      </Table>
+                      <Stack orientation="horizontal" gap={2} style={{ padding: '10px 14px', borderTop: '1px solid var(--cds-border-subtle)', justifyContent: 'flex-end' }}>
+                        <Button kind="ghost" size="sm">{t('button.intake.fixIssues', 'Fix Issues')}</Button>
+                        <Button
+                          kind="primary"
+                          size="sm"
+                          disabled={valid === 0}
+                          onClick={importValidCsv}
+                        >
+                          {t('button.intake.importValid', `Import ${valid} Valid Sample${valid === 1 ? '' : 's'}`)}
+                        </Button>
+                      </Stack>
+                    </Tile>
+                  );
+                })()}
+              </Tile>
+
+              {/* ─ B. Per-Sample Manifest Table ─ */}
+              <p style={{ fontWeight: 600, marginBottom: 'var(--cds-spacing-03)' }}>
+                {t('heading.intake.perSampleManifest', 'B. Per-Sample Manifest')}{' '}
+                <span style={{ fontWeight: 400, color: 'var(--cds-text-secondary)', fontSize: 13 }}>
+                  ({t('label.intake.perSample.subtitle', 'one row = one physical sample')})
+                </span>
+              </p>
+
+              {/* Quick-add strip — regulation-suggested sample types with per-suggestion qty stepper (NEW 2026-05-01) */}
+              {branch === 'REGULATION_DRIVEN' && regulationSuggestions.length > 0 && (
+                <Tile light style={{ padding: 'var(--cds-spacing-04)', marginBottom: 'var(--cds-spacing-04)' }}>
+                  <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-03)' }}>
+                    ⚡ <strong>{t('label.intake.quickAdd.title', 'Quick-add from regulation suggestions')}</strong>
+                    {' · '}{selectedStandards.map(s => s.regulationNumber).join(' + ')}
+                    {' · '}{t('label.intake.quickAdd.helper', 'type a count, hit Add to create N rows')}
+                  </p>
+                  <Stack orientation="horizontal" gap={2} style={{ flexWrap: 'wrap' }}>
+                    {regulationSuggestions.map(st => {
+                      const qty = suggestQty[st.id] || 0;
+                      return (
+                        <div key={st.id}
+                          style={{ display: 'flex', alignItems: 'center', gap: 6, background: 'var(--cds-background)', border: '1px solid var(--cds-border-subtle)', borderRadius: 4, padding: '6px 10px', fontSize: 12 }}
+                        >
+                          <span style={{ fontWeight: 500 }}>{st.name}</span>
+                          <Stack orientation="horizontal" gap={1}>
+                            {st.coveringStds.map(s => (
+                              <Tag key={s.id} type="purple" size="sm">{s.regulationNumber}</Tag>
+                            ))}
+                          </Stack>
+                          <NumberInput
+                            id={`qa-qty-${st.id}`}
+                            hideLabel
+                            label=""
+                            min={0}
+                            max={99}
+                            value={qty}
+                            size="sm"
+                            onChange={(_, { value }) => setSuggestQty(p => ({ ...p, [st.id]: Math.max(0, parseInt(value) || 0) }))}
+                            style={{ width: 70 }}
+                          />
+                          <Button
+                            kind="ghost"
+                            size="sm"
+                            disabled={qty <= 0}
+                            renderIcon={Add}
+                            onClick={() => addSuggestedRows(st, qty)}
+                          >
+                            {t('button.intake.quickAdd.add', `Add${qty ? ' ' + qty : ''}`)}
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </Stack>
+                </Tile>
+              )}
+
+              {/* Per-sample manifest table */}
+              {sampleRowsManifest.length === 0 ? (
+                <Tile light style={{ padding: 'var(--cds-spacing-05)' }}>
+                  <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)' }}>
+                    {t('label.intake.empty', 'No samples yet. Upload a CSV above, or click + Add sample row below to start manually.')}
+                  </p>
+                </Tile>
+              ) : (
+                <Table size="sm">
                   <TableHead>
                     <TableRow>
-                      <TableHeader style={{ width: '40px' }}></TableHeader>
-                      <TableHeader>{t('label.manifest.sampleType', 'Sample Type')}</TableHeader>
-                      <TableHeader>{t('label.manifest.code', 'Code')}</TableHeader>
-                      <TableHeader style={{ width: '120px' }}>{t('label.manifest.quantity', 'Quantity')}</TableHeader>
-                      <TableHeader></TableHeader>
-                      <TableHeader style={{ width: '40px' }}></TableHeader>
+                      <TableHeader style={{ width: 40 }}>#</TableHeader>
+                      <TableHeader>Sample Type</TableHeader>
+                      <TableHeader>Container</TableHeader>
+                      <TableHeader>GPS</TableHeader>
+                      <TableHeader>Location Details</TableHeader>
+                      <TableHeader>Address</TableHeader>
+                      <TableHeader>Collected</TableHeader>
+                      <TableHeader style={{ width: 40 }}></TableHeader>
                     </TableRow>
                   </TableHead>
                   <TableBody>
-                    {manifest.map(row => {
-                      const st = ALL_SAMPLE_TYPES.find(s => s.id === row.sampleTypeId);
-                      return (
-                        <TableRow key={row.sampleTypeId}>
-                          <TableCell>
-                            <Checkbox
-                              id={`mn-chk-${row.sampleTypeId}`}
-                              labelText=""
-                              checked={row.quantity > 0}
-                              onChange={(_, { checked }) => updateManifestQuantity(row.sampleTypeId, checked ? (row.quantity || 1) : 0)}
-                            />
-                          </TableCell>
-                          <TableCell>{st?.name}</TableCell>
-                          <TableCell><code style={{ fontSize: '12px' }}>{st?.code}</code></TableCell>
-                          <TableCell>
-                            <NumberInput
-                              id={`mn-qty-${row.sampleTypeId}`}
-                              hideLabel
-                              label=""
-                              min={0}
-                              max={999}
-                              value={row.quantity}
-                              onChange={(_, { value }) => updateManifestQuantity(row.sampleTypeId, value)}
-                              size="sm"
-                            />
-                          </TableCell>
-                          <TableCell>
-                            {/* 2026-04-28 amendment: per-row coverage tags showing which standards include this sample type */}
-                            <Stack orientation="horizontal" gap={1} style={{ flexWrap: 'wrap' }}>
-                              {row.coverageStandardIds && row.coverageStandardIds.map(stdId => {
-                                const std = MOCK_STANDARDS.find(s => s.id === stdId);
-                                return std ? <Tag key={stdId} type="purple" size="sm">{std.regulationNumber}</Tag> : null;
-                              })}
-                              {row.isOverride && <Tag type="warm-gray" size="sm">{t('tag.order.notInAnyStandard', 'Not in any selected standard')}</Tag>}
-                            </Stack>
-                          </TableCell>
-                          <TableCell>
-                            <IconButton
-                              kind="ghost"
-                              size="sm"
-                              label={t('button.manifest.remove', 'Remove')}
-                              onClick={() => removeManifestRow(row.sampleTypeId)}
-                            >
-                              <TrashCan />
-                            </IconButton>
-                          </TableCell>
-                        </TableRow>
-                      );
-                    })}
+                    {sampleRowsManifest.map((r, i) => (
+                      <TableRow key={r.id}>
+                        <TableCell>{i + 1}</TableCell>
+                        <TableCell>
+                          <ComboBox
+                            id={`mr-type-${r.id}`}
+                            titleText=""
+                            placeholder="Sample type"
+                            items={ALL_SAMPLE_TYPES}
+                            itemToString={(it) => it ? it.name : ''}
+                            initialSelectedItem={ALL_SAMPLE_TYPES.find(s => s.name === r.sampleType) || null}
+                            onChange={({ selectedItem }) => updateManifestRow(r.id, { sampleType: selectedItem?.name || '' })}
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <ComboBox
+                            id={`mr-cont-${r.id}`}
+                            titleText=""
+                            placeholder="Container"
+                            items={MOCK_CONTAINER_TYPES.map(c => ({ id: c, label: c }))}
+                            itemToString={(it) => it ? it.label : ''}
+                            initialSelectedItem={MOCK_CONTAINER_TYPES.includes(r.container) ? { id: r.container, label: r.container } : null}
+                            onChange={({ selectedItem }) => updateManifestRow(r.id, { container: selectedItem?.label || '' })}
+                            allowCustomValue
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <TextInput
+                            id={`mr-gps-${r.id}`}
+                            labelText=""
+                            hideLabel
+                            placeholder="lat, lon"
+                            value={r.gps}
+                            onChange={(e) => updateManifestRow(r.id, { gps: e.target.value })}
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <TextInput
+                            id={`mr-loc-${r.id}`}
+                            labelText=""
+                            hideLabel
+                            value={r.loc}
+                            onChange={(e) => updateManifestRow(r.id, { loc: e.target.value })}
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <TextInput
+                            id={`mr-addr-${r.id}`}
+                            labelText=""
+                            hideLabel
+                            value={r.addr}
+                            onChange={(e) => updateManifestRow(r.id, { addr: e.target.value })}
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <TextInput
+                            id={`mr-dt-${r.id}`}
+                            labelText=""
+                            hideLabel
+                            placeholder="YYYY-MM-DD HH:mm"
+                            value={r.dt}
+                            onChange={(e) => updateManifestRow(r.id, { dt: e.target.value })}
+                            size="sm"
+                          />
+                        </TableCell>
+                        <TableCell>
+                          <IconButton kind="ghost" size="sm" label="Remove" onClick={() => removeManifestRow(r.id)}>
+                            <TrashCan />
+                          </IconButton>
+                        </TableCell>
+                      </TableRow>
+                    ))}
                   </TableBody>
                 </Table>
-              ) : (
-                <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)', marginBottom: 'var(--cds-spacing-04)' }}>
-                  {branch === 'REGULATION_DRIVEN'
-                    ? t('label.order.manifest.empty.regulation', 'Select one or more compliance standards above to pre-populate sample types (union of each standard\'s applicable types, deduplicated).')
-                    : t('label.order.manifest.empty.adhoc', 'Add sample types to begin.')}
-                </p>
               )}
-
               <Stack orientation="horizontal" gap={3} style={{ marginTop: 'var(--cds-spacing-04)' }}>
-                {showAddSampleType ? (
-                  <ComboBox
-                    id="add-sample-type"
-                    items={ALL_SAMPLE_TYPES.filter(st => !manifest.find(m => m.sampleTypeId === st.id))}
-                    itemToString={(item) => item ? `${item.name} (${item.code})` : ''}
-                    titleText=""
-                    placeholder={t('placeholder.order.manifest.addSampleType', 'Pick a sample type to add…')}
-                    onChange={addOverrideSampleType}
-                    style={{ minWidth: '320px' }}
-                  />
-                ) : (
-                  <Button kind="ghost" size="sm" renderIcon={Add} onClick={() => setShowAddSampleType(true)}>
-                    {t('label.order.manifest.addOtherSampleType', 'Add Other Sample Type')}
-                  </Button>
-                )}
+                <Button kind="ghost" size="sm" renderIcon={Add} onClick={addManifestRow}>
+                  {t('button.intake.addRow', '+ Add sample row')}
+                </Button>
                 <span style={{ flex: 1 }} />
                 <p style={{ fontSize: '13px', color: 'var(--cds-text-secondary)' }}>
-                  <strong>{t('label.order.manifest.totalSamples', `Total: ${totalSamples} samples in this batch`)}</strong>
+                  <strong>{t('label.intake.totalSamples', `Total: ${sampleRowsManifest.length} sample${sampleRowsManifest.length === 1 ? '' : 's'} in this batch`)}</strong>
                 </p>
               </Stack>
             </Tile>

--- a/designs/sample-collection/environmental-order-entry.jsx
+++ b/designs/sample-collection/environmental-order-entry.jsx
@@ -383,7 +383,7 @@ export default function EnvironmentalOrderEntryV2({
     setShowAddSampleType(false);
   }, [selectedStandards]);
 
-  const removeManifestRow = useCallback((sampleTypeId) => {
+  const removeManifestType = useCallback((sampleTypeId) => {
     setManifest(prev => prev.filter(r => r.sampleTypeId !== sampleTypeId));
   }, []);
 

--- a/designs/sample-collection/environmental-order-entry.md
+++ b/designs/sample-collection/environmental-order-entry.md
@@ -1,13 +1,20 @@
 # Environmental Order Entry — Standalone (Domain-Assigned Lab)
 ## Functional Requirements Specification — v2.0
 
-**Version:** 2.0 (rewrite of v1.0)
-**Date:** 2026-04-25
+**Version:** 2.0 (rewrite of v1.0; amendments through 2026-05-01)
+**Date:** 2026-04-25 (last amended 2026-05-01)
 **Status:** Draft for Review
 **Jira:** [OGC-537](https://uwdigi.atlassian.net/browse/OGC-537) (under Vector epic [OGC-527](https://uwdigi.atlassian.net/browse/OGC-527))
 **Technology:** Java Spring Framework, Carbon React (`@carbon/react`)
-**Related Modules:** Compliance Standards Administration (S-01, OGC-528), Sampling Site Registry (S-02, OGC-531), Test Catalog (OGC-49), Storage Management (existing), NCE / Non-Conformance Events (existing)
+**Related Modules:** Compliance Standards Administration (S-01, OGC-528), Sampling Site Registry (S-02, OGC-531), **Organization Registry** (existing OE), Test Catalog (OGC-49) — env subsection for Container Types, **Program / Questionnaire Builder** (existing OE — amended for domain picker), Storage Management (existing), NCE / Non-Conformance Events (existing), Sample Collection Redesign (precedent for CSV bulk upload UX)
 **Supersedes:** v1.0 (which was framed as an "integration" extending a clinical baseline; v2.0 reframes as a standalone env order entry screen for domain-assigned labs)
+
+> **2026-05-01 amendment.** Step 1 gains five capabilities to align env order entry with the clinical AMAP backend shape and the Sample Collection Redesign's CSV intake UX. Summary:
+> 1. **Submitter** at order level → maps to the existing Organization entity (mirrors clinical AMAP backend; the customer/requestor for the entire order, e.g., "Plaza Senayan Cooling Tower Ops" or "Dinas Pendidikan DKI Jakarta — Water Safety Program"). New §5.1.12.
+> 2. **Program** at order level (optional) → renders a lab-configurable FHIR Questionnaire as inline dynamic fields (e.g., school name, building age, tower ID). The existing Program/Questionnaire Builder gains a domain picker so labs can scope a Program to ENVIRONMENTAL. New §5.1.13.
+> 3. **Sample Intake — CSV Bulk Upload + Per-Sample Manifest** (was §5.1.9 "Sample Manifest" — restructured). CSV upload is now first; the manifest is a per-sample row table (no longer aggregate quantity), with one row per physical sample. Each row carries new per-sample fields (see #4). When CSV sample types don't match or are missing, reception reconciles via bulk-or-individual apply from the regulation's suggested types OR the broader test catalog. Templates: Standard, 10×10 Box, 96-Well Plate (env-flavored).
+> 4. **Per-sample fields** (NEW columns on the manifest): GPS (free text), Location Details (free text), Address (free text), Container Type (ComboBox with type-ahead + custom — list lives in Test Catalog admin → Env subsection).
+> 5. **Report NCE button** in the page action bar — opens the existing OE NCE dialog scoped to the order (or a specific sample if one is highlighted). Mirrors QA-3 from Sample Collection Redesign. Reuses existing infrastructure.
 
 ---
 
@@ -128,19 +135,21 @@ Permissions reused from existing keys (no new permission keys introduced):
 **ID:** ENV-1-001
 **Priority:** P0
 **Requirement:**
-Step 1 SHALL render as a single-page form with all sections visible on one scroll. There is no in-page sub-wizard, no Next/Back navigation within Step 1. The page contains the following sections in order, with conditional rendering driven by the selected branch:
+Step 1 SHALL render as a single-page form with all sections visible on one scroll. There is no in-page sub-wizard, no Next/Back navigation within Step 1. The page contains the following sections in order, with conditional rendering driven by the selected branch (numbering reflects 2026-05-01 amendment):
 
-1. Lab Number + Domain Badge + Referral Tag (always)
+1. Action Bar — Lab Number + Domain Badge + Referral Tag + **Report NCE button** (always)
 2. Order Type Tile (always)
-3. Sampling Site (always)
-4. Compliance Standard (Regulation-driven branch only)
-5. Suggested Tests (Regulation-driven branch only — auto-populated; deselectable)
-6. Test Catalog Picker (Ad-hoc branch only)
-7. Regulatory Reference (Ad-hoc branch only — optional free-text)
-8. Sample Manifest (always — quantity table + CSV upload)
-9. Default Collection Conditions (always)
-10. Pool/Aliquot sub-section (referral-pre-filled orders with `Specimen.parent[]` only)
-11. Footer actions: Save Draft, Submit Order, Cancel
+3. **Submitter** (always — Organization)
+4. Sampling Site (always)
+5. **Program** (optional — renders a FHIR Questionnaire's dynamic fields when selected)
+6. Compliance Standard (Regulation-driven branch only)
+7. Test Selection (regulation-driven: pre-loaded plan; ad-hoc: full OE Order Panels + Order Tests picker)
+8. Regulatory Reference (Ad-hoc branch only — optional free-text)
+9. **Sample Intake** (always — A. CSV Bulk Upload, then B. Per-Sample Manifest table)
+10. Default Collection Conditions (always)
+11. Pool/Aliquot sub-section (referral-pre-filled orders with `Specimen.parent[]` only)
+12. Required-By date+time (GENERIC)
+13. Footer actions: Save Draft, Submit Order, Cancel
 
 **Acceptance Criteria:**
 
@@ -149,19 +158,21 @@ Step 1 SHALL render as a single-page form with all sections visible on one scrol
 - [ ] Carbon `Stack` and `Tile` components used for section grouping
 - [ ] Page is keyboard-navigable end-to-end via Tab key
 - [ ] WCAG 2.1 AA color contrast on all text + section borders
+- [ ] Action bar is sticky on scroll so the Report NCE button stays accessible from any section
 
 ---
 
-#### 5.1.2 Lab Number, Domain Badge, Referral Tag
+#### 5.1.2 Action Bar — Lab Number, Domain Badge, Referral Tag, Report NCE button
 
-**ID:** ENV-1-002
+**ID:** ENV-1-002 (amended 2026-05-01 — Report NCE button added)
 **Priority:** P0
 **Requirement:**
-The page header SHALL display:
+The page action bar SHALL be a sticky-on-scroll horizontal bar at the top of Step 1 displaying:
 
 - **Lab Number** — auto-generated, read-only TextInput (e.g., `ENV-2026-0412`). Format configurable per lab unit.
 - **Domain Badge** — Carbon `Tag` displayed adjacent to the Lab Number. Color and label reflect the lab unit's assigned domain: purple "Environmental", teal "Vector", blue "Clinical". Badge is always visible. Hover tooltip: "This order belongs to {Lab Name} ({Domain})". The badge persists on Steps 2 and 3 so reception can disambiguate when juggling orders across domains.
 - **Referral Tag** — Carbon `Tag` (kind="cyan") displayed only when the order originated from an inbound FHIR referral (`order.referralSource != null`). Label format: "Referral: {source lab name}". Click opens a side panel with the full referral payload for inspection.
+- **Report NCE button** (NEW 2026-05-01) — right-aligned Carbon `Button kind="ghost"` with the existing OE NCE icon. Clicking opens the existing OE NCE dialog scoped to the order. The dialog's existing scope selector (Sample / Order, per Sample Collection Redesign QA-3) lets reception flag a per-sample NCE if a specific sample row was highlighted on the page when the button was pressed. Reuses existing OE infrastructure — coded reasons, severity, accept-with-flag vs. reject decisions, audit trail. No new NCE component is introduced; this spec only mounts the button on Step 1.
 
 **Acceptance Criteria:**
 
@@ -171,6 +182,10 @@ The page header SHALL display:
 - [ ] Referral Tag renders only when `referralSource` is non-null
 - [ ] Referral Tag click opens the referral payload side panel
 - [ ] Tooltip on Domain Badge hover names the lab unit
+- [ ] Report NCE button is visible on Step 1 in the sticky action bar
+- [ ] Report NCE button opens the existing OE NCE dialog (no new dialog component)
+- [ ] When a per-sample row is focused/highlighted on the page, the dialog opens with scope = Sample for that row; otherwise scope = Order
+- [ ] Reuses the existing OE coded-reason picklist, severity, and reject/accept decisions verbatim
 
 ---
 
@@ -397,50 +412,131 @@ This field exists to capture audit-trail context when a paper requisition refere
 
 ---
 
-#### 5.1.9 Sample Manifest
+#### 5.1.9 Sample Intake — CSV Bulk Upload + Per-Sample Manifest (rewritten 2026-05-01)
 
-**ID:** ENV-1-009
+> **2026-05-01 restructure.** Was "Sample Manifest" — an aggregate quantity table (e.g., "5 × Surface Water"). Now restructured as a per-sample table (one row per physical sample) with CSV bulk upload as the primary intake path. Each manifest row carries new per-sample fields (GPS, Location Details, Address, Container Type) per the 2026-05-01 amendment. Uses the CSV Bulk Upload UX precedent established in the Sample Collection Redesign (COL-6 / COL-7 / COL-8 / COL-9).
+
+**ID:** ENV-1-009 (rewritten 2026-05-01)
 **Priority:** P0
 **Requirement:**
-The Sample Manifest section SHALL appear on both branches. It captures **how many of each sample type** are in this batch. The manifest can be entered three ways, all available simultaneously:
+The Sample Intake section SHALL appear on both branches and is composed of two stacked sub-sections — A. CSV Bulk Upload (primary intake) and B. Per-Sample Manifest (the resolved table reception works against). Manual entry alone is supported (no CSV); CSV upload populates the table and reception edits per row before submitting.
 
-**Entry method 1 — Sample Type Quantity Table (default):**
+##### 5.1.9.A CSV Bulk Upload
+
+**Templates.** Three downloadable CSV templates, env-flavored (precedent: Sample Collection Redesign COL-6):
+
+| Template | Use case | Required columns | Optional columns |
+|----------|----------|------------------|------------------|
+| **Standard (flat list)** | One row per sample, no spatial layout | `sample_type_code`, `container_type` | `gps`, `location_details`, `address`, `collection_dt`, `collector`, `notes` |
+| **10×10 Box Layout** | Pre-positioned samples in a storage box | `position` (e.g., `A3`), `sample_type_code`, `container_type` | same as Standard |
+| **96-Well Plate** | Plate-laid-out samples for high-throughput intake | `well` (e.g., `A1`–`H12`), `sample_type_code`, `container_type` | same as Standard |
+
+Each template downloads as `.csv` with header row, an example row, and column-comment lines explaining accepted values. Sample-type and container-type values may be supplied as a stable `code` (e.g., `st-001`, `cont-whirlpak`) or a human-readable `name` (e.g., `Surface Water`, `Whirl-Pak Bag`); the parser tries code first, then name.
+
+**Upload control.** A two-tile section (precedent: Sample Collection Redesign mockup §Bulk Import from CSV):
+
+- **Left tile — Download CSV Template:** three buttons (Standard / 10×10 Box / 96-Well Plate) wired to the corresponding template download endpoint.
+- **Right tile — Upload CSV File:** drag-and-drop area + click-to-browse. Accepts `.csv`, max 5 MB.
+
+**Preview + row-level validation.** On upload, the system parses the file and renders a preview DataTable with row-level status indicators:
+
+- ✓ Valid (green) — row passes all validation checks.
+- ⚠ Mismatch (yellow) — sample_type_code does not match a known sample type, OR container_type does not match a known container, OR a required column is missing/blank.
+- ✗ Error (red) — row is structurally malformed (e.g., bad date format, non-numeric where numeric required) and cannot be repaired inline.
+
+Status pill summary at the top of the preview: `{N} parsed · {V} valid · {W} need attention · {E} errors`. Cells with mismatches render as inline-editable widgets so reception can fix them in place — see §5.1.9.A.1 reconciliation UX below. Cells that are clean render read-only.
+
+**Sample-type reconciliation UX (§5.1.9.A.1).** When a CSV row's `sample_type_code` doesn't match a system type or is missing, the cell renders as an inline ComboBox with two reconciliation sources stacked in the dropdown:
 
 ```
-☑ Surface Water           [  5  ]   (Standard sample type)
-☑ Groundwater             [  3  ]
-☐ Drinking Water          [  0  ]
-☐ Effluent / Wastewater   [  0  ]
-[+ Add Other Sample Type]
+[ Choose sample type… ▾ ]
+┌────────────────────────────────────────────┐
+│ Suggested by selected regulation(s)         │
+│   • Surface Water (PP No. 22/2021)          │
+│   • Drinking Water (Permenkes 32/2017)      │
+│   • Cooling Water (PP No. 22/2021)          │
+│ ─────────────────────────────────────────── │
+│ Or pick from full Test Catalog               │
+│   [type to search…]                          │
+└────────────────────────────────────────────┘
 ```
 
-On the Regulation-driven branch, the table pre-populates with the **union of every selected standard's `applicableSampleTypes`**, deduplicated by sample type ID, all quantity 0. Each row is annotated with which standards include that sample type (small coverage Tags, like Suggested Tests in §5.1.6). Reception checks the types they have and enters quantities. "Add Other Sample Type" opens a ComboBox of the full system sample-type catalog; added types receive a `Tag` (kind="purple", label="Not in any selected standard") and a tooltip.
+Above the preview table when ≥ 2 rows share the same mismatch value, a banner offers a bulk action: **"2 rows have an unknown sample type 'creek_water'. [Apply same fix to all 2 rows ▾]"**. Selecting a value from the bulk dropdown applies it to every matching mismatch row in a single operation.
 
-On the Ad-hoc branch, the table starts empty; reception clicks "+ Add Sample Type" to add rows.
+The same reconciliation pattern applies to **Container Type** mismatches, drawing the suggestion list from the OE Test Catalog → Env subsection (the env-scoped container-type list maintained there) and the broader Test Catalog as fallback.
 
-**Entry method 2 — CSV bulk upload:**
-A `FileUploader` accepts a CSV manifest with columns: `sample_type_code, quantity, [optional collection_dt, optional collection_subsite, optional collection_notes]`. Upload parses the file, summarizes detected rows in a confirmation dialog ("Detected: 8 Surface Water, 3 Groundwater. Apply to manifest?"), and either populates or appends to the existing manifest based on user choice. Per-sample CSV columns (collection_dt, etc.) carry forward to Step 2 as pre-populated row values.
+**Action footer.** Two buttons:
 
-**Entry method 3 — Drag/drop or click-add inline rows:**
-"+ Add Sample Type" button at the bottom of the table adds a new row with a ComboBox in the type column.
+- **Fix Issues** — focuses the first unresolved mismatch row.
+- **Import {V} Valid Samples** — imports rows currently in ✓ Valid state into the per-sample manifest table (§5.1.9.B). Mismatch and error rows stay in the preview for reception to repair or discard. Reception can re-import after fixes by clicking the button again.
 
-**Total samples count** displayed below the table: "Total: {N} samples in this batch."
+##### 5.1.9.B Per-Sample Manifest Table
 
-**Validation:** at least one sample type with quantity ≥ 1 is required to submit Step 1. Quantity must be a positive integer; max 999 per type.
+After CSV import (or via manual "+ Add sample row" or via the regulation suggestion strip), each physical sample is represented by one row in the manifest table. There is no aggregate quantity column — quantity is implicit (one row per sample).
+
+**Quick-add strip — regulation-suggested sample types (NEW 2026-05-01).** When the order is on the Regulation-driven branch and ≥ 1 standard is selected, the deduped union of the standards' `applicableSampleTypes` SHALL render above the per-sample manifest table as a horizontal strip of suggestion chips. The strip is **pre-loaded — no click required to reveal**. Each chip shows:
+
+- Sample type name
+- Coverage tag(s) — which selected regulation(s) include this sample type
+- A small NumberInput (`0–99`) — the count of rows to add
+- An `+ Add {N}` button — when clicked, appends N rows of that sample type to the per-sample manifest, each with empty per-sample fields (Container Type, GPS, Location Details, Address) for reception to fill in. The NumberInput resets to `0` after the add.
+
+This gives reception two complementary intake paths on the Regulation-driven branch:
+
+| Path | Use case |
+|------|----------|
+| **CSV upload** (§5.1.9.A) | Pre-collected samples with full per-sample data already known offline (e.g., school courier with twelve labeled bottles) |
+| **Quick-add strip** (here) | Regulation-driven entry where reception types a count per suggested type, then fills in per-row details on the bench |
+| **+ Add sample row** | Manual addition of one row at a time; useful for ad-hoc samples or override types not in the regulation's suggestions |
+
+All three paths produce rows in the same per-sample manifest table; rows are indistinguishable after creation.
+
+| Column | Type | Required | Notes |
+|--------|------|----------|-------|
+| `#` | Auto | — | Row index, 1-based |
+| Sample Type | ComboBox | Yes | From OE sample-type catalog. Regulation-driven branch annotates with coverage Tags showing which regulation(s) include this type. Ad-hoc branch shows a "Not in any selected standard" Tag if applicable. |
+| **Container Type** | ComboBox + custom | Yes | **NEW (2026-05-01).** ComboBox with type-ahead from the OE Test Catalog → Env subsection's container-type list. Allow custom entry — typed values are persisted on the row but flagged for admin review. |
+| **GPS** | TextInput (free text) | No | **NEW (2026-05-01).** Free text, max 100 chars. Convention: `lat, lon` (e.g., `-6.1885, 106.8114`). Not validated for format — labs may capture `MGRS`, plus codes, or notes. |
+| **Location Details** | TextInput (free text) | No | **NEW (2026-05-01).** Free text, max 500 chars. Per-sample sub-site descriptor (e.g., `Tower A — return loop`, `North playground — by goalpost`). |
+| **Address** | TextInput (free text) | No | **NEW (2026-05-01).** Free text, max 500 chars. Per-sample street/postal address when distinct from the Sampling Site's address. |
+| Collection Date/Time | DateTimePicker | No (Step 1) | Optional in Step 1; required by Step 2. Carried forward from CSV when supplied. |
+| Notes | TextInput | No | Free text, max 255 chars. |
+| Actions | — | — | `🗑` row delete; row select for "highlight" so the Action Bar Report NCE button targets that row. |
+
+**Bulk-apply controls** above the table (mirror Sample Collection Redesign precedent):
+
+- "Apply Container Type to all" — applies the picked container to every row.
+- "Apply GPS to all" — for sites with a single coordinate.
+
+**"+ Add sample row"** at the bottom — adds an empty row with the Sample Type ComboBox open.
+
+**Total samples count** below the table: `Total: {N} samples in this batch.`
+
+**Validation:** ≥ 1 row with a valid Sample Type AND a valid Container Type is required to submit Step 1. Per-sample fields (GPS / Location / Address / Collection Date) are optional at Step 1 — Step 2 (Label & Store) flags any per-sample required-by-the-existing-OE-pattern omissions.
 
 **Acceptance Criteria:**
 
-- [ ] Table renders on both branches
-- [ ] Regulation-driven pre-populates with standard's applicable sample types (quantity 0)
-- [ ] Ad-hoc starts empty
-- [ ] Quantities accept positive integers up to 999
-- [ ] "Add Other Sample Type" opens system catalog ComboBox
-- [ ] Override sample types display "Not in Standard" tag (regulation-driven only)
-- [ ] CSV upload parses, summarizes, and asks before applying
-- [ ] CSV per-sample columns carry forward to Step 2
+- [ ] CSV templates download with env-flavored columns (Standard, 10×10 Box, 96-Well Plate)
+- [ ] CSV upload accepts `.csv` up to 5 MB via drag-drop or click-browse
+- [ ] Preview table shows row-level Valid / Mismatch / Error status with summary pills
+- [ ] Sample-type mismatch cells render an inline ComboBox with regulation-suggested types and full-catalog search
+- [ ] Container-type mismatch cells render an inline ComboBox sourced from the OE Test Catalog Env subsection
+- [ ] Bulk-apply banner appears when ≥ 2 rows share the same mismatch value, and applies the chosen value to every match
+- [ ] "Import N Valid Samples" promotes only ✓ Valid rows into the per-sample manifest table; mismatches and errors stay in the preview for repair
+- [ ] Per-sample manifest table renders one row per physical sample (no aggregate quantity column)
+- [ ] Each row supports Container Type, GPS, Location Details, Address, Collection Date/Time, and Notes
+- [ ] Container Type ComboBox is type-ahead from OE Test Catalog Env subsection with custom entry allowed
+- [ ] GPS / Location Details / Address are free-text; not format-validated
+- [ ] "Apply Container Type to all" and "Apply GPS to all" bulk controls work as described
+- [ ] "+ Add sample row" appends a new empty row
+- [ ] On the Regulation-driven branch, a quick-add strip pre-loads the deduped union of selected standards' applicable sample types, no click required to reveal
+- [ ] Each suggestion chip shows the sample type name, coverage tag(s), a NumberInput, and an "+ Add N" button
+- [ ] Clicking "+ Add N" appends N rows of that sample type to the per-sample manifest with empty per-sample fields
+- [ ] NumberInput resets to 0 after a successful add
 - [ ] Total samples count updates dynamically
-- [ ] At least one sample with quantity ≥ 1 required to submit
-- [ ] Suggested test list (regulation-driven) updates as manifest sample types change
+- [ ] ≥ 1 row with valid Sample Type AND Container Type required to submit
+- [ ] Manual entry without CSV is fully supported
+- [ ] CSV-imported rows are indistinguishable from manually-entered rows after import (same edit affordances)
 
 ---
 
@@ -497,6 +593,67 @@ This sub-section is hidden when the order has no parent specimens.
 - [ ] Local aliquot LABNOs follow the X-Y scheme
 - [ ] Deconvolution mapping table is visible
 - [ ] Hidden when no parent specimens are present
+
+---
+
+#### 5.1.12 Submitter (Organization) — NEW 2026-05-01
+
+**ID:** ENV-1-012
+**Priority:** P0
+**Requirement:**
+Every env order SHALL carry a **Submitter** — the customer/requestor for the entire order. The Submitter section appears below the Order Type tile and above Sampling Site, on both branches.
+
+**Backend mapping.** Submitter is stored as a foreign key to the existing OE **Organization** entity. This mirrors the clinical AMAP backend shape ("Add Many at Provider/Patient" — clinical multi-order screen uses the existing Organization entity for the requesting facility). No new entity, no new schema migration. The env screen reads/writes the same `order.requestingOrganizationId` column the clinical AMAP path writes to.
+
+**UI.** Carbon `ComboBox` with type-ahead against the active set of Organizations the user can see (per existing OE permission model). Beneath the ComboBox: a small **+ Create new Organization** affordance that opens the existing OE Organization create modal (no env-specific create flow — the existing modal handles all required fields). After creation, the new Organization is auto-selected on the Submitter ComboBox.
+
+**Selected Submitter Card.** When an Organization is picked, a Tile renders below the ComboBox showing: Organization name, address (if recorded), primary contact name + email + phone (if recorded), and a small "X orders in last 90 days" stat (from existing OE order history). Card has a `Change` button to re-open the picker.
+
+**Distinction from Sampling Site.** The Submitter is *who pays / requests* (e.g., `Plaza Senayan Cooling Tower Operations`); the Sampling Site is *where the samples come from* (e.g., site code `PSN-CT-01`). One Submitter may own many Sites; one Site may be sampled for multiple Submitters over time.
+
+**Validation.** Required to submit Step 1.
+
+**Acceptance Criteria:**
+
+- [ ] Submitter section renders on both branches between Order Type and Sampling Site
+- [ ] ComboBox provides type-ahead search of OE Organizations
+- [ ] "+ Create new Organization" opens the existing OE Organization create modal verbatim
+- [ ] Selected Submitter Card shows name, address, primary contact, recent order count
+- [ ] Selection persists in `order.requestingOrganizationId` (existing column, no new schema)
+- [ ] Required to submit Step 1
+- [ ] Mirrors clinical AMAP backend mapping (data parity)
+
+---
+
+#### 5.1.13 Program (FHIR Questionnaire — Optional) — NEW 2026-05-01
+
+**ID:** ENV-1-013
+**Priority:** P1
+**Requirement:**
+The Program section SHALL appear below Sampling Site and above Compliance Standard, on both branches, and is **optional**. When reception selects a Program, the system renders the Program's associated FHIR Questionnaire as inline dynamic fields, capturing program-specific metadata (e.g., school name + building age + last plumbing inspection for a "School Water Safety Program," or tower ID + loop name + last cleaning date for a "Cooling Tower Compliance" program).
+
+**Reuses existing OE Program/Questionnaire Builder.** The Program admin already exists in OpenELIS; this spec does **not** redesign it. The only amendment required upstream is a **domain picker** on the Program admin record so labs can scope a Program to `ENVIRONMENTAL` (or `CLINICAL` / `VECTOR` / `BOTH`). On the env order entry screen, the Program ComboBox filters to programs where `program.domain ∈ {ENVIRONMENTAL, BOTH}`.
+
+**UI.**
+- **ComboBox (`Program (optional)`)** — type-ahead from active env-domain Programs. Below the field: helper text *"Select a program to capture program-specific metadata. Programs are configured in Admin → Programs."*
+- When a Program is selected, the Questionnaire renders below the ComboBox as a **Tile** containing the dynamic field set. Field types come from the Questionnaire definition (text, number, date, select, boolean, attachment, etc.). All fields are saved as `order.programResponses` (a FHIR `QuestionnaireResponse` resource serialized into the order). Required fields (per the Questionnaire) block Step 1 submission with the same validation pattern used for OE's existing fields; optional fields don't.
+- **Change Program** button on the Tile re-opens the picker. Switching Programs prompts a confirmation if any answers were entered: "Switching programs will clear {N} program-specific answers. Continue?"
+- **Clear Program** removes the Program association and clears `programResponses`.
+
+**Persistence.** Stored as a FHIR `QuestionnaireResponse` linked to the order via `order.programResponseId`. The Questionnaire itself lives in the existing OE Questionnaire registry, versioned by the Program admin.
+
+**Acceptance Criteria:**
+
+- [ ] Program section renders on both branches between Sampling Site and Compliance Standard
+- [ ] ComboBox lists active Programs with `domain ∈ {ENVIRONMENTAL, BOTH}`
+- [ ] Selecting a Program renders its Questionnaire as inline dynamic fields
+- [ ] Required Questionnaire fields block Step 1 submission with field-level error
+- [ ] Optional Questionnaire fields don't block submission
+- [ ] Switching Programs with answers entered prompts a confirmation
+- [ ] Clearing the Program removes the association and the answers
+- [ ] Answers persist as a FHIR `QuestionnaireResponse` linked to the order
+
+**Upstream dependency:** Existing Program/Questionnaire Builder gains a `domain` picker (ENVIRONMENTAL / CLINICAL / VECTOR / BOTH). Tracked separately — small amendment, ~1 dev-day. Cross-reference with the Program admin Jira ticket (TBD).
 
 ---
 
@@ -677,11 +834,15 @@ Primary key: `(orderId, complianceStandardId)`. The join enforces "each regulati
 | `parentSpecimenIds` | String[] | No | For pool/aliquot referrals |
 | Default conditions: `defaultCollectionMethod`, `defaultWaterTemperature`, `defaultAmbientTemperature`, `defaultWeatherConditions`, `defaultPreservationMethod`, `defaultFieldNotes` | (various) | (varies) | Defaults applied to all samples |
 
-**Sample (extended):**
+**Sample (extended; per-sample fields added 2026-05-01):**
 
 | Field | Type | Required | Notes |
 |---|---|---|---|
 | `sampleType` | Enum/FK | Yes | From manifest |
+| `containerType` | String(100) | Yes | **NEW (2026-05-01).** Stable code from OE Test Catalog → Env subsection. Custom values allowed; flagged for admin review. |
+| `gpsRaw` | String(100) | No | **NEW (2026-05-01).** Free text; convention `lat, lon` but accepts MGRS / plus codes / labs' free notes. Not format-validated. |
+| `locationDetails` | String(500) | No | **NEW (2026-05-01).** Free text; per-sample sub-site descriptor. |
+| `address` | String(500) | No | **NEW (2026-05-01).** Free text; per-sample address when distinct from the Site's address. |
 | `accessionNumber` | String(50) | Yes | Auto or user-entered |
 | `barcode` | String(100) | Yes | Linked to accession |
 | `collectionDateTime` | Timestamp | Yes | Starts hold-time clock |
@@ -695,6 +856,14 @@ Primary key: `(orderId, complianceStandardId)`. The join enforces "each regulati
 | `qcExpectedValues` | JSON | No | qcType = CONTROL only; per-parameter expected values |
 | `qcBlankSubtype` | Enum | No | qcType = BLANK only: FIELD \| TRIP \| EQUIPMENT \| METHOD \| OTHER |
 | `nceId` | Long (FK) | No | Existing NCE entity reference |
+
+**Order (additions 2026-05-01):**
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `requestingOrganizationId` | Long (FK) | Yes | **NEW (2026-05-01).** FK → existing Organization entity. The Submitter — order-level customer/requestor. Mirrors clinical AMAP backend mapping (no new schema; this column already exists for clinical). |
+| `programId` | Long (FK) | No | **NEW (2026-05-01).** FK → existing Program entity (env-domain via the new `program.domain` field). |
+| `programResponseId` | Long (FK) | No | **NEW (2026-05-01).** FK → FHIR `QuestionnaireResponse` linked to the order. Populated when a Program is selected and its Questionnaire is answered. |
 
 ### 6.2 Database Schema Changes
 
@@ -736,6 +905,27 @@ ALTER TABLE sample ADD COLUMN storage_location_id BIGINT REFERENCES storage_loca
 ALTER TABLE sample ADD COLUMN hold_time_expires_at TIMESTAMP;
 ALTER TABLE sample ADD COLUMN qc_type VARCHAR(20);
 ALTER TABLE sample ADD COLUMN qc_parent_sample_id BIGINT REFERENCES sample(id);
+
+-- 2026-05-01 amendment: per-sample env fields (Container Type, GPS, Location Details, Address)
+ALTER TABLE sample ADD COLUMN container_type VARCHAR(100);
+ALTER TABLE sample ADD COLUMN gps_raw VARCHAR(100);
+ALTER TABLE sample ADD COLUMN location_details VARCHAR(500);
+ALTER TABLE sample ADD COLUMN address VARCHAR(500);
+
+-- 2026-05-01 amendment: order-level Submitter (reuses existing Organization),
+-- Program (env-domain), and Program response (FHIR QuestionnaireResponse).
+-- requesting_organization_id may already exist on the orders table from clinical AMAP;
+-- if so, this migration is a no-op for that column.
+ALTER TABLE orders ADD COLUMN IF NOT EXISTS requesting_organization_id BIGINT REFERENCES organization(id);
+ALTER TABLE orders ADD COLUMN program_id BIGINT REFERENCES program(id);
+ALTER TABLE orders ADD COLUMN program_response_id BIGINT REFERENCES questionnaire_response(id);
+CREATE INDEX idx_orders_requesting_organization ON orders(requesting_organization_id) WHERE requesting_organization_id IS NOT NULL;
+CREATE INDEX idx_orders_program ON orders(program_id) WHERE program_id IS NOT NULL;
+
+-- 2026-05-01 amendment: domain picker on Program (small upstream change)
+-- Owned by Program/Questionnaire Builder spec; included here for cross-reference.
+-- ALTER TABLE program ADD COLUMN domain VARCHAR(20) NOT NULL DEFAULT 'CLINICAL';
+-- (allowed values: CLINICAL, ENVIRONMENTAL, VECTOR, BOTH)
 ALTER TABLE sample ADD COLUMN qc_material_name VARCHAR(255);
 ALTER TABLE sample ADD COLUMN qc_material_source VARCHAR(255);
 ALTER TABLE sample ADD COLUMN qc_expected_values JSONB;

--- a/mockup-viewer/public/designs/sample-collection/environmental-order-entry.html
+++ b/mockup-viewer/public/designs/sample-collection/environmental-order-entry.html
@@ -232,6 +232,51 @@
     const REFERRAL = null; // set to { name:'Lab XYZ Bandung', fhirTaskId:'task-987' } to demo referral state
     const HAS_PARENT_SPECIMENS = false;
 
+    // ─── 2026-05-01 amendment: Submitter (Organization), Program (Questionnaire), Container Types ─
+    const ORGANIZATIONS = [
+      { id:'org-001', name:'Plaza Senayan Cooling Tower Operations', address:'Jl. Asia Afrika, Senayan, Jakarta', contact:'Bapak Andi · andi@psn.co.id · +62 21 555 0042', recent:14 },
+      { id:'org-002', name:'Dinas Pendidikan DKI Jakarta — Water Safety Program', address:'Jl. Gatot Subroto, Jakarta Selatan', contact:'Ibu Lestari · lestari@dinaspendidikan.dki.go.id · +62 21 555 0193', recent:48 },
+      { id:'org-003', name:'PT Inkindo Jaya — Discharge Compliance', address:'Bekasi Industrial Park', contact:'Ibu Siti · siti@inkindo.co.id', recent:6 },
+      { id:'org-004', name:'BAPPEDA Bogor — River Monitoring', address:'Jl. Pajajaran, Bogor', contact:'Pak Hadi · hadi@bappeda.bogor.go.id', recent:23 },
+    ];
+
+    const PROGRAMS = [
+      { id:'prog-001', name:'School Water Safety Program', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'school-name', label:'School Name', type:'text', required:true },
+          { code:'building-age', label:'Building Age (years)', type:'number', required:false },
+          { code:'last-plumbing-inspection', label:'Last Plumbing Inspection', type:'date', required:false },
+          { code:'student-count', label:'Approx. student count', type:'number', required:false },
+        ]},
+      { id:'prog-002', name:'Cooling Tower Compliance', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'tower-id', label:'Tower ID', type:'text', required:true },
+          { code:'loop-name', label:'Loop / Circuit', type:'select', options:['Open recirculating','Once-through','Closed loop','Make-up'], required:true },
+          { code:'last-cleaning-date', label:'Last cleaning / disinfection date', type:'date', required:false },
+        ]},
+      { id:'prog-003', name:'Industrial Discharge Monitoring', domain:'ENVIRONMENTAL',
+        questionnaire:[
+          { code:'discharge-point', label:'Discharge Point ID', type:'text', required:true },
+          { code:'flow-rate', label:'Flow Rate (m³/h)', type:'number', required:false },
+          { code:'permit-number', label:'Discharge Permit Number', type:'text', required:false },
+        ]},
+    ];
+
+    // Container types live in OE Test Catalog → Env subsection. Seeded list, custom allowed.
+    const CONTAINER_TYPES = [
+      'Whirl-Pak bag',
+      'Glass amber bottle (250 mL)',
+      'Glass amber bottle (1 L)',
+      'Sterile polypropylene bottle (250 mL)',
+      'Sterile polypropylene bottle (1 L)',
+      'Vacuum sample bag (Tedlar)',
+      'Composite jerry can (5 L)',
+      'Composite jerry can (10 L)',
+      'Sediment trap jar',
+      'Filter cassette (47 mm)',
+      'Sterile cooler (insulated)',
+    ];
+
     // ─── App ─────────────────────────────────────────────────────
     function App() {
       const [step, setStep] = useState(0);
@@ -244,6 +289,99 @@
       const [deselected, setDeselected] = useState(new Set());
       const [showAddType, setShowAddType] = useState(false);
       const [showSwitch, setShowSwitch] = useState(null);
+
+      // 2026-05-01: Submitter (Organization)
+      const [submitter, setSubmitter] = useState(null);
+      const [submitterSearch, setSubmitterSearch] = useState('');
+
+      // 2026-05-01: Program (FHIR Questionnaire)
+      const [program, setProgram] = useState(null);
+      const [programResponses, setProgramResponses] = useState({});
+
+      // 2026-05-01: CSV bulk upload + per-sample manifest
+      const [sampleRowsManifest, setSampleRowsManifest] = useState([]);  // per-sample rows (NEW shape)
+      const [csvPreview, setCsvPreview] = useState(null);  // null when no CSV uploaded; otherwise { rows, summary }
+      const DEMO_CSV_PREVIEW = {
+        filename:'plaza_senayan_2026-05-01.csv',
+        template:'Standard',
+        rows:[
+          { row:1, sampleType:'Cooling Water', container:'Whirl-Pak bag', gps:'-6.2249, 106.7984', loc:'Tower A — return loop', addr:'Plaza Senayan, Jl. Asia Afrika', dt:'2026-05-01 07:42', collector:'Bapak Andi', status:'VALID', mismatchField:null },
+          { row:2, sampleType:'Cooling Water', container:'Whirl-Pak bag', gps:'-6.2251, 106.7986', loc:'Tower B — return loop', addr:'Plaza Senayan, Jl. Asia Afrika', dt:'2026-05-01 07:48', collector:'Bapak Andi', status:'VALID', mismatchField:null },
+          { row:3, sampleType:'creek_water', container:'Glass bottle 1L', gps:'-6.2255, 106.7990', loc:'Make-up source', addr:'Plaza Senayan', dt:'2026-05-01 07:53', collector:'Bapak Andi', status:'MISMATCH_TYPE', mismatchField:'sampleType' },
+          { row:4, sampleType:'Cooling Water', container:'Mason jar', gps:'-6.2249, 106.7980', loc:'Tower A — supply', addr:'Plaza Senayan', dt:'2026-05-01 07:55', collector:'Bapak Andi', status:'MISMATCH_CONT', mismatchField:'container' },
+        ],
+      };
+
+      const totalCsvRows = csvPreview?.rows.length || 0;
+      const validCsvRows = csvPreview?.rows.filter(r => r.status === 'VALID').length || 0;
+      const mismatchCsvRows = csvPreview?.rows.filter(r => r.status.startsWith('MISMATCH')).length || 0;
+
+      const importValidCsv = () => {
+        if (!csvPreview) return;
+        const valid = csvPreview.rows.filter(r => r.status === 'VALID');
+        setSampleRowsManifest(prev => [
+          ...prev,
+          ...valid.map((r, i) => ({
+            id:`csv-${Date.now()}-${i}`,
+            sampleType:r.sampleType,
+            container:r.container,
+            gps:r.gps,
+            loc:r.loc,
+            addr:r.addr,
+            dt:r.dt,
+            notes:'',
+          })),
+        ]);
+        // remove valid rows from preview, leave mismatches behind
+        setCsvPreview(p => ({ ...p, rows: p.rows.filter(r => r.status !== 'VALID') }));
+      };
+      const reconcileCsvRow = (rowId, field, value) => {
+        setCsvPreview(p => ({ ...p, rows: p.rows.map(r => r.row === rowId
+          ? { ...r, [field]:value, status:'VALID', mismatchField:null }
+          : r) }));
+      };
+      const addManifestRow = () => {
+        setSampleRowsManifest(prev => [...prev, {
+          id:`m-${Date.now()}`, sampleType:'', container:'', gps:'', loc:'', addr:'', dt:'', notes:'',
+        }]);
+      };
+      // 2026-05-01 (later same day): add N rows of a suggested sample type from regulation suggestions
+      const [suggestQty, setSuggestQty] = useState({});  // { sampleTypeId: number }
+      const addSuggestedRows = (sampleType, qty) => {
+        if (qty <= 0) return;
+        setSampleRowsManifest(prev => {
+          const next = [...prev];
+          for (let k = 0; k < qty; k++) {
+            next.push({
+              id:`m-${Date.now()}-${k}`,
+              sampleType:sampleType.name, container:'', gps:'', loc:'', addr:'', dt:'', notes:'',
+            });
+          }
+          return next;
+        });
+        setSuggestQty(prev => ({ ...prev, [sampleType.id]:0 }));
+      };
+      // Suggestions = deduped union of selected regulations' applicable sample types.
+      const regulationSuggestions = useMemo(() => {
+        if (branch !== 'REGULATION_DRIVEN' || standards.length === 0) return [];
+        const ids = new Set();
+        const out = [];
+        standards.forEach(s => (s.sampleTypeIds || []).forEach(stId => {
+          if (ids.has(stId)) return;
+          ids.add(stId);
+          const st = ALL_SAMPLE_TYPES.find(x => x.id === stId);
+          if (!st) return;
+          const coveringStds = standards.filter(x => (x.sampleTypeIds || []).includes(stId));
+          out.push({ ...st, coveringStds });
+        }));
+        return out;
+      }, [branch, standards]);
+      const updateManifestRow = (id, p) => {
+        setSampleRowsManifest(rows => rows.map(r => r.id === id ? { ...r, ...p } : r));
+      };
+      const removeManifestRow = (id) => {
+        setSampleRowsManifest(rows => rows.filter(r => r.id !== id));
+      };
 
       const [collMethod, setCollMethod] = useState('');
       const [waterT, setWaterT] = useState('');
@@ -323,8 +461,17 @@
       };
       const removeRow = (sid) => setManifest(m => m.filter(r => r.sampleTypeId !== sid));
 
-      const total = useMemo(() => manifest.reduce((s,r) => s + r.quantity, 0), [manifest]);
-      const activeTypes = useMemo(() => manifest.filter(r => r.quantity > 0).map(r => r.sampleTypeId), [manifest]);
+      // 2026-05-01: derive total + active sample types from new per-sample manifest rows.
+      // Match by sample type NAME against ALL_SAMPLE_TYPES catalog, since CSV/free-text rows store names.
+      const total = useMemo(() => sampleRowsManifest.length, [sampleRowsManifest]);
+      const activeTypes = useMemo(() => {
+        const seen = new Set();
+        sampleRowsManifest.forEach(r => {
+          const st = ALL_SAMPLE_TYPES.find(x => x.name.toLowerCase() === (r.sampleType || '').toLowerCase());
+          if (st) seen.add(st.id);
+        });
+        return Array.from(seen);
+      }, [sampleRowsManifest]);
 
       // 2026-04-29 (rewritten): Branch-aware test selection
       // — Regulation-driven: pre-loaded deduped Test Plan + blocked-by-missing-sample + add-extra
@@ -472,17 +619,21 @@
         : adhocSelectedCount;
 
       // ── Step 2 handlers ──
+      // 2026-05-01: advanceTo2 reads from per-sample manifest rows directly (one-to-one).
       const advanceTo2 = () => {
         const rows = [];
         let i = 1;
-        manifest.forEach(r => {
-          const st = ALL_SAMPLE_TYPES.find(s => s.id === r.sampleTypeId);
-          for (let k = 0; k < r.quantity; k++) {
-            rows.push({
-              id:`s-${i}`, idx:i, type:st,
-              accession:`ENV-2026-0412.${String(i).padStart(3,'0')}`,
-              barcode:'', dt:'', cond:'', storage:'',
-            });
+        sampleRowsManifest.forEach(r => {
+          const st = ALL_SAMPLE_TYPES.find(s => s.name.toLowerCase() === (r.sampleType || '').toLowerCase());
+          rows.push({
+            id:`s-${i}`, idx:i, type:st || { name:r.sampleType, code:'?' },
+            container:r.container, gps:r.gps, loc:r.loc, addr:r.addr,
+            accession:`ENV-2026-0412.${String(i).padStart(3,'0')}`,
+            barcode:'', dt:r.dt || '', cond:'', storage:'',
+          });
+          i++;
+          // dummy loop boundary preserved for diff stability
+          for (let k = 0; k < 0; k++) {
             i++;
           }
         });
@@ -544,15 +695,15 @@
             </div>
           </div>
 
-          {/* ── Lab Number + Domain Badge + Referral Tag (always) ─ */}
-          <div className="tile">
-            <div className="header-row">
-              <div className="lab-no form-field">
+          {/* ── Action Bar — Lab Number + Domain Badge + Referral Tag + Report NCE button (2026-05-01) ─ */}
+          <div className="tile" style={{ position:'sticky', top:0, zIndex:10, marginBottom:'1rem' }}>
+            <div className="header-row" style={{ display:'flex', alignItems:'flex-end', gap:16 }}>
+              <div className="lab-no form-field" style={{ marginBottom:0 }}>
                 <label>Lab Number</label>
                 <input type="text" value="ENV-2026-0412" readOnly />
                 <span className="helper">Auto-generated</span>
               </div>
-              <div className="badges">
+              <div className="badges" style={{ flex:1 }}>
                 <span className={`tag ${DOMAIN_TAGS[LAB_UNIT.domain]}`} title={`This order belongs to ${LAB_UNIT.name} (${LAB_UNIT.domain})`}>
                   {LAB_UNIT.domain}
                 </span>
@@ -560,6 +711,12 @@
                   <span className="tag tag-cyan">📥 Referral: {REFERRAL.name}</span>
                 )}
               </div>
+              {/* 2026-05-01: Report NCE button — opens existing OE NCE dialog scoped to order (or sample if a row is highlighted) */}
+              <button className="btn btn-ghost"
+                      style={{ border:'1px solid #da1e28', color:'#da1e28', fontSize:13 }}
+                      onClick={() => alert('Opens existing OE NCE dialog (scope: Order or Sample). No new dialog component — wires existing infra onto Step 1.')}>
+                ⚠ Report NCE
+              </button>
             </div>
           </div>
 
@@ -587,6 +744,50 @@
                   <p className="branch-helper">ⓘ Auto-set when order arrives from referral. You can override.</p>
                 )}
               </div>
+
+              {/* ── Submitter (Organization) — NEW 2026-05-01 ───────────── */}
+              {branch && (
+                <div className="tile">
+                  <h4>Submitter</h4>
+                  <p className="step-helper">The customer or program requesting this order. Maps to the existing OE Organization entity (mirrors clinical AMAP backend).</p>
+                  {!submitter ? (
+                    <div className="form-field" style={{ position:'relative' }}>
+                      <label>Organization *</label>
+                      <input type="text"
+                             placeholder="Search organizations…"
+                             value={submitterSearch}
+                             onChange={(e) => setSubmitterSearch(e.target.value)} />
+                      {submitterSearch && (
+                        <div style={{ position:'absolute', top:'100%', left:0, right:0, background:'#fff', border:'1px solid #e0e0e0', borderTop:'none', maxHeight:200, overflowY:'auto', zIndex:5 }}>
+                          {ORGANIZATIONS.filter(o => o.name.toLowerCase().includes(submitterSearch.toLowerCase())).map(o => (
+                            <div key={o.id} style={{ padding:'8px 12px', cursor:'pointer', borderBottom:'1px solid #f4f4f4' }}
+                                 onClick={() => { setSubmitter(o); setSubmitterSearch(''); }}>
+                              <div style={{ fontWeight:500 }}>{o.name}</div>
+                              <div style={{ fontSize:12, color:'#525252' }}>{o.address}</div>
+                            </div>
+                          ))}
+                          <div style={{ padding:'8px 12px', borderTop:'1px solid #e0e0e0', background:'#f4f4f4' }}>
+                            <a href="#" style={{ color:'#0f62fe', fontSize:13 }}>+ Create new Organization</a>
+                          </div>
+                        </div>
+                      )}
+                      <span className="helper">Existing OE Organization picker — same modal as clinical AMAP for create-new.</span>
+                    </div>
+                  ) : (
+                    <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, display:'flex', gap:16 }}>
+                      <div style={{ flex:1 }}>
+                        <div style={{ fontWeight:600 }}>{submitter.name}</div>
+                        <div style={{ fontSize:12, color:'#525252', marginTop:2 }}>{submitter.address}</div>
+                        <div style={{ fontSize:12, color:'#525252', marginTop:2 }}>{submitter.contact}</div>
+                        <div style={{ fontSize:11, color:'#525252', marginTop:6 }}>
+                          <span className="tag tag-blue" style={{ fontSize:10 }}>{submitter.recent} orders in last 90 days</span>
+                        </div>
+                      </div>
+                      <button className="btn btn-ghost" onClick={() => setSubmitter(null)}>Change</button>
+                    </div>
+                  )}
+                </div>
+              )}
 
               {/* Sampling Site (always when branch chosen) */}
               {branch && (
@@ -619,6 +820,54 @@
                       <button className="btn btn-ghost">✕ Clear</button>
                     </div>
                   </div>
+                </div>
+              )}
+
+              {/* ── Program (FHIR Questionnaire — Optional) — NEW 2026-05-01 ── */}
+              {branch && (
+                <div className="tile">
+                  <h4>Program <span style={{ fontWeight:400, color:'#525252', fontSize:13 }}>(optional)</span></h4>
+                  <p className="step-helper">Select a program to capture program-specific metadata. Programs are configured in Admin → Programs and scoped to the env domain.</p>
+                  <div className="form-field">
+                    <label>Program</label>
+                    <select value={program?.id || ''}
+                            onChange={(e) => {
+                              const p = PROGRAMS.find(x => x.id === e.target.value);
+                              setProgram(p || null);
+                              setProgramResponses({});
+                            }}>
+                      <option value="">— No program —</option>
+                      {PROGRAMS.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
+                    </select>
+                  </div>
+                  {program && (
+                    <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, marginTop:12 }}>
+                      <div style={{ fontSize:11, color:'#525252', letterSpacing:1, marginBottom:8, textTransform:'uppercase' }}>
+                        ⓘ Rendered from FHIR Questionnaire · {program.name}
+                      </div>
+                      <div className="grid grid-2" style={{ gap:12 }}>
+                        {program.questionnaire.map(q => (
+                          <div key={q.code} className="form-field" style={{ marginBottom:0 }}>
+                            <label>{q.label}{q.required && ' *'}</label>
+                            {q.type === 'select' ? (
+                              <select value={programResponses[q.code] || ''}
+                                      onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))}>
+                                <option value="">Select…</option>
+                                {q.options.map(o => <option key={o} value={o}>{o}</option>)}
+                              </select>
+                            ) : q.type === 'date' ? (
+                              <input type="date" value={programResponses[q.code] || ''}
+                                     onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))} />
+                            ) : (
+                              <input type={q.type === 'number' ? 'number' : 'text'}
+                                     value={programResponses[q.code] || ''}
+                                     onChange={(e) => setProgramResponses(r => ({ ...r, [q.code]:e.target.value }))} />
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
                 </div>
               )}
 
@@ -703,80 +952,227 @@
                 </div>
               )}
 
-              {/* Sample Manifest */}
+              {/* ── Sample Intake — CSV Bulk Upload + Per-Sample Manifest (rewritten 2026-05-01) ── */}
               {branch && (
                 <div className="tile">
-                  <div style={{ display:'flex', alignItems:'center', gap:12, marginBottom:'1rem' }}>
-                    <h4 style={{ flex:1, marginBottom:0 }}>Sample Manifest</h4>
-                    <span className="file-uploader-stub">📎 Upload CSV manifest</span>
+                  <h4>Sample Intake</h4>
+                  <p className="step-helper">Upload a CSV of pre-collected samples (primary path), or add rows manually below. One row = one physical sample. Each row carries Container Type, GPS, Location Details, Address.</p>
+
+                  {/* ─ A. CSV Bulk Upload ─ */}
+                  <div style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4, marginBottom:'1rem' }}>
+                    <div style={{ fontWeight:600, marginBottom:8 }}>A. CSV Bulk Upload</div>
+                    <div style={{ display:'flex', gap:16, marginBottom:12 }}>
+                      <div style={{ flex:1, padding:16, background:'#fff', border:'2px dashed #c6c6c6', textAlign:'center', borderRadius:4 }}>
+                        <div style={{ fontSize:13, fontWeight:500, marginBottom:6 }}>⬇ Download CSV Template</div>
+                        <div style={{ fontSize:11, color:'#525252', marginBottom:10 }}>Pre-formatted env columns (sample type, container type, GPS, location, address, collection date/time, collector, notes).</div>
+                        <div style={{ display:'flex', gap:6, justifyContent:'center', flexWrap:'wrap' }}>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #0f62fe' }}>Standard</button>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #c6c6c6', color:'#525252' }}>10×10 Box</button>
+                          <button className="btn btn-ghost" style={{ fontSize:12, border:'1px solid #c6c6c6', color:'#525252' }}>96-Well Plate</button>
+                        </div>
+                      </div>
+                      <div style={{ flex:1, padding:16, background:'#edf5ff', border:'2px dashed #0f62fe', textAlign:'center', borderRadius:4, cursor:'pointer' }}
+                           onClick={() => setCsvPreview(DEMO_CSV_PREVIEW)}>
+                        <div style={{ fontSize:13, fontWeight:500, marginBottom:6, color:'#0f62fe' }}>⬆ Upload CSV File</div>
+                        <div style={{ fontSize:11, color:'#525252' }}>Drag &amp; drop or click to browse.<br/>.csv up to 5 MB.</div>
+                        {!csvPreview && <div style={{ fontSize:10, color:'#525252', marginTop:8, fontStyle:'italic' }}>(click to load demo preview)</div>}
+                      </div>
+                    </div>
+
+                    {/* CSV Preview Table */}
+                    {csvPreview && (
+                      <div style={{ background:'#fff', border:'1px solid #e0e0e0', borderRadius:4 }}>
+                        <div style={{ padding:'10px 14px', background:'#f4f4f4', borderBottom:'1px solid #e0e0e0', display:'flex', alignItems:'center', justifyContent:'space-between' }}>
+                          <div style={{ display:'flex', alignItems:'center', gap:8, fontSize:13 }}>
+                            <span style={{ fontWeight:500 }}>Preview: {csvPreview.filename}</span>
+                            <span className="tag tag-blue" style={{ fontSize:10 }}>{totalCsvRows} parsed</span>
+                            <span className="tag" style={{ background:'#defbe6', color:'#0e6027', fontSize:10 }}>{validCsvRows} valid</span>
+                            {mismatchCsvRows > 0 && <span className="tag" style={{ background:'#fcf4d6', color:'#684e00', fontSize:10 }}>{mismatchCsvRows} need attention</span>}
+                          </div>
+                          <button className="btn btn-ghost" style={{ fontSize:12 }} onClick={() => setCsvPreview(null)}>Clear</button>
+                        </div>
+                        {/* Bulk-apply banner for repeat mismatches */}
+                        {mismatchCsvRows > 0 && (
+                          <div style={{ padding:'8px 14px', background:'#fff8e1', borderBottom:'1px solid #f1c21b', fontSize:12, color:'#525252' }}>
+                            ⚡ <strong>Bulk fix:</strong> if multiple rows share the same unknown value, fix one and apply to all.
+                          </div>
+                        )}
+                        <div style={{ overflowX:'auto' }}>
+                          <table style={{ fontSize:11 }}>
+                            <thead>
+                              <tr>
+                                <th>#</th><th>Sample Type</th><th>Container</th><th>GPS</th><th>Location</th><th>Address</th><th>Status</th>
+                              </tr>
+                            </thead>
+                            <tbody>
+                              {csvPreview.rows.map(r => (
+                                <tr key={r.row} style={r.status !== 'VALID' ? { background:'#fff8e1' } : {}}>
+                                  <td>{r.row}</td>
+                                  <td>
+                                    {r.mismatchField === 'sampleType' ? (
+                                      <select style={{ border:'1px solid #da1e28', background:'#fff8e1', fontSize:11 }}
+                                              value=""
+                                              onChange={(e) => reconcileCsvRow(r.row, 'sampleType', e.target.value)}>
+                                        <option value="" disabled>⚠ {r.sampleType} — pick…</option>
+                                        <optgroup label="Suggested by selected regulation(s)">
+                                          {standards.flatMap(s => s.sampleTypeIds || []).filter((v,i,a) => a.indexOf(v) === i).map(stId => {
+                                            const st = ALL_SAMPLE_TYPES.find(x => x.id === stId);
+                                            return st ? <option key={stId} value={st.name}>{st.name}</option> : null;
+                                          })}
+                                        </optgroup>
+                                        <optgroup label="Or pick from full Test Catalog">
+                                          {ALL_SAMPLE_TYPES.map(st => <option key={st.id} value={st.name}>{st.name}</option>)}
+                                        </optgroup>
+                                      </select>
+                                    ) : r.sampleType}
+                                  </td>
+                                  <td>
+                                    {r.mismatchField === 'container' ? (
+                                      <select style={{ border:'1px solid #da1e28', background:'#fff8e1', fontSize:11 }}
+                                              value=""
+                                              onChange={(e) => reconcileCsvRow(r.row, 'container', e.target.value)}>
+                                        <option value="" disabled>⚠ {r.container} — pick…</option>
+                                        <optgroup label="OE Test Catalog → Env subsection">
+                                          {CONTAINER_TYPES.map(c => <option key={c} value={c}>{c}</option>)}
+                                        </optgroup>
+                                      </select>
+                                    ) : r.container}
+                                  </td>
+                                  <td><code style={{ fontSize:10 }}>{r.gps}</code></td>
+                                  <td>{r.loc}</td>
+                                  <td style={{ maxWidth:140, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap' }}>{r.addr}</td>
+                                  <td>
+                                    {r.status === 'VALID' && <span style={{ color:'#0e6027' }}>✓ Valid</span>}
+                                    {r.status === 'MISMATCH_TYPE' && <span style={{ color:'#684e00' }}>⚠ Unknown type</span>}
+                                    {r.status === 'MISMATCH_CONT' && <span style={{ color:'#684e00' }}>⚠ Unknown container</span>}
+                                  </td>
+                                </tr>
+                              ))}
+                            </tbody>
+                          </table>
+                        </div>
+                        <div style={{ padding:'10px 14px', borderTop:'1px solid #e0e0e0', display:'flex', gap:10, justifyContent:'flex-end' }}>
+                          <button className="btn btn-ghost" style={{ fontSize:12 }}>Fix Issues</button>
+                          <button className="btn btn-primary" style={{ fontSize:12 }}
+                                  onClick={importValidCsv}
+                                  disabled={validCsvRows === 0}>
+                            Import {validCsvRows} Valid Sample{validCsvRows === 1 ? '' : 's'}
+                          </button>
+                        </div>
+                      </div>
+                    )}
                   </div>
 
-                  {manifest.length > 0 ? (
-                    <table>
-                      <thead>
-                        <tr>
-                          <th style={{ width:30 }}></th>
-                          <th>Sample Type</th>
-                          <th>Code</th>
-                          <th style={{ width:120 }}>Quantity</th>
-                          <th></th>
-                          <th style={{ width:30 }}></th>
-                        </tr>
-                      </thead>
-                      <tbody>
-                        {manifest.map(row => {
-                          const st = ALL_SAMPLE_TYPES.find(s => s.id === row.sampleTypeId);
+                  {/* ─ B. Per-Sample Manifest Table ─ */}
+                  <div style={{ fontWeight:600, marginBottom:8 }}>B. Per-Sample Manifest <span style={{ fontWeight:400, color:'#525252', fontSize:13 }}>(one row = one physical sample)</span></div>
+
+                  {/* 2026-05-01: Quick-add strip — regulation-suggested sample types with per-suggestion qty stepper.
+                      Pre-loaded; no click needed to reveal. Type a number, hit Add, and N rows appear below. */}
+                  {branch === 'REGULATION_DRIVEN' && regulationSuggestions.length > 0 && (
+                    <div style={{ background:'#f4f4f4', padding:'10px 14px', borderRadius:4, marginBottom:12 }}>
+                      <div style={{ fontSize:12, color:'#525252', marginBottom:8, letterSpacing:0.5 }}>
+                        ⚡ <strong>Quick-add from regulation suggestions</strong> · {standards.map(s => s.reg).join(' + ')} · type a count, hit Add to create N rows
+                      </div>
+                      <div style={{ display:'flex', flexWrap:'wrap', gap:8 }}>
+                        {regulationSuggestions.map(st => {
+                          const qty = suggestQty[st.id] || 0;
                           return (
-                            <tr key={row.sampleTypeId}>
-                              <td>
-                                <input type="checkbox" checked={row.quantity > 0}
-                                       onChange={(e) => setQty(row.sampleTypeId, e.target.checked ? (row.quantity || 1) : 0)} />
-                              </td>
-                              <td>{st?.name}</td>
-                              <td><code>{st?.code}</code></td>
-                              <td>
-                                <input type="number" min={0} max={999}
-                                       value={row.quantity}
-                                       onChange={(e) => setQty(row.sampleTypeId, e.target.value)} />
-                              </td>
-                              <td>
-                                {/* 2026-04-28: per-row coverage tags showing which standards include this sample type */}
-                                <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4 }}>
-                                  {row.coverageStandardIds && row.coverageStandardIds.map(stdId => {
-                                    const std = STANDARDS.find(s => s.id === stdId);
-                                    return std ? <span key={stdId} className="tag tag-purple">{std.reg}</span> : null;
-                                  })}
-                                  {row.isOverride && <span className="tag tag-warm-gray">Not in any selected standard</span>}
-                                </div>
-                              </td>
-                              <td>
-                                <button className="btn-icon" title="Remove" onClick={() => removeRow(row.sampleTypeId)}>🗑</button>
-                              </td>
-                            </tr>
+                            <div key={st.id}
+                                 style={{ display:'flex', alignItems:'center', gap:6,
+                                          background:'#fff', border:'1px solid #e0e0e0', borderRadius:4,
+                                          padding:'6px 10px', fontSize:12 }}>
+                              <span style={{ fontWeight:500 }}>{st.name}</span>
+                              <div style={{ display:'flex', gap:2 }}>
+                                {st.coveringStds.map(s => (
+                                  <span key={s.id} className="tag tag-purple" style={{ fontSize:10, padding:'1px 6px' }}>{s.reg}</span>
+                                ))}
+                              </div>
+                              <input type="number" min={0} max={99}
+                                     value={qty}
+                                     onChange={(e) => setSuggestQty(p => ({ ...p, [st.id]:Math.max(0, parseInt(e.target.value) || 0) }))}
+                                     style={{ width:50, padding:'2px 6px', fontSize:12 }}
+                                     placeholder="0" />
+                              <button className="btn btn-ghost"
+                                      style={{ fontSize:11, padding:'2px 8px',
+                                               color: qty > 0 ? '#0f62fe' : '#a8a8a8',
+                                               border:'1px solid ' + (qty > 0 ? '#0f62fe' : '#e0e0e0') }}
+                                      onClick={() => addSuggestedRows(st, qty)}
+                                      disabled={qty <= 0}>
+                                + Add {qty || ''}
+                              </button>
+                            </div>
                           );
                         })}
-                      </tbody>
-                    </table>
-                  ) : (
-                    <p className="step-helper">
-                      {branch === 'REGULATION_DRIVEN'
-                        ? 'Select one or more compliance standards above to pre-populate sample types (union, deduplicated).'
-                        : 'Add sample types to begin.'}
-                    </p>
+                      </div>
+                    </div>
                   )}
 
+                  {sampleRowsManifest.length === 0 ? (
+                    <p className="step-helper" style={{ background:'#f4f4f4', padding:'12px 16px', borderRadius:4 }}>
+                      No samples yet. Upload a CSV above, or click <strong>+ Add sample row</strong> below to start manually.
+                    </p>
+                  ) : (
+                    <div style={{ overflowX:'auto', border:'1px solid #e0e0e0', borderRadius:4 }}>
+                      <table style={{ fontSize:12 }}>
+                        <thead>
+                          <tr>
+                            <th>#</th><th>Sample Type</th><th>Container</th><th>GPS</th><th>Location Details</th><th>Address</th><th>Collected</th><th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {sampleRowsManifest.map((r, i) => (
+                            <tr key={r.id}>
+                              <td>{i + 1}</td>
+                              <td>
+                                <input type="text" value={r.sampleType}
+                                       onChange={(e) => updateManifestRow(r.id, { sampleType:e.target.value })}
+                                       list="sample-types-list" style={{ width:140, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.container}
+                                       onChange={(e) => updateManifestRow(r.id, { container:e.target.value })}
+                                       list="container-types-list" style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.gps}
+                                       onChange={(e) => updateManifestRow(r.id, { gps:e.target.value })}
+                                       placeholder="lat, lon" style={{ width:130, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.loc}
+                                       onChange={(e) => updateManifestRow(r.id, { loc:e.target.value })}
+                                       style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.addr}
+                                       onChange={(e) => updateManifestRow(r.id, { addr:e.target.value })}
+                                       style={{ width:160, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <input type="text" value={r.dt}
+                                       onChange={(e) => updateManifestRow(r.id, { dt:e.target.value })}
+                                       placeholder="YYYY-MM-DD HH:mm" style={{ width:130, fontSize:12 }} />
+                              </td>
+                              <td>
+                                <button className="btn-icon" title="Remove" onClick={() => removeManifestRow(r.id)}>🗑</button>
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      {/* datalists for type-ahead */}
+                      <datalist id="sample-types-list">
+                        {ALL_SAMPLE_TYPES.map(st => <option key={st.id} value={st.name} />)}
+                      </datalist>
+                      <datalist id="container-types-list">
+                        {CONTAINER_TYPES.map(c => <option key={c} value={c} />)}
+                      </datalist>
+                    </div>
+                  )}
                   <div style={{ display:'flex', alignItems:'center', gap:12, marginTop:'1rem' }}>
-                    {showAddType ? (
-                      <select onChange={(e) => e.target.value && addType(e.target.value)} defaultValue="">
-                        <option value="" disabled>Pick a sample type to add…</option>
-                        {ALL_SAMPLE_TYPES.filter(st => !manifest.find(m => m.sampleTypeId === st.id))
-                                         .map(st => <option key={st.id} value={st.id}>{st.name} ({st.code})</option>)}
-                      </select>
-                    ) : (
-                      <button className="btn btn-ghost" onClick={() => setShowAddType(true)}>+ Add Other Sample Type</button>
-                    )}
+                    <button className="btn btn-ghost" onClick={addManifestRow}>+ Add sample row</button>
                     <span style={{ flex:1 }} />
-                    <span className="total-samples"><strong>Total: {total} samples in this batch</strong></span>
+                    <span className="total-samples"><strong>Total: {sampleRowsManifest.length} sample{sampleRowsManifest.length === 1 ? '' : 's'} in this batch</strong></span>
                   </div>
                 </div>
               )}
@@ -784,12 +1180,12 @@
               {/* Test Selection — 2026-04-29 (rewritten): Branch-aware UX
                   Regulation: pre-loaded deduped Test Plan + blocked-by-missing-sample + add-extra
                   Ad-hoc: existing OE Panels + Tests two-stack
-                  Both gated behind ≥1 manifest row with quantity > 0 */}
-              {branch && activeTypes.length === 0 && manifest.length > 0 && (
+                  Both gated behind ≥1 per-sample manifest row with a recognized sample type (2026-05-01 amendment) */}
+              {branch && activeTypes.length === 0 && sampleRowsManifest.length > 0 && (
                 <div className="tile">
                   <h4>Test Selection</h4>
                   <p className="step-helper">
-                    Add a sample type with quantity ≥ 1 to the manifest above to choose tests.
+                    Add a sample row with a recognized Sample Type in the Sample Intake table above to choose tests.
                   </p>
                 </div>
               )}


### PR DESCRIPTION
…er-sample fields

§5.1.1: 13-section visual order.
§5.1.2 Action Bar: sticky Report NCE button (opens existing OE NCE dialog). §5.1.9 Sample Intake rewrite:
  A. CSV Bulk Upload — 3 env templates, drag-drop, preview table with
     Valid/Mismatch/Error rows, inline ComboBox reconciliation, bulk-apply.
  B. Per-Sample Manifest Table — one row per physical sample; new columns:
     Container Type, GPS, Location Details, Address.
  Quick-add strip (regulation-driven branch) — suggested sample type chips
  with NumberInput + Add N button.
§5.1.12 Submitter (NEW): order-level Organization mapping (mirrors AMAP). §5.1.13 Program (NEW): optional FHIR Questionnaire renderer for env programs. §6 Data Model: Sample adds container_type, gps_raw, location_details, address;
  Order adds program_id, program_response_id. SQL migration updated.

Jira: OGC-537

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
