### PR TITLE
feat(quality): QA Menu v0.5 — IA rehome (tech debt, pre-v1 MVP)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -115,6 +115,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Batch Workplan with Reagent QC | [batch-workplan-reagent-qc.jsx](designs/quality/batch-workplan-reagent-qc.jsx) | [batch-workplan-reagent-qc.md](designs/quality/batch-workplan-reagent-qc.md) · [changelog](designs/quality/batch-workplan-reagent-qc-CHANGELOG-v1-to-v1.1.md) |
 | Analyzer Manual QC | [analyzer-manual-qc.jsx](designs/quality/analyzer-manual-qc.jsx) | [analyzer-manual-qc.md](designs/quality/analyzer-manual-qc.md) |
 | WHONET Integration | — | [whonet-integration.md](designs/quality/whonet-integration.md) |
+| QA Menu v0.5 (IA Rehome) | [qa-menu-v0.5.html](designs/quality/qa-menu-v0.5.html) | [qa-menu-v0.5.md](designs/quality/qa-menu-v0.5.md) · [rehome outline](designs/quality/qa-menu-v0.5-rehome-outline.md) · [QA narrative](designs/quality/qa-qc-narrative.md) · [versioning plan](designs/quality/qa-menu-versioning-plan.md) |
 
 ## Results & Validation
 

--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -2233,3 +2233,16 @@
     - planning
   added: "2026-04-24"
   status: draft
+
+- id: qa-menu-v0.5
+  type: html
+  path: designs/quality/qa-menu-v0.5.html
+  spec: designs/quality/qa-menu-v0.5.md
+  category: quality
+  description: "IA rehome for all existing QA-adjacent features before v1 MVP — Statistical QC / EQA / QMS pillars, legacy URL redirects, GRIST UAT alignment."
+  links:
+    github: null
+    jira: null
+    gallery: "https://digi-uw.github.io/openelis-work/#/quality/qa-menu-v0.5"
+  added: "2026-05-01"
+  status: draft

--- a/designs/quality/qa-menu-v0.5-rehome-outline.md
+++ b/designs/quality/qa-menu-v0.5-rehome-outline.md
@@ -1,0 +1,368 @@
+# QA Menu v0.5 — IA Rehome (existing + in-progress)
+## FRS Outline — ships **before** v1 (MVP)
+
+**Document Version:** 0.1 (outline)
+**Date:** 2026-05-01
+**Author:** Casey Iiams-Hauser
+**Status:** Outline; replaces the rehome scope previously in v2 of the versioning plan
+**Companion mockup:** `qa-v0.5-preview.html` (forthcoming)
+**Sources of truth:**
+- Piotr Mankowski's landscape review (Slack #oe-madagascar-internal, 2026-05-01) — four-QC-feature mental model
+- Piotr's "Concrete proposal for aligning the three reqs" (Slack same channel, same day) — Madagascar GRIST LO-07-02/03/04 alignment
+- `designs/quality/analyzer-manual-qc.md` (DIGI-UW/openelis-work)
+- `designs/quality/batch-workplan-reagent-qc.md` (DIGI-UW/openelis-work)
+- Beth Dunbar's note that Audit Trail is missing from the menu (per MedX validation L0-02-03)
+
+---
+
+## 0. Why v0.5 exists
+
+The Madagascar GRIST treats Quality Control as one umbrella with three "QC reqs" (LO-07-02, -03, -04). Piotr's landscape review surfaced what's actually under the hood: **four distinct QC features at different ship stages**, none of which currently have a coherent menu home, plus **NCE v2 in active development** without a final IA destination.
+
+Today, a user looking for any of these features has to know to navigate through Validation, the Analyzer module, the legacy NCE workflow, or the Admin menu — depending on which feature they want. UAT testers can't validate the QC reqs because the surfaces are too fragmented.
+
+v0.5 fixes the IA without adding net-new features: it brings everything that already exists (or is actively being built) under a new top-level **Quality Assurance** menu. This unblocks the Madagascar UAT, gives in-progress NCE v2 work a final IA destination, and sets up the foundation that v1 (MVP) and later versions will build on.
+
+**The four-feature mental model** (Piotr) is preserved in the v0.5 IA: each gets its own slot under Statistical QC, with FUTURE features rendered as placeholder leaves cross-linked to their design docs.
+
+---
+
+## 1. Scope
+
+### 1.1 In scope
+
+1. **New top-level Quality Assurance sidenav group** — same as v1 spec, but lands in v0.5 instead.
+2. **Statistical QC pillar** with the Westgard / QC Dashboard module rehomed:
+   - QC Dashboard (existing — at `/analyzers/qc/db`, fully merged)
+   - QC Alerts tab (existing — accessed via QC Dashboard)
+   - **Reagent QC** placeholder leaf — cross-links to `designs/quality/batch-workplan-reagent-qc.md`. **FUTURE**, no functional UI.
+   - **Analyzer Manual QC** placeholder leaf — cross-links to `designs/quality/analyzer-manual-qc.md`. **FUTURE**, no functional UI.
+3. **EQA pillar** with the existing EQA module rehomed (V1 EQA, the `isEqaSample` flag flow, validates today).
+4. **QMS & Improvement pillar** with:
+   - **NCE v2** rehomed under `/qa/qms/nce-register` — the in-progress Carbon-React modernization. v0.5 ships whatever NCE v2 includes at the time it lands.
+   - **Audit Trail** rehomed from Admin (cross-link preserved). Currently missing from the menu per Beth's L0-02-03 note — v0.5 fixes this.
+5. **301 redirects** from old paths:
+   - `/analyzers/qc/db` → `/qa/qc/dashboard`
+   - `/analyzers/qc/db/alerts` → `/qa/qc/dashboard/alerts`
+   - `/eqa/...` → `/qa/eqa/...` (preserve all sub-paths)
+   - `/non-conform/...` → `/qa/qms/nce/...` (the NCE v2 paths)
+   - `/admin/audit-trail` → `/qa/qms/audit-trail`
+6. **Permission registry additions**:
+   - `qa.view.overview` (visibility of the QA top-level node)
+   - `qa.view.qc` (Statistical QC pillar)
+   - `qa.view.eqa` (EQA pillar)
+   - `qa.view.qms` (QMS pillar)
+7. **Pillar landings** (Statistical QC, EQA, QMS) — simple tile-grid pages listing the leaves under each pillar. No pillar rollup status (that's v1+ territory).
+8. **i18n** — new menu / breadcrumb / pillar-landing strings.
+
+### 1.2 Out of scope (deferred, version listed)
+
+| Feature | Lands in |
+|---|---|
+| QA Overview landing page (5-question strip + 4 pillar tiles) | v1 |
+| QI Dashboard MVP | v1 |
+| 3 new REST wrappers (rejection-rate, amendment-rate, tat-compliance) | v1 |
+| QA Officer default role | v1 |
+| Electronic Signature Log | v2 |
+| Accreditation Status registry | v3 |
+| Modern NCE Create/Report flow (if not already in NCE v2 scope) | v5 |
+| NCE Analytics page | v6 |
+| CAPA Register | v7 |
+| QI Dashboard full + QI Configuration + Pillar-3 detail pages | v8 |
+| Critical Callback Compliance | v9 |
+| EQA V2 full build (My EQA, Lab Performance, Follow-Up, Competency, Program Mgmt) | v10–v11 |
+| Results Entry inline NCE upgrade | v12 |
+| **Reagent QC** functional UI (per Piotr) | TBD — design doc exists, build not scoped |
+| **Analyzer Manual QC** functional UI (per Piotr) | TBD — design doc exists, build not scoped |
+
+### 1.3 Non-goals
+
+- v0.5 does **not** redesign any of the rehomed pages. It moves them; the existing UI continues to render at the new URL.
+- v0.5 does **not** modernize Audit Trail or QC Dashboard beyond what's already merged.
+- v0.5 does **not** add net-new database tables or schema migrations.
+- v0.5 does **not** redefine the Madagascar GRIST reqs — see `qa-v0.5-grist-alignment.md` for how v0.5 enables passing them, but the reqs themselves are owned by the Madagascar consortium.
+
+---
+
+## 2. Information architecture (v0.5)
+
+### 2.1 Sidenav
+
+```
+Home
+Order
+Results
+Patient
+Sample
+Quality Assurance                              ◄── NEW (top-level)
+  ├── Statistical QC                           ◄── NEW pillar
+  │   ├── QC Dashboard           [rehomed]     ◄── existing /analyzers/qc/db
+  │   ├── QC Alerts              [rehomed]     ◄── existing /analyzers/qc/db/alerts
+  │   ├── Reagent QC             [future]      ◄── placeholder, cross-links to design doc
+  │   └── Analyzer Manual QC     [future]      ◄── placeholder, cross-links to design doc
+  ├── EQA                                       ◄── NEW pillar
+  │   └── (existing EQA pages, rehomed under)
+  └── QMS & Improvement                         ◄── NEW pillar
+      ├── NCE Register           [in progress] ◄── NCE v2, rehomed when it lands
+      └── Audit Trail            [rehomed]     ◄── existing, was missing from menu
+Reports
+Administration
+```
+
+The legacy entry points (top-level NCE if it existed; Validation > Westgard; Admin > Audit Trail) are **removed** from the sidenav in v0.5. Legacy URLs continue to resolve via 301 redirects for one major release.
+
+### 2.2 Pillar landing pages (new in v0.5)
+
+Three simple landing pages, one per pillar. Each page renders a tile grid of the pillar's leaves with one-line descriptions, plus standardized placeholder treatment for FUTURE leaves.
+
+**Statistical QC landing** (`/qa/qc`):
+```
+Statistical QC
+
+QC Dashboard          [rehomed]
+  Internal-control monitoring with Westgard rules.
+  View ↗
+
+QC Alerts             [rehomed]
+  Westgard rule violations across analyzers.
+  View ↗
+
+Reagent QC            [future]
+  Per-lot reagent QC frequency tracking. Design doc.
+  Read design ↗
+
+Analyzer Manual QC    [future]
+  PASS/FAIL log per instrument per day. Design doc.
+  Read design ↗
+```
+
+**EQA landing** (`/qa/eqa`):
+```
+EQA (Proficiency Testing)
+
+(Tile grid of existing EQA pages — same titles, new URL.)
+```
+
+**QMS & Improvement landing** (`/qa/qms`):
+```
+QMS & Improvement
+
+NCE Register          [in progress]
+  Non-conformity events. NCE v2 lands here.
+  View ↗
+
+Audit Trail           [rehomed]
+  Configuration / record-change audit log.
+  View ↗
+```
+
+### 2.3 Pillar landings vs. QA Overview
+
+v0.5 does **not** ship a QA Overview page. The QA top-level node defaults its landing to the Statistical QC pillar (or the most recently visited pillar via user-pref). v1 (MVP) introduces QA Overview later as a rollup of the QI Dashboard MVP plus pillar status.
+
+### 2.4 FUTURE-leaf placeholder UX
+
+For Reagent QC and Analyzer Manual QC (and any other FUTURE leaves added later), the placeholder page shows:
+
+- Page title (e.g., "Reagent QC")
+- Banner: "This feature is in design. Read the design doc on GitHub."
+- Cross-link to the design doc URL on `DIGI-UW/openelis-work`
+- Brief functional summary (1–2 paragraphs from the design doc)
+- "Notify me when this ships" button (optional; defers to v2+ if email notifications aren't wired up)
+
+This treatment is also how the v0.5 IA enables the Madagascar GRIST partial passes (LO-07-03 instrument-verification + reagent-batch bullets).
+
+---
+
+## 3. Madagascar GRIST alignment (per Piotr)
+
+v0.5 directly enables the three QC reqs to pass UAT, in the way Piotr proposed:
+
+| Req | Today | After v0.5 | Round-2 rewrite |
+|---|---|---|---|
+| **LO-07-02** Internal Control | Test points at `/analyzers/errors`, no clear surface | Test points at `/qa/qc/dashboard` (the rehomed Westgard module) and seeds a Westgard violation | Update test step paths + seed a 1-3s violation via the harness. ✓ Achievable in v0.5. |
+| **LO-07-03** Calibration samples | Smushed: EQA + instrument-verification + reagent-batch all under one req | Split: EQA path validates against the rehomed `/qa/eqa/...` (V1 EQA `isEqaSample` flag flow). Instrument-verification + reagent-batch bullets marked **PARTIAL** with cross-links to the future-feature placeholders at `/qa/qc/analyzer-manual-qc` and `/qa/qc/reagent-qc` (which themselves link to the design docs). | Validate EQA path; mark the other two bullets PARTIAL with design-doc references. ✓ Achievable in v0.5. |
+| **LO-07-04** Invalid quality indicators | No clear surface | 3-step pass-through against `/qa/qc/dashboard/alerts` (the rehomed Alerts tab); piggybacks on the LO-07-02 seeded violation | 3-step Alerts-tab walk. ✓ Achievable in v0.5. |
+
+Companion doc: `qa-v0.5-grist-alignment.md` (forthcoming) — captures the test-step rewrites for each LO and the harness fixture seed (control lot with established mean/SD + a fresh control result that breaches 1-3s).
+
+---
+
+## 4. Permission registry
+
+Four new permissions, all visibility-scoped (no `manage` permissions in v0.5 — nothing in v0.5 is editable that wasn't already editable in its pre-rehome location):
+
+| Permission key | Description |
+|---|---|
+| `qa.view.overview` | Visibility of the Quality Assurance top-level sidenav node. |
+| `qa.view.qc` | Visibility of the Statistical QC pillar + its leaves. |
+| `qa.view.eqa` | Visibility of the EQA pillar + existing EQA pages at new URLs. |
+| `qa.view.qms` | Visibility of the QMS pillar + NCE Register + Audit Trail. |
+
+**Existing permissions inherit unchanged.** A user who could see Westgard at `/analyzers/qc/db` can see it at `/qa/qc/dashboard` if they have `qa.view.qc` plus whatever permission gated the original Westgard page. Existing permission keys (e.g., for NCE, EQA, audit access) remain authoritative for the underlying actions.
+
+No default role changes in v0.5. The QA Officer role is added in v1 (MVP).
+
+---
+
+## 5. Frontend implementation
+
+### 5.1 What changes
+
+- **Sidenav**: new Carbon `SideNavMenu` for Quality Assurance with three sub-`SideNavMenu` for the pillars and `SideNavMenuItem` for each leaf.
+- **Routes** (react-router):
+  - `/qa` → redirects to `/qa/qc` (default) or last-visited pillar via user-pref
+  - `/qa/qc` → Statistical QC landing
+  - `/qa/qc/dashboard` → existing `<QCDashboard />` component (no change to the component itself)
+  - `/qa/qc/dashboard/alerts` → existing `<QCAlerts />` component
+  - `/qa/qc/reagent-qc` → `<FutureFeaturePlaceholder feature="reagent-qc" />`
+  - `/qa/qc/analyzer-manual-qc` → `<FutureFeaturePlaceholder feature="analyzer-manual-qc" />`
+  - `/qa/eqa` → EQA landing
+  - `/qa/eqa/*` → existing EQA components (mounted at new path prefix)
+  - `/qa/qms` → QMS landing
+  - `/qa/qms/nce/*` → NCE v2 components (whatever NCE v2 lands with)
+  - `/qa/qms/audit-trail` → existing `<AuditTrail />` component
+- **301 redirects** from old paths configured in the existing OpenELIS routing layer.
+
+### 5.2 What does **not** change
+
+- Component implementations of QC Dashboard, QC Alerts, EQA pages, NCE v2, Audit Trail. v0.5 mounts them at new routes; their internals are untouched.
+- Database schema. No new tables, no migrations.
+- Backend endpoints. Existing REST endpoints continue to serve. (NCE v2 may add endpoints as part of its own scope — those are separate from v0.5.)
+
+### 5.3 New components (small)
+
+- `<QualityAssurancePillarLanding pillar="qc|eqa|qms" />` — tile-grid landing.
+- `<FutureFeaturePlaceholder feature="..." />` — placeholder + design-doc link.
+
+Both are thin compositions of existing Carbon `Tile` components. Estimated build: ~4–6h.
+
+---
+
+## 6. Acceptance criteria
+
+### 6.1 IA + sidenav
+
+- [ ] Quality Assurance top-level node renders in the sidenav.
+- [ ] Three pillar sub-menus render: Statistical QC, EQA, QMS & Improvement.
+- [ ] Statistical QC pillar shows four leaves: QC Dashboard, QC Alerts, Reagent QC (future), Analyzer Manual QC (future).
+- [ ] EQA pillar lists existing EQA pages.
+- [ ] QMS pillar shows two leaves: NCE Register, Audit Trail.
+- [ ] Top-level Validation node no longer contains Westgard / QC Dashboard entries.
+- [ ] Admin → Audit Trail entry is removed (cross-link preserved as a redirect; old Admin item is hidden).
+- [ ] Old top-level NCE entry (if present) is hidden.
+
+### 6.2 Routing + redirects
+
+- [ ] `/analyzers/qc/db` 301-redirects to `/qa/qc/dashboard`.
+- [ ] `/analyzers/qc/db/alerts` 301-redirects to `/qa/qc/dashboard/alerts`.
+- [ ] `/eqa/*` 301-redirects to `/qa/eqa/*` preserving sub-paths.
+- [ ] `/non-conform/*` 301-redirects to `/qa/qms/nce/*`.
+- [ ] `/admin/audit-trail` 301-redirects to `/qa/qms/audit-trail`.
+- [ ] All three pillar landings render at `/qa/qc`, `/qa/eqa`, `/qa/qms`.
+- [ ] Future-feature placeholders render at `/qa/qc/reagent-qc` and `/qa/qc/analyzer-manual-qc` with working design-doc cross-links.
+
+### 6.3 Permissions
+
+- [ ] User without `qa.view.overview` does not see the Quality Assurance node.
+- [ ] User without `qa.view.qc` does not see the Statistical QC pillar; direct navigation 403s.
+- [ ] User without `qa.view.eqa` does not see the EQA pillar; direct nav 403s.
+- [ ] User without `qa.view.qms` does not see the QMS pillar; direct nav 403s.
+- [ ] Underlying page-level permissions (Westgard config edit, Audit Trail view, NCE permissions) remain authoritative for actions within each page.
+
+### 6.4 Madagascar GRIST UAT
+
+- [ ] LO-07-02 Round-2 test points at `/qa/qc/dashboard` and a seeded Westgard 1-3s violation appears.
+- [ ] LO-07-03 EQA-bullet validates against rehomed EQA path.
+- [ ] LO-07-03 instrument-verification + reagent-batch bullets are marked PARTIAL in Grist with links to the design-doc cross-link pages.
+- [ ] LO-07-04 3-step Alerts-tab walk passes against `/qa/qc/dashboard/alerts`.
+
+### 6.5 Cross-cutting
+
+- [ ] All new strings (sidenav labels, pillar landings, future-feature placeholder text) localized.
+- [ ] Lighthouse a11y score ≥ 95 on each new pillar-landing page.
+- [ ] Existing component a11y is unchanged (no regressions from rehome).
+
+---
+
+## 7. Effort estimate
+
+| Item | Hours (low–high) |
+|---|---|
+| Top-level QA sidenav group + IA wiring | 4–6 |
+| Three pillar landings (`<QualityAssurancePillarLanding />`) | 4–6 |
+| Two FUTURE-feature placeholders (`<FutureFeaturePlaceholder />`) | 2–3 |
+| Route mounts for existing components at new paths | 4–6 |
+| 301 redirects for legacy URLs | 2–3 |
+| Permission registry (4 new keys, visibility-only) | 3–5 |
+| Hide legacy entry points (Validation > Westgard, Admin > Audit Trail, top-level NCE) | 2–3 |
+| Madagascar GRIST UAT step rewrites + seed fixture | 3–5 |
+| Tests (route resolution + permission gating + redirect coverage) | 4–6 |
+| Cross-team PR review iteration (Westgard / EQA / NCE owners flagged) | 2–3 |
+| **v0.5 total** | **30–46** |
+
+Baseline: ~35h with Claude.
+
+This sits between the original "Sprint 2 fast-follow MVP" estimate (~30h) and the previous v2 estimate (~30–40h). It also subsumes most of what was in v2, so the **post-v0.5 v2 shrinks to just the E-Sig Log + any v2 cleanup** (~15–20h).
+
+---
+
+## 8. Versioning impact
+
+v0.5 inserts before v1 (MVP). The version sequence becomes:
+
+| Version | Scope | Effort | Status |
+|---|---|---|---|
+| **v0.5** | IA reorganization + rehomes (Westgard / EQA / NCE v2 / Audit Trail) + future-feature placeholders + Madagascar GRIST alignment | 30–46h | NEW |
+| v1 | MVP QI Dashboard (QA Overview + 4 KPI tiles + 3 wrappers + permissions) | 45–55h | Unchanged scope; lands on v0.5 IA |
+| v2 | Electronic Signature Log + cleanup | ~15–20h (down from 30–40h) | Reduced — most v2 rehomes moved to v0.5 |
+| v3 | Accreditation Status registry | 25–30h | Unchanged |
+| v4 | NCE Register modernization | 40–50h | **Reconsider:** if NCE v2 covers the modernization, v4 may collapse into v0.5 / NCE v2 scope |
+| v5 | NCE Create/Report flow | 30–40h | Reconsider in light of NCE v2 scope |
+| v6 | NCE Analytics | 30–40h | Reconsider in light of NCE v2 scope |
+| v7 | CAPA Register | 25–35h | Unchanged |
+| v8 | QI Dashboard full + QI Configuration + Pillar-3 detail pages | 50–60h | Unchanged |
+| v9 | Critical Callback Compliance | 30–40h | Unchanged |
+| v10 | EQA V2 part 1 | 45–55h | Unchanged |
+| v11 | EQA V2 part 2 | 40–50h | Unchanged |
+| v12 | Results Entry inline NCE upgrade | 10–15h | Unchanged |
+
+**v0.5 reframes v4–v6** because NCE v2 (in progress) covers some or all of the NCE modernization scope we previously had in v4. Once NCE v2 lands and we know what it shipped, v4–v6 can be re-scoped (or collapsed) accordingly. **Action item:** clarify NCE v2 scope with Piotr / Mozzy before v0.5 ships so the post-v0.5 v4 / v5 / v6 plan is accurate.
+
+---
+
+## 9. Open questions
+
+1. **NCE v2 scope** — does the in-progress NCE v2 build cover everything we previously had in v4 (modern Carbon-React register), v5 (Create/Report flow with 11 trigger points), and v6 (Analytics page)? Or just the register? Need confirmation from Piotr / Mozzy. **Owner:** Casey.
+2. **Old Admin → Audit Trail menu entry** — completely remove, or leave a "Moved" entry that redirects? Recommend remove + 301 redirect on the URL; admins who have muscle memory get the redirect. Confirm with Piotr.
+3. **Old Validation → Westgard entries** — same question. Recommend remove + 301 redirect.
+4. **Future-feature placeholder voice** — should the page say "in design" / "coming soon" / "design doc"? Recommend "in design" with link to GitHub design doc — matches Piotr's framing as "future feature with referenced design".
+5. **Madagascar fixture seeding** — Piotr suggested seeding "a control lot with established mean/SD, a fresh control result that breaches 1-3s." Confirm this is a one-time harness setup that lives in the test repo, not a v0.5 deliverable per se.
+
+---
+
+## 10. Cross-references
+
+| Document | Relevance |
+|---|---|
+| `qa-menu-versioning-plan.md` | Master version sequence — needs v0.5 insertion (this outline informs that update) |
+| `qa-v1-mvp-frs.md` | v1 ships on top of the v0.5 IA |
+| `qa-final-preview.html` | End-state mockup; v0.5 is a stepping stone |
+| `qa-mvp-kpi-rollup-outline.md` | The v1 (MVP) KPI dashboard, unchanged by v0.5 |
+| Piotr's Slack message (2026-05-01 06:18:12 +07) | Four-QC-feature mental model — basis for v0.5's Statistical QC pillar IA |
+| Piotr's Slack message (2026-05-01 06:22:38 +07) | Madagascar GRIST alignment proposal — basis for §3 |
+| `designs/quality/analyzer-manual-qc.md` (DIGI-UW/openelis-work) | Cross-linked from Analyzer Manual QC placeholder |
+| `designs/quality/batch-workplan-reagent-qc.md` (DIGI-UW/openelis-work) | Cross-linked from Reagent QC placeholder |
+| Beth's L0-02-03 Audit Trail note | Justification for adding Audit Trail to the menu via QMS pillar |
+
+---
+
+## 11. Revision history
+
+| Version | Date | Author | Notes |
+|---|---|---|---|
+| 0.1 | 2026-05-01 | Casey | Initial outline. Inserts a v0.5 before v1 (MVP) per user request. Incorporates Piotr's four-QC-feature mental model + Madagascar GRIST alignment proposal + Beth's Audit Trail note. |
+
+---
+
+*Outline only — full FRS authored alongside the v0.5 mockup.*

--- a/designs/quality/qa-menu-v0.5.html
+++ b/designs/quality/qa-menu-v0.5.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QA Menu v0.5 — Preview (IA rehome + in-progress)</title>
+
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+
+  <style>
+    :root { --rail-w: 256px; --header-h: 48px; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: 'IBM Plex Sans', system-ui, sans-serif; background: #f4f4f4; color: #161616; }
+
+    .app-header { height: var(--header-h); background: #161616; color: #fff; display: flex; align-items: center; padding: 0 1rem; gap: 1rem; position: sticky; top: 0; z-index: 50; }
+    .app-header .brand { font-size: 0.875rem; font-weight: 500; letter-spacing: 0.04em; }
+    .app-header .brand .sub { opacity: 0.7; font-weight: 400; margin-left: 0.5rem; }
+    .app-header .spacer { flex: 1; }
+    .app-header .user-chip { font-size: 0.8125rem; opacity: 0.85; padding: 0.25rem 0.5rem; border: 1px solid #393939; }
+
+    .layout { display: flex; min-height: calc(100vh - var(--header-h)); }
+    .rail { width: var(--rail-w); flex: 0 0 var(--rail-w); background: #fff; border-right: 1px solid #e0e0e0; display: flex; flex-direction: column; position: sticky; top: var(--header-h); height: calc(100vh - var(--header-h)); overflow-y: auto; }
+    .main { flex: 1; padding: 1.5rem 2rem; max-width: 100%; overflow-x: auto; }
+
+    .rail-title { padding: 1rem 1rem 0.5rem 1rem; font-size: 0.75rem; letter-spacing: 0.06em; color: #525252; text-transform: uppercase; }
+    .rail-bucket { display: flex; align-items: center; width: 100%; padding: 0.625rem 1rem; font-size: 0.875rem; color: #161616; background: transparent; border: 0; border-left: 3px solid transparent; cursor: pointer; text-align: left; font-family: inherit; }
+    .rail-bucket:hover { background: #e5e5e5; }
+    .rail-bucket.current { background: #edf5ff; border-left-color: #0f62fe; font-weight: 600; }
+    .rail-bucket.is-new { color: #0043ce; }
+    .rail-bucket .icon { margin-right: 0.625rem; flex: 0 0 20px; display: inline-flex; justify-content: center; }
+    .rail-bucket .label { flex: 1; }
+    .rail-bucket .new-tag { font-size: 0.625rem; background: #defbe6; color: #0e6027; padding: 0.0625rem 0.375rem; border-radius: 8px; margin-left: 0.375rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .rail-bucket .chev { flex: 0 0 16px; opacity: 0.6; font-size: 0.75rem; transition: transform 0.12s; margin-left: 0.25rem; }
+    .rail-bucket.expanded .chev { transform: rotate(180deg); }
+    .rail-children { display: none; background: #fafafa; border-top: 1px solid #f0f0f0; }
+    .rail-bucket.expanded + .rail-children { display: block; }
+
+    .rail-pillar { display: flex; align-items: center; width: 100%; padding: 0.5rem 1rem 0.5rem 2.25rem; font-size: 0.8125rem; background: transparent; border: 0; cursor: pointer; text-align: left; font-family: inherit; color: #161616; font-weight: 500; }
+    .rail-pillar:hover { background: #e8e8e8; }
+    .rail-pillar.current { background: #e0e0e0; }
+    .rail-pillar .chev { font-size: 0.625rem; margin-left: auto; opacity: 0.6; transition: transform 0.12s; }
+    .rail-pillar.expanded .chev { transform: rotate(180deg); }
+
+    .rail-pillar-children { display: none; }
+    .rail-pillar.expanded + .rail-pillar-children { display: block; }
+    .rail-page { display: flex; align-items: center; width: 100%; padding: 0.4375rem 1rem 0.4375rem 3.5rem; font-size: 0.8125rem; color: #525252; background: transparent; border: 0; border-left: 3px solid transparent; cursor: pointer; text-align: left; font-family: inherit; }
+    .rail-page:hover { background: #ececec; }
+    .rail-page.current { background: #edf5ff; border-left-color: #0f62fe; font-weight: 600; color: #161616; }
+    .rail-page .pill { margin-left: auto; font-size: 0.625rem; padding: 0.0625rem 0.375rem; border-radius: 8px; letter-spacing: 0.04em; text-transform: uppercase; }
+    .rail-page .pill.new { background: #defbe6; color: #0e6027; }
+    .rail-page .pill.rehome { background: #d0e2ff; color: #002d9c; }
+    .rail-page .pill.future { background: #f4f4f4; color: #6f6f6f; }
+    .rail-page .pill.in-progress { background: #fff1c2; color: #6f4700; }
+
+    .crumb { font-size: 0.8125rem; color: #525252; margin-bottom: 0.5rem; }
+    .crumb a { color: #0f62fe; text-decoration: none; cursor: pointer; }
+    .crumb a:hover { text-decoration: underline; }
+    .crumb .sep { margin: 0 0.375rem; }
+    .crumb .current { color: #161616; font-weight: 500; }
+
+    h1.page-title { font-size: 1.75rem; font-weight: 300; margin: 0 0 0.25rem 0; letter-spacing: -0.01em; }
+    p.page-sub { color: #525252; margin: 0 0 1.5rem 0; font-size: 0.9375rem; }
+
+    .preview-note {
+      background: #fdf6dd; border-left: 3px solid #f1c21b;
+      padding: 0.625rem 0.875rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #684e00;
+    }
+    .preview-note code { background: rgba(0,0,0,0.06); padding: 0.0625rem 0.25rem; }
+
+    /* Pillar landing tile grid */
+    .leaf-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
+    .leaf-tile {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+      cursor: pointer; transition: background 0.12s;
+      display: flex; flex-direction: column; gap: 0.5rem;
+    }
+    .leaf-tile:hover { background: #fafafa; border-color: #0f62fe; }
+    .leaf-tile h3 { font-size: 0.9375rem; font-weight: 600; margin: 0; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+    .leaf-tile p { font-size: 0.8125rem; color: #525252; margin: 0; line-height: 1.5; }
+    .leaf-tile .tag { font-size: 0.625rem; padding: 0.0625rem 0.375rem; border-radius: 8px; letter-spacing: 0.04em; text-transform: uppercase; }
+    .leaf-tile .tag.new { background: #defbe6; color: #0e6027; }
+    .leaf-tile .tag.rehome { background: #d0e2ff; color: #002d9c; }
+    .leaf-tile .tag.future { background: #f4f4f4; color: #6f6f6f; }
+    .leaf-tile .tag.in-progress { background: #fff1c2; color: #6f4700; }
+    .leaf-tile.future { background: #f7f7f7; border-style: dashed; }
+    .leaf-tile.future:hover { background: #f4f4f4; border-color: #c6c6c6; }
+    .leaf-tile .deep-link { font-size: 0.75rem; color: #0f62fe; margin-top: auto; padding-top: 0.5rem; }
+    .leaf-tile.future .deep-link { color: #525252; }
+
+    /* Rehome stub note */
+    .rehome-note {
+      background: #d0e2ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #002d9c;
+    }
+    .rehome-note strong { color: #002d9c; }
+    .rehome-note code { background: rgba(0,0,0,0.06); padding: 0.0625rem 0.25rem; font-size: 0.8125rem; }
+
+    .future-note {
+      background: #f4f4f4; border-left: 3px solid #8d8d8d;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #393939;
+    }
+    .future-note strong { color: #161616; }
+
+    .in-progress-note {
+      background: #fff1c2; border-left: 3px solid #f1c21b;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #6f4700;
+    }
+
+    .stub-app-frame {
+      background: #fafafa; border: 1px dashed #c6c6c6; padding: 2rem;
+      text-align: center; color: #6f6f6f; font-size: 0.875rem;
+    }
+    .stub-app-frame .frame-title { font-weight: 600; color: #393939; margin-bottom: 0.25rem; }
+
+    .design-doc-link {
+      display: inline-block; padding: 0.5rem 0.875rem; background: #fff;
+      border: 1px solid #c6c6c6; color: #0f62fe; font-size: 0.875rem;
+      cursor: pointer; font-family: inherit; text-decoration: none;
+      margin-top: 0.5rem;
+    }
+    .design-doc-link:hover { background: #f4f4f4; border-color: #0f62fe; }
+
+    /* GRIST alignment block */
+    .grist-block {
+      background: #fff; border: 1px solid #e0e0e0; padding: 1.25rem;
+      margin-top: 1.5rem;
+    }
+    .grist-block h3 { margin: 0 0 0.75rem 0; font-size: 0.9375rem; }
+    .grist-block table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+    .grist-block th, .grist-block td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid #f0f0f0; }
+    .grist-block th { background: #f4f4f4; font-weight: 500; color: #525252; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .grist-block .req-id { font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; }
+    .grist-block .pass { color: #198038; font-weight: 600; }
+    .grist-block .partial { color: #f1c21b; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, Fragment } = React;
+
+    /*
+     * v0.5 — IA rehome + in-progress integration.
+     *
+     * What ships in v0.5:
+     *   - New top-level "Quality Assurance" sidenav group
+     *   - Statistical QC pillar:
+     *       - QC Dashboard (rehomed from /analyzers/qc/db — fully merged today)
+     *       - QC Alerts (rehomed)
+     *       - Reagent QC (FUTURE placeholder, design-doc cross-link)
+     *       - Analyzer Manual QC (FUTURE placeholder, design-doc cross-link)
+     *   - EQA pillar (rehomed; existing V1 EQA functionality)
+     *   - QMS & Improvement pillar:
+     *       - NCE Register (NCE v2 in progress — landing site for the modernization)
+     *       - Audit Trail (rehomed from Admin; was missing from menu per Beth)
+     *
+     * What does NOT ship in v0.5:
+     *   - QA Overview landing page → v1 (MVP)
+     *   - QI Dashboard MVP → v1 (MVP)
+     *   - Electronic Signature Log → v2
+     *   - Accreditation management → v2 (community-led; uses test-accreditation specs)
+     *   - Modern NCE Create/Report flow / Analytics / CAPA Register → reconsider after NCE v2 lands
+     *
+     * v0.5's job is purely IA: give the existing + in-progress features a coherent home so
+     * the Madagascar GRIST UAT (LO-07-02 / -03 / -04) can pass and so v1 (MVP) lands on
+     * a stable container.
+     */
+
+    const TOP_LEVEL = [
+      { slug: 'home', label: 'Home', icon: '🏠' },
+      { slug: 'order', label: 'Order', icon: '📋' },
+      { slug: 'results', label: 'Results', icon: '🧪' },
+      { slug: 'patient', label: 'Patient', icon: '👤' },
+      { slug: 'sample', label: 'Sample', icon: '🩸' },
+      { slug: 'qa', label: 'Quality Assurance', icon: '⚖️', isNew: true,
+        children: [
+          { slug: 'qc', label: 'Statistical QC', kind: 'pillar', children: [
+            { slug: 'dashboard', label: 'QC Dashboard',  tag: 'rehome' },
+            { slug: 'alerts',    label: 'QC Alerts',     tag: 'rehome' },
+            { slug: 'reagent-qc', label: 'Reagent QC',   tag: 'future' },
+            { slug: 'manual-qc',  label: 'Analyzer Manual QC', tag: 'future' },
+          ] },
+          { slug: 'eqa', label: 'EQA', kind: 'pillar', children: [
+            { slug: 'eqa-home', label: 'EQA (existing)', tag: 'rehome' },
+          ] },
+          { slug: 'qms', label: 'QMS & Improvement', kind: 'pillar', children: [
+            { slug: 'nce-register', label: 'NCE Register', tag: 'in-progress' },
+            { slug: 'audit-trail',  label: 'Audit Trail',  tag: 'rehome' },
+          ] },
+        ] },
+      { slug: 'reports', label: 'Reports', icon: '📊' },
+      { slug: 'admin', label: 'Administration', icon: '⚙️' },
+    ];
+
+    function parseHash() {
+      const raw = window.location.hash.replace(/^#/, '') || '/qa/qc';
+      const parts = raw.split('/').filter(Boolean);
+      if (parts[0] !== 'qa') return { kind: 'qc-landing' };
+      const pillar = parts[1];
+      const leaf = parts[2];
+      if (!pillar) return { kind: 'qc-landing' };
+      if (!leaf) return { kind: 'pillar-landing', pillar };
+      return { kind: 'leaf', pillar, leaf };
+    }
+    function useRoute() {
+      const [route, setRoute] = useState(parseHash());
+      useEffect(() => {
+        const onHash = () => setRoute(parseHash());
+        window.addEventListener('hashchange', onHash);
+        return () => window.removeEventListener('hashchange', onHash);
+      }, []);
+      return route;
+    }
+    const go = h => { window.location.hash = h; };
+
+    function AppHeader() {
+      return (
+        <div className="app-header">
+          <span className="brand">OpenELIS Global<span className="sub">— v0.5 preview (IA rehome)</span></span>
+          <span className="spacer"></span>
+          <span className="user-chip">Casey · QA Officer</span>
+        </div>
+      );
+    }
+
+    function Rail({ route }) {
+      const isQA = ['pillar-landing','leaf','qc-landing'].includes(route.kind);
+      const expandedPillar = route.pillar || (route.kind === 'qc-landing' ? 'qc' : null);
+
+      const isCurrentLeaf = (pillar, slug) => {
+        if (route.kind !== 'leaf') return false;
+        return route.pillar === pillar && route.leaf === slug;
+      };
+
+      return (
+        <aside className="rail">
+          <div className="rail-title">Navigation</div>
+          {TOP_LEVEL.map(item => (
+            <Fragment key={item.slug}>
+              {item.children ? (
+                <Fragment>
+                  <button className={`rail-bucket ${isQA ? 'expanded current' : ''} ${item.isNew ? 'is-new' : ''}`}>
+                    <span className="icon">{item.icon}</span>
+                    <span className="label">{item.label}</span>
+                    {item.isNew && <span className="new-tag">New</span>}
+                    <span className="chev">▾</span>
+                  </button>
+                  <div className="rail-children">
+                    {item.children.map(p => {
+                      const isExpanded = expandedPillar === p.slug;
+                      return (
+                        <Fragment key={p.slug}>
+                          <button className={`rail-pillar ${isExpanded ? 'expanded current' : ''}`}
+                            onClick={() => go(`/qa/${p.slug}`)}>
+                            <span>{p.label}</span>
+                            <span className="chev">▾</span>
+                          </button>
+                          <div className="rail-pillar-children" style={{ display: isExpanded ? 'block' : 'none' }}>
+                            {p.children.map(leaf => (
+                              <button key={leaf.slug}
+                                className={`rail-page ${isCurrentLeaf(p.slug, leaf.slug) ? 'current' : ''}`}
+                                onClick={() => go(`/qa/${p.slug}/${leaf.slug}`)}>
+                                <span>{leaf.label}</span>
+                                {leaf.tag === 'new' && <span className="pill new">New</span>}
+                                {leaf.tag === 'rehome' && <span className="pill rehome">moved</span>}
+                                {leaf.tag === 'future' && <span className="pill future">future</span>}
+                                {leaf.tag === 'in-progress' && <span className="pill in-progress">in progress</span>}
+                              </button>
+                            ))}
+                          </div>
+                        </Fragment>
+                      );
+                    })}
+                  </div>
+                </Fragment>
+              ) : (
+                <button className="rail-bucket">
+                  <span className="icon">{item.icon}</span>
+                  <span className="label">{item.label}</span>
+                </button>
+              )}
+            </Fragment>
+          ))}
+        </aside>
+      );
+    }
+
+    function Crumb({ items }) {
+      return (
+        <div className="crumb">
+          {items.map((it, i) => (
+            <Fragment key={i}>
+              {i > 0 && <span className="sep">›</span>}
+              {it.target && i < items.length - 1
+                ? <a onClick={() => go(it.target)}>{it.label}</a>
+                : <span className={i === items.length - 1 ? 'current' : ''}>{it.label}</span>}
+            </Fragment>
+          ))}
+        </div>
+      );
+    }
+
+    function PreviewNote() {
+      return (
+        <div className="preview-note">
+          <strong>v0.5 (IA rehome + in-progress)</strong> ships before v1 (MVP). It gives every
+          existing QA-adjacent feature (Westgard / QC Dashboard, EQA, Audit Trail) a coherent home
+          and adds the in-progress NCE v2 to the new menu. Two FUTURE placeholders
+          (Reagent QC, Analyzer Manual QC) cross-link to design docs per Piotr's four-QC-feature
+          framing. ~30–46h estimated. Unblocks the Madagascar GRIST UAT (LO-07-02/03/04).
+        </div>
+      );
+    }
+
+    /* --------------------------- Pillar landings --------------------------- */
+
+    function QCLanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'Statistical QC' }]} />
+          <h1 className="page-title">Statistical QC</h1>
+          <p className="page-sub">Internal control monitoring + the future-feature surfaces from Piotr's four-QC-feature framing.</p>
+          <PreviewNote />
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/qc/dashboard')}>
+              <h3>QC Dashboard <span className="tag rehome">Rehomed</span></h3>
+              <p>Internal control monitoring with Westgard rules + Levey-Jennings charts. Existing UI; new URL.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile" onClick={() => go('/qa/qc/alerts')}>
+              <h3>QC Alerts <span className="tag rehome">Rehomed</span></h3>
+              <p>Westgard rule violations across analyzers. Existing UI; rehomed from QC Dashboard sub-tab.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile future" onClick={() => go('/qa/qc/reagent-qc')}>
+              <h3>Reagent QC <span className="tag future">Future</span></h3>
+              <p>Per-lot reagent QC frequency tracking. Design doc on GitHub; build not yet scheduled.</p>
+              <div className="deep-link">Read design ↗</div>
+            </div>
+            <div className="leaf-tile future" onClick={() => go('/qa/qc/manual-qc')}>
+              <h3>Analyzer Manual QC <span className="tag future">Future</span></h3>
+              <p>Daily PASS/FAIL log per instrument. Design doc on GitHub; build not yet scheduled.</p>
+              <div className="deep-link">Read design ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    function EQALanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'EQA' }]} />
+          <h1 className="page-title">EQA (Proficiency Testing)</h1>
+          <p className="page-sub">External quality assessment — V1 EQA functionality, rehomed under Quality Assurance.</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 rehome:</strong> existing EQA pages keep their UI and behavior;
+            their URL prefix changes from <code>/eqa/...</code> to <code>/qa/eqa/...</code>.
+            The <code>isEqaSample</code> flag flow continues to validate as it does today.
+            EQA V2 (cycle/scheme model + Lab Performance dashboard + Follow-Up Queue + Analyst Competency + Program Management)
+            arrives in v10–v11.
+          </div>
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/eqa/eqa-home')}>
+              <h3>EQA <span className="tag rehome">Rehomed</span></h3>
+              <p>The existing OpenELIS EQA pages — sample submissions, scheme management — at the new URL.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    function QMSLanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'QMS & Improvement' }]} />
+          <h1 className="page-title">QMS &amp; Improvement</h1>
+          <p className="page-sub">Quality management surfaces. v0.5 lands the in-progress NCE v2 here and pulls Audit Trail in from Admin.</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 changes:</strong> NCE Register lands as the destination URL for the
+            <strong> in-progress NCE v2</strong> Carbon-React modernization. Audit Trail rehomes
+            from Admin (Admin cross-link preserved). Electronic Signature Log arrives in v2.
+            Accreditation management arrives in v2 — community may lead the build using the
+            existing <code>test-accreditation-frs.md</code> spec.
+          </div>
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/qms/nce-register')}>
+              <h3>NCE Register <span className="tag in-progress">In progress</span></h3>
+              <p>Non-conformity events. Carbon-React modernization (NCE v2) lands here when it ships.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile" onClick={() => go('/qa/qms/audit-trail')}>
+              <h3>Audit Trail <span className="tag rehome">Rehomed</span></h3>
+              <p>Configuration / record-change audit log, rehomed from Admin. Admin cross-link preserved.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Rehome stubs --------------------------- */
+
+    const REHOME = {
+      'qc/dashboard':  { title: 'QC Dashboard',                        old: '/analyzers/qc/db',           desc: 'Internal control monitoring with Westgard rules + Levey-Jennings charts.' },
+      'qc/alerts':     { title: 'QC Alerts',                           old: '/analyzers/qc/db/alerts',    desc: 'Westgard rule violations across analyzers.' },
+      'eqa/eqa-home':  { title: 'EQA',                                 old: '/eqa',                       desc: 'External quality assessment / proficiency testing.' },
+      'qms/audit-trail': { title: 'Audit Trail',                       old: '/admin/audit-trail',         desc: 'Configuration and record-change audit log.' },
+    };
+
+    function RehomeStub({ pillar, leaf }) {
+      const meta = REHOME[`${pillar}/${leaf}`];
+      const pillarLabel = pillar === 'qc' ? 'Statistical QC' : pillar === 'eqa' ? 'EQA' : 'QMS & Improvement';
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: pillarLabel, target: `/qa/${pillar}` },
+            { label: meta.title }
+          ]} />
+          <h1 className="page-title">{meta.title}</h1>
+          <p className="page-sub">{meta.desc}</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 rehome — UI unchanged.</strong> This page renders the existing OpenELIS
+            UI; only the URL and breadcrumb changed. Old path <code>{meta.old}</code> issues a 301
+            redirect to the new URL for one major release.
+            {leaf === 'audit-trail' && <Fragment><br /><br />Cross-link preserved from <code>Admin → Audit Trail</code> so administrators with muscle memory still find it.</Fragment>}
+          </div>
+
+          <div className="stub-app-frame">
+            <div className="frame-title">[ Existing OpenELIS {meta.title} UI renders here ]</div>
+            Same component, same data, same controls.<br />
+            v0.5 mockup omits the page body intentionally — only the IA position changed.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Future placeholders --------------------------- */
+
+    const FUTURE = {
+      'reagent-qc': {
+        title: 'Reagent QC',
+        designDoc: 'designs/quality/batch-workplan-reagent-qc.md',
+        designDocUrl: 'https://github.com/DIGI-UW/openelis-work/blob/main/designs/quality/batch-workplan-reagent-qc.md',
+        question: 'Has this reagent lot been verified before we use it on patients?',
+        summary: 'Per-lot QC frequency tracking. Before a new reagent lot is used clinically, the system requires a documented set of verification samples comparing the new lot against the old lot or a peer-comparison reference. The data model holds which lots, which controls, which analyzer, which user, and which timestamp.',
+        why: 'Without lot verification, a bad reagent lot can ruin a week of patient results before anyone notices. Most labs do this informally today (paper logs, supervisor reminders); shipping it as a system feature catches the cases where the informal process fails.',
+      },
+      'manual-qc': {
+        title: 'Analyzer Manual QC',
+        designDoc: 'designs/quality/analyzer-manual-qc.md',
+        designDocUrl: 'https://github.com/DIGI-UW/openelis-work/blob/main/designs/quality/analyzer-manual-qc.md',
+        question: 'Did the technician run a daily control on this instrument today, and did it pass?',
+        summary: 'Daily PASS/FAIL log per instrument. Different instruments have different daily checks (a microscope has a calibration slide, a hematology analyzer has a precision check on a control sample, a refrigerator has a temperature reading). The system holds them all to one shape: a daily PASS/FAIL log with a signer, a timestamp, and a block on instrument use if FAIL.',
+        why: 'The first thing a CAP inspector asks when they walk into a lab is some version of "show me your daily QC log for this instrument." A signed log per instrument per day, every day. Forgetting it is what fails inspections.',
+      },
+    };
+
+    function FutureStub({ leaf }) {
+      const meta = FUTURE[leaf];
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: 'Statistical QC', target: '/qa/qc' },
+            { label: meta.title }
+          ]} />
+          <h1 className="page-title">{meta.title}</h1>
+          <p className="page-sub">Future feature — design exists; build not yet scheduled.</p>
+
+          <div className="future-note">
+            <strong>One of Piotr's four QC features.</strong> The lens this feature provides:
+            <em> {meta.question}</em><br /><br />
+            {meta.summary}<br /><br />
+            <strong>Why it matters:</strong> {meta.why}
+          </div>
+
+          <div style={{ background: '#fff', padding: '1.5rem', border: '1px solid #e0e0e0' }}>
+            <h3 style={{ margin: '0 0 0.5rem 0', fontSize: '0.875rem', fontWeight: 600 }}>Design document</h3>
+            <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.8125rem', color: '#525252' }}>
+              The full design specification is on GitHub at <code>DIGI-UW/openelis-work</code>:
+            </p>
+            <p style={{ margin: '0', fontFamily: 'IBM Plex Mono, monospace', fontSize: '0.8125rem', color: '#0f62fe' }}>
+              {meta.designDoc}
+            </p>
+            <a className="design-doc-link" href={meta.designDocUrl} target="_blank" rel="noopener">
+              Read design doc on GitHub ↗
+            </a>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: '0.8125rem', color: '#6f6f6f' }}>
+            <strong>Why this page exists in v0.5:</strong> the four-QC-feature mental model is
+            preserved in the IA from day one. UAT testers (Madagascar GRIST LO-07-03 specifically)
+            can reference these placeholder pages to mark the relevant requirement bullets PARTIAL
+            with a documented future-feature link, instead of leaving the requirement in limbo.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- NCE Register (in-progress) --------------------------- */
+
+    function NCERegister() {
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: 'QMS & Improvement', target: '/qa/qms' },
+            { label: 'NCE Register' }
+          ]} />
+          <h1 className="page-title">NCE Register</h1>
+          <p className="page-sub">Non-conformity events. NCE v2 (Carbon-React modernization) lands here when it ships.</p>
+
+          <div className="in-progress-note">
+            <strong>NCE v2 is in active development.</strong> This URL is the landing site
+            for the modernized register. v0.5 hides the legacy top-level NCE menu entry and
+            301-redirects <code>/non-conform/*</code> to <code>/qa/qms/nce/*</code>. When NCE v2
+            ships into the develop branch, it appears at this URL automatically. Until then,
+            this page renders the existing legacy NCE workflow at the new URL.
+            <br /><br />
+            <strong>Open question (per Casey + Piotr / Mozzy):</strong> does the in-progress NCE v2
+            cover the modern register (formerly v4), the create/report flow with 11 trigger
+            points (formerly v5), and the analytics page (formerly v6) — or just the register?
+            Confirm before v0.5 ships so the post-v0.5 v4–v6 plan is accurate.
+          </div>
+
+          <div className="stub-app-frame">
+            <div className="frame-title">[ Existing OpenELIS NCE workflow renders here today; NCE v2 swaps in when it ships ]</div>
+            Same data; UI evolves with the NCE v2 build.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Madagascar GRIST alignment --------------------------- */
+
+    function GristAlignment() {
+      return (
+        <div className="grist-block">
+          <h3>Madagascar GRIST UAT alignment (per Piotr's proposal, Slack 2026-05-01)</h3>
+          <p style={{ margin: '0 0 0.75rem 0', fontSize: '0.8125rem', color: '#525252' }}>
+            v0.5 directly enables the three QC-related Madagascar UAT requirements to pass UAT
+            with a documented Round-2 rewrite per requirement.
+          </p>
+          <table>
+            <thead>
+              <tr><th>Req</th><th>Title</th><th>v0.5 path</th><th>Round-2 rewrite</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="req-id">LO-07-02</td>
+                <td>Internal Control</td>
+                <td><code>/qa/qc/dashboard</code></td>
+                <td><span className="pass">PASS</span> — point test at QC Dashboard, seed a 1-3s violation via harness fixture.</td>
+              </tr>
+              <tr>
+                <td className="req-id">LO-07-03</td>
+                <td>Calibration samples</td>
+                <td><code>/qa/eqa/eqa-home</code> (EQA bullet) +<br /><code>/qa/qc/manual-qc</code> + <code>/qa/qc/reagent-qc</code> (PARTIAL)</td>
+                <td><span className="partial">SPLIT</span> — EQA bullet validates against existing V1 EQA path; instrument-verification + reagent-batch bullets marked PARTIAL with cross-links to the FUTURE-feature design docs.</td>
+              </tr>
+              <tr>
+                <td className="req-id">LO-07-04</td>
+                <td>Invalid quality indicators</td>
+                <td><code>/qa/qc/alerts</code></td>
+                <td><span className="pass">PASS</span> — 3-step pass-through against the rehomed Alerts tab; piggybacks on LO-07-02's seeded violation.</td>
+              </tr>
+            </tbody>
+          </table>
+          <p style={{ margin: '0.75rem 0 0 0', fontSize: '0.75rem', color: '#6f6f6f' }}>
+            Source: Piotr Mankowski's "Concrete proposal for aligning the three reqs"
+            (#oe-madagascar-internal, 2026-05-01).
+          </p>
+        </div>
+      );
+    }
+
+    /* --------------------------- App --------------------------- */
+
+    function App() {
+      const route = useRoute();
+      let body;
+
+      const showGrist = route.kind === 'qc-landing' || (route.kind === 'pillar-landing' && route.pillar === 'qc');
+
+      if (route.kind === 'qc-landing') body = <QCLanding />;
+      else if (route.kind === 'pillar-landing') {
+        if (route.pillar === 'qc') body = <QCLanding />;
+        else if (route.pillar === 'eqa') body = <EQALanding />;
+        else if (route.pillar === 'qms') body = <QMSLanding />;
+        else body = <QCLanding />;
+      }
+      else if (route.kind === 'leaf') {
+        const key = `${route.pillar}/${route.leaf}`;
+        if (REHOME[key]) body = <RehomeStub pillar={route.pillar} leaf={route.leaf} />;
+        else if (route.pillar === 'qc' && (route.leaf === 'reagent-qc' || route.leaf === 'manual-qc'))
+          body = <FutureStub leaf={route.leaf} />;
+        else if (route.pillar === 'qms' && route.leaf === 'nce-register')
+          body = <NCERegister />;
+        else body = <QCLanding />;
+      }
+      else body = <QCLanding />;
+
+      return (
+        <Fragment>
+          <AppHeader />
+          <div className="layout">
+            <Rail route={route} />
+            <main className="main">
+              {body}
+              {showGrist && <GristAlignment />}
+            </main>
+          </div>
+        </Fragment>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/designs/quality/qa-menu-v0.5.md
+++ b/designs/quality/qa-menu-v0.5.md
@@ -1,0 +1,567 @@
+# QA Menu v0.5 (IA Rehome) — Functional Requirements Specification
+
+**Document Version:** 1.0
+**Date:** 2026-05-01
+**Author:** Casey Iiams-Hauser
+**Status:** Ship-ready FRS for v0.5 (the IA-rehome version that lands **before** v1 MVP)
+**Effort estimate:** ~30–46 engineer-hours with Claude (~55–85 without)
+**Companion mockup:** `qa-v0.5-preview.html`
+**Companion outline:** `qa-v0.5-rehome-outline.md`
+**Source-of-truth references:**
+- Piotr Mankowski, "Landscape review: QC subsystems in OpenELIS Global" (Slack #oe-madagascar-internal, 2026-05-01 06:18:12 +07)
+- Piotr Mankowski, "Concrete proposal for aligning the three reqs" (Slack same channel, 2026-05-01 06:22:38 +07)
+- `designs/quality/analyzer-manual-qc.md` (DIGI-UW/openelis-work)
+- `designs/quality/batch-workplan-reagent-qc.md` (DIGI-UW/openelis-work)
+- Beth Dunbar, Audit Trail menu-gap note (Slack same channel, 2026-04-30; ref MedX validation L0-02-03)
+
+---
+
+## 0. What v0.5 actually ships
+
+A new top-level **Quality Assurance** sidenav group, with three pillar landings (Statistical QC, EQA, QMS & Improvement) populated by **rehomed existing pages** plus the **in-progress NCE v2** plus **two FUTURE-feature placeholders** (Reagent QC, Analyzer Manual QC) that cross-link to design docs on GitHub.
+
+v0.5 ships **no net-new functional features**. Its purpose is to give every QA-adjacent surface a coherent home — so the Madagascar GRIST UAT can pass, so NCE v2 has a destination URL when it lands, and so v1 (MVP) lands on a stable IA container.
+
+This FRS is the ship-ready consolidation of:
+- `qa-v0.5-rehome-outline.md` — outline-level scope and rationale
+- Piotr's two Slack messages — four-QC-feature framing + Madagascar GRIST proposal
+- The two GitHub design docs (Reagent QC, Analyzer Manual QC) — for FUTURE-placeholder content
+
+The mockup `qa-v0.5-preview.html` is the canonical visual reference. Any conflict between text below and the mockup → mockup wins for visual layout; FRS wins for data/route/permission/acceptance semantics.
+
+---
+
+## 1. Scope
+
+### 1.1 In scope
+
+1. **Top-level Quality Assurance sidenav group** with the `New` tag.
+2. **Three pillar sub-menus**: Statistical QC, EQA, QMS & Improvement. Each pillar has a landing page (`/qa/qc`, `/qa/eqa`, `/qa/qms`).
+3. **Statistical QC pillar leaves** (4 total):
+   - **QC Dashboard** — rehomed from `/analyzers/qc/db`. Existing UI; new URL + breadcrumb.
+   - **QC Alerts** — rehomed from `/analyzers/qc/db/alerts`. Existing UI; new URL + breadcrumb.
+   - **Reagent QC** — FUTURE placeholder. No functional UI. Cross-links to `designs/quality/batch-workplan-reagent-qc.md`.
+   - **Analyzer Manual QC** — FUTURE placeholder. No functional UI. Cross-links to `designs/quality/analyzer-manual-qc.md`.
+4. **EQA pillar** — rehomes the existing OpenELIS EQA pages from `/eqa/...` to `/qa/eqa/...` preserving sub-paths. The V1 `isEqaSample` flag flow continues to validate as it does today.
+5. **QMS & Improvement pillar leaves** (2 total in v0.5):
+   - **NCE Register** — destination URL for the in-progress NCE v2 build. v0.5 hides the legacy top-level NCE entry and 301-redirects `/non-conform/*` to `/qa/qms/nce/*`. Until NCE v2 ships, the existing legacy NCE workflow renders at this URL.
+   - **Audit Trail** — rehomed from `/admin/audit-trail`. Cross-link preserved from Admin so administrators with muscle memory still find it.
+6. **301 redirects** from old paths (full table in §3.4).
+7. **Permission registry additions**:
+   - `qa.view.overview` — visibility of the QA top-level node.
+   - `qa.view.qc` — Statistical QC pillar visibility.
+   - `qa.view.eqa` — EQA pillar visibility.
+   - `qa.view.qms` — QMS pillar visibility.
+8. **Madagascar GRIST UAT alignment**: test-step rewrites for LO-07-02, LO-07-03, LO-07-04 + a fixture seed (a control lot with established mean/SD plus a fresh control result that breaches 1-3s).
+9. **i18n** — new menu / breadcrumb / pillar-landing / FUTURE-placeholder strings.
+
+### 1.2 Out of scope (deferred, version listed)
+
+| Feature | Lands in |
+|---|---|
+| QA Overview landing page (5-question strip + 4 pillar tiles) | v1 |
+| QI Dashboard MVP (4 KPI tiles) | v1 |
+| 3 new REST wrappers (rejection-rate, amendment-rate, tat-compliance) | v1 |
+| QA Officer default role | v1 |
+| Electronic Signature Log | v2 |
+| **Test Accreditation management** (Accrediting Bodies + Test Accreditations admin pages) | **v2 — community may lead.** Spec is ready in `test-accreditation-frs.md`. |
+| NCE Register modernization beyond what NCE v2 ships | Reconsider after NCE v2 lands |
+| NCE Create/Report flow (11 triggers) beyond what NCE v2 ships | Reconsider |
+| NCE Analytics page beyond what NCE v2 ships | Reconsider |
+| CAPA Register | v7 (renumbering pending NCE v2 scope confirmation) |
+| QI Dashboard full + QI Configuration + Pillar-3 detail pages | v8 |
+| Critical Callback Compliance | v9 |
+| EQA V2 build | v10–v11 |
+| Results Entry inline NCE upgrade | v12 |
+| Reagent QC functional UI | TBD — design doc exists; build not scoped |
+| Analyzer Manual QC functional UI | TBD — design doc exists; build not scoped |
+
+### 1.3 Non-goals
+
+- v0.5 does **not** redesign any of the rehomed pages. The components, controls, and behavior are unchanged.
+- v0.5 does **not** add new database tables, columns, or migrations.
+- v0.5 does **not** modify any backend endpoints (NCE v2 may add endpoints as part of its own scope; those are separate).
+- v0.5 does **not** redefine the Madagascar GRIST requirements themselves — see §6 for how v0.5 enables passing them.
+
+---
+
+## 2. The four-QC-feature mental model (Piotr's framing)
+
+Per Piotr's landscape review, OpenELIS has four distinct QC features at different ship stages, all under the ISO 15189 §7.7 umbrella but with different data models:
+
+| # | Feature | Status today | Lens it provides |
+|---|---|---|---|
+| 1 | **Westgard / Internal QC** | Fully merged into OpenELIS-Global-2 | Are the numbers from this analyzer-test-control-lot tuple still in tolerance? |
+| 2 | **EQA / Proficiency Testing** | V1 done (`isEqaSample` flag) | Do our results match the external program's target value? |
+| 3 | **Reagent QC** | **FUTURE** — design doc only | Has this reagent lot been verified before we use it? |
+| 4 | **Analyzer Manual QC** | **FUTURE** — design doc only | Did the technician run a daily control on this instrument today? |
+
+v0.5 preserves this four-lens framing in the IA from day one: each feature gets its own slot under Statistical QC. The two future features render as placeholder pages with prominent design-doc cross-links, so UAT testers (Madagascar GRIST, future inspections) can mark related bullets PARTIAL with documented future-feature references.
+
+---
+
+## 3. Information architecture
+
+### 3.1 Sidenav (v0.5)
+
+```
+Home
+Order
+Results
+Patient
+Sample
+Quality Assurance                              ◄── NEW (top-level, with `New` tag)
+  ├── Statistical QC                           ◄── NEW pillar
+  │   ├── QC Dashboard           [moved]
+  │   ├── QC Alerts              [moved]
+  │   ├── Reagent QC             [future]
+  │   └── Analyzer Manual QC     [future]
+  ├── EQA                                       ◄── NEW pillar
+  │   └── (existing EQA pages, rehomed under)
+  └── QMS & Improvement                         ◄── NEW pillar
+      ├── NCE Register           [in progress]
+      └── Audit Trail            [moved]
+Reports
+Administration
+```
+
+The legacy entry points are **removed** from the sidenav in v0.5:
+- Top-level NCE menu (if it existed): removed; legacy URLs continue to resolve via 301 redirects for one major release.
+- Validation → Westgard / QC Dashboard entries: removed; legacy URLs continue via 301.
+- Admin → Audit Trail: removed; legacy URL continues via 301. **Admin-side cross-link preserved** so administrators with muscle memory still find it.
+
+The QA top-level parent shows the **`New`** tag for one major release after launch, auto-removed in v1 once the QI Dashboard child lands.
+
+### 3.2 Routes
+
+| Path | Page |
+|---|---|
+| `/qa` | Redirects to `/qa/qc` (default) or last-visited pillar via user-pref |
+| `/qa/qc` | Statistical QC pillar landing |
+| `/qa/qc/dashboard` | QC Dashboard (rehomed) |
+| `/qa/qc/alerts` | QC Alerts (rehomed) |
+| `/qa/qc/reagent-qc` | Reagent QC future-feature placeholder |
+| `/qa/qc/manual-qc` | Analyzer Manual QC future-feature placeholder |
+| `/qa/eqa` | EQA pillar landing |
+| `/qa/eqa/*` | Existing EQA pages mounted at new path prefix |
+| `/qa/qms` | QMS pillar landing |
+| `/qa/qms/nce-register` | NCE Register (NCE v2 lands here when it ships; legacy NCE workflow renders here in the meantime) |
+| `/qa/qms/nce/*` | NCE v2 sub-paths (whatever NCE v2 ships with) |
+| `/qa/qms/audit-trail` | Audit Trail (rehomed) |
+
+### 3.3 Breadcrumbs
+
+```
+Quality Assurance  ›  Statistical QC
+Quality Assurance  ›  Statistical QC  ›  QC Dashboard
+Quality Assurance  ›  Statistical QC  ›  Reagent QC
+Quality Assurance  ›  EQA  ›  (sub-paths inherit existing EQA breadcrumb)
+Quality Assurance  ›  QMS & Improvement  ›  NCE Register
+Quality Assurance  ›  QMS & Improvement  ›  Audit Trail
+```
+
+### 3.4 301 redirects
+
+| Old path | New path |
+|---|---|
+| `/analyzers/qc/db` | `/qa/qc/dashboard` |
+| `/analyzers/qc/db/alerts` | `/qa/qc/alerts` |
+| `/analyzers/qc/db/*` | `/qa/qc/dashboard/*` (preserve any sub-paths) |
+| `/eqa` | `/qa/eqa/eqa-home` |
+| `/eqa/*` | `/qa/eqa/*` (preserve sub-paths) |
+| `/non-conform` | `/qa/qms/nce-register` |
+| `/non-conform/*` | `/qa/qms/nce/*` (preserve sub-paths) |
+| `/admin/audit-trail` | `/qa/qms/audit-trail` |
+
+Redirects use HTTP 301 (permanent). They remain in place for one major release, then can be removed once analytics show the new URLs are dominant.
+
+---
+
+## 4. Pillar landing pages
+
+Three new landing pages — one per pillar — render a tile grid of the pillar's leaves.
+
+### 4.1 Statistical QC landing
+
+Tile grid with 4 tiles:
+- **QC Dashboard** (rehomed) — "Internal control monitoring with Westgard rules + Levey-Jennings charts."
+- **QC Alerts** (rehomed) — "Westgard rule violations across analyzers."
+- **Reagent QC** (future) — "Per-lot reagent QC frequency tracking. Design doc on GitHub."
+- **Analyzer Manual QC** (future) — "Daily PASS/FAIL log per instrument. Design doc on GitHub."
+
+The two FUTURE tiles render with a dashed border + lighter background to distinguish them from clickable functional tiles. Clicking a future tile navigates to its placeholder page (which itself prominently links to the design doc).
+
+### 4.2 EQA landing
+
+Single-tile grid pointing at the rehomed existing EQA module. Includes a `rehome-note` banner: "v0.5 rehome: existing EQA pages keep their UI and behavior; their URL prefix changes from `/eqa/...` to `/qa/eqa/...`. The `isEqaSample` flag flow continues to validate as it does today. EQA V2 (cycle/scheme model + Lab Performance dashboard + Follow-Up Queue + Analyst Competency + Program Management) arrives in v10–v11."
+
+### 4.3 QMS & Improvement landing
+
+Tile grid with 2 tiles:
+- **NCE Register** (in-progress) — "Non-conformity events. Carbon-React modernization (NCE v2) lands here when it ships."
+- **Audit Trail** (rehomed) — "Configuration / record-change audit log, rehomed from Admin. Admin cross-link preserved."
+
+Includes a `rehome-note` banner explaining: NCE Register lands as the destination URL for the in-progress NCE v2 build; Audit Trail rehomed from Admin; Electronic Signature Log arrives in v2; Accreditation management arrives in v2 with the existing `test-accreditation-frs.md` spec as the canonical implementation reference (community may lead).
+
+---
+
+## 5. Future-feature placeholder pages
+
+Two placeholder pages, one for each FUTURE feature. Each page has the same structure:
+
+- Page title (e.g., "Reagent QC")
+- Page subtitle: "Future feature — design exists; build not yet scheduled."
+- A `future-note` banner that explicitly states which of Piotr's four QC features this is, the lens it provides (the question), a one-paragraph functional summary, and a one-sentence "why this matters" closing.
+- A "Design document" panel with the GitHub-relative path and a `Read design doc on GitHub ↗` button linking to the public DIGI-UW/openelis-work URL.
+- A footer note explaining that the placeholder exists in v0.5 specifically to enable UAT testers to mark Madagascar GRIST LO-07-03 bullets PARTIAL with documented future-feature links.
+
+### 5.1 Reagent QC placeholder content
+
+- **Question (lens):** "Has this reagent lot been verified before we use it on patients?"
+- **Summary:** "Per-lot QC frequency tracking. Before a new reagent lot is used clinically, the system requires a documented set of verification samples comparing the new lot against the old lot or a peer-comparison reference. The data model holds which lots, which controls, which analyzer, which user, and which timestamp."
+- **Why it matters:** "Without lot verification, a bad reagent lot can ruin a week of patient results before anyone notices. Most labs do this informally today (paper logs, supervisor reminders); shipping it as a system feature catches the cases where the informal process fails."
+- **Design doc:** `designs/quality/batch-workplan-reagent-qc.md`
+
+### 5.2 Analyzer Manual QC placeholder content
+
+- **Question (lens):** "Did the technician run a daily control on this instrument today, and did it pass?"
+- **Summary:** "Daily PASS/FAIL log per instrument. Different instruments have different daily checks (a microscope has a calibration slide, a hematology analyzer has a precision check on a control sample, a refrigerator has a temperature reading). The system holds them all to one shape: a daily PASS/FAIL log with a signer, a timestamp, and a block on instrument use if FAIL."
+- **Why it matters:** "The first thing a CAP inspector asks when they walk into a lab is some version of 'show me your daily QC log for this instrument.' A signed log per instrument per day, every day. Forgetting it is what fails inspections."
+- **Design doc:** `designs/quality/analyzer-manual-qc.md`
+
+---
+
+## 6. Madagascar GRIST UAT alignment
+
+Per Piotr's "Concrete proposal for aligning the three reqs" (Slack 2026-05-01), v0.5 directly enables the three QC-related Madagascar UAT requirements to pass UAT with documented Round-2 rewrites.
+
+### 6.1 LO-07-02 (Internal Control)
+
+| Today | After v0.5 |
+|---|---|
+| Test points at `/analyzers/errors`; no clear surface | Test points at `/qa/qc/dashboard` (rehomed Westgard module); harness seeds a Westgard 1-3s violation |
+
+**Round-2 rewrite:** Update test step paths to `/qa/qc/dashboard`. Pre-seed via the harness fixture: a control lot with established mean/SD plus a fresh control result that breaches 1-3s. UAT tester runs the test; the violation surfaces on the QC Dashboard. ✓ **PASS.**
+
+### 6.2 LO-07-03 (Calibration samples — split)
+
+The original requirement smushes three independent bullets:
+
+| Bullet | Today | After v0.5 |
+|---|---|---|
+| Identify + exclude verification samples | EQA `isEqaSample` flag (V1, validates today) | Same V1 flow, now at `/qa/eqa/...` — UAT tester validates the EQA path |
+| Alert when verification not performed on new instrument | Analyzer Manual QC — future feature | Cross-link to `/qa/qc/manual-qc` placeholder → design doc on GitHub. **PARTIAL** with documented future reference. |
+| Batch-by-batch verification on new reagent lots (optimal-only) | Reagent QC — future feature | Cross-link to `/qa/qc/reagent-qc` placeholder → design doc on GitHub. **PARTIAL** with documented future reference. |
+
+**Round-2 rewrite:** Split the requirement into three bullets in Grist. Validate the EQA bullet via the existing V1 flow at the new URL. Mark the other two bullets PARTIAL with the placeholder-page URLs as documented future references. The Mekom team accepts PARTIAL with design-doc reference per the standing ISO 15189 partial-pass convention.
+
+### 6.3 LO-07-04 (Invalid quality indicators)
+
+| Today | After v0.5 |
+|---|---|
+| No clear surface | 3-step pass-through against `/qa/qc/alerts` (rehomed Alerts tab); piggybacks on LO-07-02's seeded violation |
+
+**Round-2 rewrite:** 3-step Alerts-tab walk against the seeded 1-3s violation from LO-07-02. The Alerts tab shows the violation with timestamp + analyzer + test + lot. ✓ **PASS.**
+
+### 6.4 Fixture seed (one-time harness setup)
+
+Per Piotr's recommendation, a single fixture seed satisfies LO-07-02 and LO-07-04 jointly:
+
+```
+Control lot: lot 22417C-TEST
+  test:        potassium
+  analyzer:    Architect ci8200 (test instance)
+  level:       Level 1
+  established_mean: 4.30 mmol/L
+  established_sd:   0.04
+  
+Run history (last 9 runs in window):
+  4.32, 4.28, 4.31, 4.35, 4.27, 4.29, 4.33, 4.30, 4.28
+  (all in tolerance)
+
+Triggering run (10th):
+  value: 4.46 mmol/L
+  z-score: +4.0 (breaches 1-3s and 1-2s)
+  expected violations: 1-3s (critical), 1-2s (warning)
+```
+
+The seed lives in the test repo (not in v0.5 production code). One-time setup; reused across UAT cycles.
+
+---
+
+## 7. Permission registry
+
+Four new permissions, all visibility-scoped (no `manage` permissions in v0.5 — nothing in v0.5 introduces editable surfaces that weren't already editable in their pre-rehome locations):
+
+| Permission key | Description |
+|---|---|
+| `qa.view.overview` | Visibility of the Quality Assurance top-level sidenav node. Required to see the QA group at all. |
+| `qa.view.qc` | Visibility of the Statistical QC pillar + its leaves (QC Dashboard, QC Alerts, Reagent QC + Analyzer Manual QC placeholders). |
+| `qa.view.eqa` | Visibility of the EQA pillar + existing EQA pages at new URLs. |
+| `qa.view.qms` | Visibility of the QMS pillar + NCE Register + Audit Trail. |
+
+**Existing permissions inherit unchanged.** A user who could see Westgard at `/analyzers/qc/db` can see it at `/qa/qc/dashboard` if they have `qa.view.qc` plus whatever permission gated the original Westgard page. Existing permission keys (NCE permissions, EQA permissions, audit permissions) remain authoritative for the underlying actions.
+
+**No default role changes in v0.5.** The QA Officer role is added in v1 (MVP).
+
+### 7.1 Visibility cascade
+
+```
+User sees QA top-level sidenav node          ⇔ qa.view.overview
+User sees Statistical QC pillar              ⇔ qa.view.overview ∧ qa.view.qc
+User sees EQA pillar                         ⇔ qa.view.overview ∧ qa.view.eqa
+User sees QMS pillar                         ⇔ qa.view.overview ∧ qa.view.qms
+User sees QC Dashboard / Alerts page         ⇔ qa.view.qc ∧ existing QC permission
+User sees specific EQA page                  ⇔ qa.view.eqa ∧ existing EQA permission
+User sees NCE Register / Audit Trail         ⇔ qa.view.qms ∧ existing NCE / audit permission
+```
+
+Direct navigation to `/qa/qc/dashboard` without the prerequisite permissions returns 403.
+
+---
+
+## 8. i18n
+
+### 8.1 New localization keys
+
+| Element | Key |
+|---|---|
+| Sidenav: Quality Assurance | `label.menu.qa` |
+| Sidenav: Statistical QC | `label.menu.qa.qc` |
+| Sidenav: EQA | `label.menu.qa.eqa` |
+| Sidenav: QMS & Improvement | `label.menu.qa.qms` |
+| Sidenav: QC Dashboard | `label.menu.qa.qc.dashboard` |
+| Sidenav: QC Alerts | `label.menu.qa.qc.alerts` |
+| Sidenav: Reagent QC | `label.menu.qa.qc.reagentQc` |
+| Sidenav: Analyzer Manual QC | `label.menu.qa.qc.manualQc` |
+| Sidenav: NCE Register | `label.menu.qa.qms.nceRegister` |
+| Sidenav: Audit Trail | `label.menu.qa.qms.auditTrail` |
+| Pillar landing: Statistical QC heading | `label.qa.qc.landing.heading` |
+| Pillar landing: Statistical QC sub | `label.qa.qc.landing.sub` |
+| Pillar landing: EQA heading | `label.qa.eqa.landing.heading` |
+| Pillar landing: QMS heading | `label.qa.qms.landing.heading` |
+| Tile tag: Rehomed | `label.qa.tag.rehome` |
+| Tile tag: Future | `label.qa.tag.future` |
+| Tile tag: In progress | `label.qa.tag.inProgress` |
+| Future-feature page: question label | `label.qa.future.questionLabel` |
+| Future-feature page: read design doc CTA | `label.qa.future.readDesignDoc` |
+| Rehome-note banner heading | `label.qa.rehomeNote.heading` |
+
+### 8.2 i18n requirements
+
+- Every visible string uses the `t(key, fallback)` pattern.
+- No hard-coded English in the new pillar-landing or future-placeholder components.
+- French and Khmer translations land alongside the English defaults at v0.5 release.
+
+---
+
+## 9. Frontend implementation
+
+### 9.1 What changes
+
+- **Sidenav**: new Carbon `SideNavMenu` for Quality Assurance with three sub-`SideNavMenu` entries for the pillars, each containing `SideNavMenuItem` entries for the leaves.
+- **Routes** (`react-router-dom` v6):
+
+```jsx
+<Route path="/qa">
+  <Route index element={<Navigate to="/qa/qc" replace />} />
+  <Route path="qc" element={<QCLanding />} />
+  <Route path="qc/dashboard" element={<QCDashboard />} />        {/* existing component */}
+  <Route path="qc/alerts" element={<QCAlerts />} />              {/* existing component */}
+  <Route path="qc/reagent-qc" element={<FutureFeaturePlaceholder feature="reagent-qc" />} />
+  <Route path="qc/manual-qc" element={<FutureFeaturePlaceholder feature="manual-qc" />} />
+  <Route path="eqa" element={<EQALanding />} />
+  <Route path="eqa/*" element={<EQARoutes />} />                 {/* existing EQA tree */}
+  <Route path="qms" element={<QMSLanding />} />
+  <Route path="qms/nce-register" element={<NCERegister />} />    {/* legacy or NCE v2 */}
+  <Route path="qms/nce/*" element={<NCEv2Routes />} />           {/* NCE v2 sub-tree */}
+  <Route path="qms/audit-trail" element={<AuditTrail />} />      {/* existing component */}
+</Route>
+```
+
+- **301 redirects** configured in the existing OpenELIS routing layer (path-rewrite middleware).
+- **Hidden legacy menu entries** in the existing sidenav component: Validation → Westgard, Admin → Audit Trail, top-level NCE.
+
+### 9.2 What does **not** change
+
+- Component implementations of QC Dashboard, QC Alerts, EQA pages, NCE workflows, Audit Trail. v0.5 mounts them at new routes; their internals are untouched.
+- Database schema. No new tables, no migrations.
+- Backend REST endpoints. (NCE v2 may add endpoints on its own; those are separate.)
+- Existing permission keys.
+
+### 9.3 New components (small)
+
+| Component | Purpose | LOC estimate |
+|---|---|---|
+| `<QualityAssurancePillarLanding pillar="qc|eqa|qms" />` | Generic tile-grid landing parameterized by pillar | ~120 lines |
+| `<FutureFeaturePlaceholder feature="reagent-qc|manual-qc" />` | FUTURE-feature placeholder with question / summary / why / design-doc link | ~90 lines |
+| `<RehomeNote leaf={leafSlug} />` | The blue rehome-note banner with old-path → new-path explanation | ~50 lines |
+
+All three are thin compositions of existing Carbon `Tile`, `InlineNotification`, and link components.
+
+### 9.4 File structure
+
+```
+src/main/webapp/app/quality-assurance/
+  index.jsx                     // route mount
+  pillar-landings/
+    QualityAssurancePillarLanding.jsx
+  placeholders/
+    FutureFeaturePlaceholder.jsx
+    rehome-content.js           // map of {leafSlug → {oldPath, description, etc.}}
+    future-content.js           // map of {feature → {question, summary, why, designDoc}}
+  shared/
+    RehomeNote.jsx
+```
+
+### 9.5 User-prefs
+
+The QA menu's default landing (which pillar opens when a user clicks the QA top-level node) persists per user via `user_pref` (existing). Default for new users: Statistical QC.
+
+---
+
+## 10. Acceptance criteria
+
+### 10.1 IA + sidenav
+
+- [ ] New top-level "Quality Assurance" sidenav group renders with the `New` tag.
+- [ ] Three pillar sub-menus render: Statistical QC, EQA, QMS & Improvement.
+- [ ] Statistical QC pillar shows four leaves: QC Dashboard, QC Alerts, Reagent QC (future), Analyzer Manual QC (future).
+- [ ] EQA pillar lists existing EQA pages at new URL prefix.
+- [ ] QMS pillar shows two leaves: NCE Register, Audit Trail.
+- [ ] Top-level Validation node no longer contains Westgard / QC Dashboard entries.
+- [ ] Admin → Audit Trail entry is removed (cross-link preserved as a redirect; old Admin item is hidden).
+- [ ] Old top-level NCE entry (if present) is hidden.
+- [ ] Active-state highlighting is correct on every pillar landing and leaf page.
+- [ ] Tile-tag rendering: rehomed leaves show a blue "moved" pill; future leaves show a gray "future" pill; in-progress leaves show a yellow "in progress" pill.
+
+### 10.2 Routing + redirects
+
+- [ ] `/analyzers/qc/db` 301-redirects to `/qa/qc/dashboard`.
+- [ ] `/analyzers/qc/db/alerts` 301-redirects to `/qa/qc/alerts`.
+- [ ] `/eqa/*` 301-redirects to `/qa/eqa/*` preserving sub-paths.
+- [ ] `/non-conform/*` 301-redirects to `/qa/qms/nce/*` preserving sub-paths.
+- [ ] `/admin/audit-trail` 301-redirects to `/qa/qms/audit-trail`.
+- [ ] All three pillar landings render at `/qa/qc`, `/qa/eqa`, `/qa/qms`.
+- [ ] FUTURE-feature placeholders render at `/qa/qc/reagent-qc` and `/qa/qc/manual-qc` with working design-doc cross-links to the public DIGI-UW/openelis-work URLs.
+- [ ] Browser back/forward preserves user-pref last-visited pillar.
+
+### 10.3 Permissions
+
+- [ ] User without `qa.view.overview` does not see the Quality Assurance node.
+- [ ] User without `qa.view.qc` does not see the Statistical QC pillar; direct navigation 403s.
+- [ ] User without `qa.view.eqa` does not see the EQA pillar; direct navigation 403s.
+- [ ] User without `qa.view.qms` does not see the QMS pillar; direct navigation 403s.
+- [ ] Underlying page-level permissions (Westgard config edit, Audit Trail view, NCE permissions) remain authoritative for actions within each page.
+
+### 10.4 FUTURE-feature placeholders
+
+- [ ] Reagent QC placeholder renders with the documented question, summary, why, and design-doc cross-link.
+- [ ] Analyzer Manual QC placeholder renders with the same structure.
+- [ ] Both placeholders link to the correct GitHub URLs (`designs/quality/batch-workplan-reagent-qc.md` and `designs/quality/analyzer-manual-qc.md` respectively).
+- [ ] Both placeholders render the "v0.5 Madagascar GRIST" footer note explaining why the placeholder exists.
+
+### 10.5 Madagascar GRIST UAT
+
+- [ ] LO-07-02 Round-2 test points at `/qa/qc/dashboard` and a seeded Westgard 1-3s violation appears.
+- [ ] LO-07-03 EQA-bullet validates against rehomed `/qa/eqa/...` path.
+- [ ] LO-07-03 instrument-verification + reagent-batch bullets are marked PARTIAL in Grist with links to the design-doc cross-link pages.
+- [ ] LO-07-04 3-step Alerts-tab walk passes against `/qa/qc/alerts`.
+- [ ] Fixture seed is in place in the test harness (control lot 22417C-TEST with mean=4.30, SD=0.04, plus a 10th run at 4.46 that breaches 1-3s).
+
+### 10.6 Cross-cutting
+
+- [ ] All new strings (sidenav labels, pillar landings, future-feature placeholder text) localized.
+- [ ] Lighthouse a11y score ≥ 95 on each new pillar-landing page.
+- [ ] Existing component a11y is unchanged (no regressions from rehome).
+- [ ] No console errors / warnings on any v0.5 page mount.
+
+---
+
+## 11. Open items
+
+### 11.1 Resolved during design
+
+| Question | Decision |
+|---|---|
+| Where do the four QC features live in the IA? | Three under Statistical QC (Westgard via QC Dashboard + QC Alerts; Reagent QC + Analyzer Manual QC as FUTURE placeholders). EQA gets its own pillar. |
+| What about NCE v2? | Lands at `/qa/qms/nce-register` when it ships. v0.5 reserves the URL and 301-redirects legacy `/non-conform/*`. |
+| Audit Trail location | QMS pillar with Admin cross-link preserved. |
+| FUTURE placeholder voice | "Future feature — design exists; build not yet scheduled" + design-doc link. Avoid "coming soon" without context. |
+| Madagascar GRIST UAT alignment | Per Piotr's proposal: LO-07-02 PASS, LO-07-03 SPLIT (EQA pass + 2 PARTIAL with design-doc refs), LO-07-04 PASS. |
+| Accreditation management | **Moved to v2** (was v3). Community may lead. Canonical implementation reference: `test-accreditation-frs.md`. |
+
+### 11.2 Outstanding (resolve before v0.5 merges)
+
+1. **NCE v2 scope** — does the in-progress NCE v2 build cover the modern register + create flow + analytics + CAPA register, or just the register? Confirm with Piotr / Mozzy. Determines how many later versions (v4–v7) collapse into v0.5/NCE v2 scope. **Owner:** Casey.
+2. **Old Admin → Audit Trail menu entry** — remove + 301 redirect (recommended) vs. leave a "Moved" entry. Confirm with Piotr.
+3. **Old Validation → Westgard entries** — same question. Recommend remove + 301 redirect.
+4. **Madagascar fixture seeding ownership** — Piotr's recommended fixture (control lot 22417C-TEST + 1-3s breach): lives in test repo, not v0.5 production code. Confirm test-repo location + commit ownership with Piotr.
+
+---
+
+## 12. Effort estimate
+
+| Item | Hours (low–high) |
+|---|---|
+| Top-level QA sidenav group + IA wiring | 4–6 |
+| Three pillar landings (`<QualityAssurancePillarLanding />`) | 4–6 |
+| Two FUTURE-feature placeholders (`<FutureFeaturePlaceholder />`) | 2–3 |
+| Route mounts for existing components at new paths | 4–6 |
+| 301 redirects for legacy URLs | 2–3 |
+| Permission registry (4 new keys, visibility-only) | 3–5 |
+| Hide legacy entry points (Validation > Westgard, Admin > Audit Trail, top-level NCE) | 2–3 |
+| Madagascar GRIST UAT step rewrites + fixture seed (test repo) | 3–5 |
+| Tests (route resolution + permission gating + redirect coverage + new-component snapshots) | 4–6 |
+| Cross-team PR review iteration (Westgard / EQA / NCE owners flagged) | 2–3 |
+| **v0.5 total** | **30–46** |
+
+Baseline midpoint: ~38h with Claude. Without Claude: ~55–85h.
+
+This sits between the original "Sprint 2 fast-follow MVP" estimate (~30h) and the previous v2 estimate (~30–40h). It also subsumes most of what was in v2, so the **post-v0.5 v2 shrinks to E-Sig Log + accreditation management (community-led) + cleanup** (~20–30h or less if community leads accreditation).
+
+---
+
+## 13. Cross-references
+
+| Document | Relevance |
+|---|---|
+| `qa-menu-versioning-plan.md` | Master version sequence — v0.5 inserts before v1; this FRS reflects the updated sequence |
+| `qa-v0.5-rehome-outline.md` | Outline-level scope and rationale; this FRS is its ship-ready consolidation |
+| `qa-v1-mvp-frs.md` | v1 ships on top of the v0.5 IA |
+| `qa-final-preview.html` | End-state mockup; v0.5 is the first ship-ready slice |
+| `qa-qc-narrative.md` | Audience-friendly walk-through of the four QC lenses + NCE/CAPA/QI/Accreditation |
+| `test-accreditation-frs.md` (uploaded) | Canonical implementation reference for v2 accreditation work (community may lead) |
+| `test-accreditation-mockup.jsx` (uploaded) | Reference Carbon-React implementation for the v2 accreditation pages |
+| `test-accreditation-preview.html` (uploaded) | Reference HTML preview for the v2 accreditation pages |
+| Piotr Mankowski Slack messages (2026-05-01) | Source of the four-QC-feature framing + Madagascar GRIST proposal |
+| `designs/quality/analyzer-manual-qc.md` (DIGI-UW/openelis-work) | Cross-linked from Analyzer Manual QC FUTURE placeholder |
+| `designs/quality/batch-workplan-reagent-qc.md` (DIGI-UW/openelis-work) | Cross-linked from Reagent QC FUTURE placeholder |
+| Beth Dunbar's L0-02-03 Audit Trail note | Justification for adding Audit Trail to the menu via QMS pillar |
+
+---
+
+## 14. Revision history
+
+| Version | Date | Author | Notes |
+|---|---|---|---|
+| 1.0 | 2026-05-01 | Casey | Initial ship-ready FRS for v0.5. Inserts before v1 (MVP) per user request. Incorporates Piotr's four-QC-feature mental model + Madagascar GRIST alignment proposal + Beth's Audit Trail note. Accreditation management moved to v2 (community may lead) with `test-accreditation-frs.md` as canonical reference. |
+
+---
+
+## Appendix A — Comparison: v0.5 vs. v1 vs. v2
+
+| Dimension | v0.5 | v1 (MVP) | v2 |
+|---|---|---|---|
+| Net-new features | None — pure IA | QI Dashboard MVP (4 KPI tiles) | E-Sig Log + Accreditation (community) |
+| Sidenav | Adds QA top-level + 3 pillars + 6 leaves | Adds QI Dashboard child to QI pillar (which v1 introduces under QA) | Adds E-Sig Log + Accreditation under QMS |
+| Backend | Routes + redirects only | 3 new wrappers (`/rest/qi/*`, `/rest/reports/tat/compliance`) | Accreditation backend (per `test-accreditation-frs.md`) |
+| New permissions | 4 visibility (`qa.view.*`) | + `qa.manage.qi` (reserved) + QA Officer role | + accreditation permissions |
+| Schema changes | None | None | New tables: `accrediting_body`, `test_accreditation` (per attached FRS) |
+| Effort estimate | 30–46h | 45–55h | 25–35h (down from 30–40h after v0.5 absorbs the rehomes) |
+| Risk profile | Low — IA only, no logic changes | Low — read-only wrappers + dashboard frontend | Medium — accreditation has report-rendering implications |
+| External dependencies | NCE v2 scope (in progress) | Flexible-roles engine, sample_test_order table name | Test Catalog Management surface for accreditation pages |
+
+---
+
+*End of v0.5 (IA Rehome) FRS.*

--- a/designs/quality/qa-menu-versioning-plan.md
+++ b/designs/quality/qa-menu-versioning-plan.md
@@ -1,0 +1,340 @@
+# QA Menu — Thin-Slice Versioning Plan
+
+**Date:** 2026-04-23
+**Author:** Casey Iiams-Hauser
+**Supersedes:** the 6-sprint structure in `qa-menu-roadmap.md` (kept for context, but versions below are the canonical sequence)
+
+---
+
+## Why thin slices
+
+The earlier 6-sprint plan grouped work by capability area (NCE bedrock, rehomes, Pillar 3, EQA V2, Results Entry). That worked for spec authoring but creates fat releases — Sprint 2 alone is 66–99h, Sprint 5 is 86–123h. Each release blocks on multiple modules being ready.
+
+Thin slicing aims for **~25–50h releasable units** that:
+
+- Land independently. Each version is a complete, shippable, useful thing.
+- Don't block on cross-team coordination unless explicitly needed.
+- Build on what came before — the previous version's surfaces stay live.
+- Can be re-ordered without breaking the IA. Hard dependencies are called out per-version.
+
+Total v1+ effort matches the Claude-assisted estimate from `effort-estimate-with-claude.md` (~360–500h for the equivalent of original Sprints 1–6). Slicing redistributes effort, doesn't add to it.
+
+---
+
+## Version sequence
+
+### v0.5 — IA Rehome + In-Progress Integration
+
+**Effort:** ~30–46h
+**Blocks on:** nothing — but coordinates with the in-progress NCE v2 build for the QMS pillar destination URL
+**Ships:** No net-new features. Gives every QA-adjacent existing/in-progress surface a coherent home so v1+ can land on a stable IA, and so the Madagascar GRIST UAT can pass.
+
+Scope (per `qa-v0.5-frs.md`):
+- New top-level **Quality Assurance** sidenav group with three pillars (Statistical QC, EQA, QMS & Improvement).
+- **Statistical QC pillar** — QC Dashboard + QC Alerts (rehomed from `/analyzers/qc/db`); Reagent QC + Analyzer Manual QC as FUTURE placeholders cross-linking to design docs on GitHub (per Piotr's four-QC-feature framing).
+- **EQA pillar** — existing EQA pages rehomed from `/eqa/...` to `/qa/eqa/...`.
+- **QMS pillar** — NCE Register (destination URL for in-progress NCE v2); Audit Trail rehomed from Admin (cross-link preserved).
+- 301 redirects from legacy URLs.
+- 4 new visibility-only permission keys (`qa.view.overview`, `qa.view.qc`, `qa.view.eqa`, `qa.view.qms`).
+- Madagascar GRIST UAT alignment: LO-07-02 PASS, LO-07-03 SPLIT (EQA pass + 2 PARTIAL with design-doc refs), LO-07-04 PASS.
+
+**Customer-visible value:** "Every QA feature lives in one menu. The four-QC-feature framing is preserved from day one. UAT testers can pass the Madagascar QC reqs with documented Round-2 rewrites."
+
+Out of scope (deferred to v1+): QA Overview, QI Dashboard, E-Sig Log, Accreditation, NCE modernization beyond what NCE v2 ships.
+
+---
+
+### v1 — QA Overview placeholder + QI Dashboard MVP
+
+**Effort:** ~45–55h
+**Blocks on:** nothing
+**Ships:** A working Quality Assurance sidenav with the QI Dashboard MVP populated. Other pillars visible as "coming soon" placeholders.
+
+Scope:
+- New top-level **Quality Assurance** sidenav group with the four pillar nodes (Statistical QC / EQA / Quality Indicators / QMS & Improvement) — three of them rendering placeholder pages.
+- **QA Overview** landing page with four pillar tiles. QI tile is live (rolls up from the QI Dashboard MVP); other three render gray "coming soon" with deep-links to existing surfaces (Validation, EQA, NCE) where applicable.
+- **QI Dashboard MVP** with four tiles (TAT Compliance, Rejection Rate, Amendment Rate, NCE Pulse) per `qa-mvp-kpi-rollup-outline.md`.
+- **Three new wrappers**: `/rest/reports/tat/compliance`, `/rest/qi/rejection-rate`, `/rest/qi/amendment-rate`.
+- NCE Pulse tile uses existing `/rest/nce/dashboard` with client-side filter (no new wrapper).
+- **Permission registry** — `qa.view.overview`, `qa.view.qi`, `qa.manage.qi` registered in the flexible-roles engine. Other pillar permissions registered as no-ops (locked-out by default).
+- **QA Officer default role** — pre-bundled with v1 permissions only.
+
+Out of scope (in later versions):
+- NCE menu rehome (URL stays at `/nce/...` for now; the QMS pillar's NCE Register node deep-links to the existing legacy URL).
+- Audit Trail rehome.
+- Any pillar functionality beyond the QI Dashboard MVP.
+- QI Configuration admin page.
+- Critical Callback Compliance.
+
+**Customer-visible value:** "We have a Quality Assurance menu and four KPI tiles."
+
+---
+
+### v2 — Electronic Signature Log + Test Accreditation Management
+
+**Effort:** ~25–35h core team + community contribution for accreditation
+**Blocks on:** v1 IA skeleton merged. Most of the original v2 rehome scope (NCE rehome, Audit Trail rehome, Westgard rehome) **moved to v0.5**.
+**Ships:** Electronic Signature Log + Test Accreditation Management surfaces.
+
+Scope:
+- **Electronic Signature Log** built per outline (small thanks to unified `electronic_signature` table audit). Reads `electronic_signature` directly with `record_type` filter; CSV/PDF export.
+- **Test Accreditation Management** per the existing `test-accreditation-frs.md` (uploaded reference). Two new admin pages under Test Catalog Management:
+  - **Accrediting bodies** (CRUD with logo + per-body expiration + logo visibility mode) — `/admin/test-catalog/accreditation/bodies`
+  - **Test accreditations** (pivot view; read-only; bulk-remove) — `/admin/test-catalog/accreditation/test-accreditations`
+  - Conditional logo rendering on patient reports + automated notes line.
+  - **Community may lead this build** — the spec is fully ready (`test-accreditation-frs.md` v5), the mockup exists (`test-accreditation-mockup.jsx`), and the HTML preview exists (`test-accreditation-preview.html`). This is a self-contained admin feature that's a good fit for community contribution.
+
+Out of scope:
+- Lab-attested accreditation registry under QMS (the earlier v3 design — superseded by Test Accreditation Management approach, which models accreditation by body + per-test enrollments rather than a self-attested record).
+
+**Customer-visible value:** "Inspectors get the signature log they ask for. Labs can configure which accrediting bodies they hold and which tests are accredited under each, with automatic logo rendering on reports."
+
+---
+
+### v3 — Reconsider scope post-NCE-v2
+
+**Effort:** TBD
+**Blocks on:** NCE v2 actual scope confirmed (currently in progress).
+**Ships:** Whatever NCE work didn't make NCE v2's scope, or rolls forward to a different version.
+
+The original v3 (lab-attested Accreditation Status registry) was superseded by moving Test Accreditation Management to v2. The original v4 (NCE Register modernization), v5 (NCE Create/Report flow), and v6 (NCE Analytics) may collapse into v0.5/NCE v2 scope depending on what NCE v2 actually delivers.
+
+**Action item before v3 planning:** confirm NCE v2 scope with Piotr / Mozzy (open question §11.2.1 of `qa-v0.5-frs.md`).
+
+---
+
+### v4 — NCE Register modernization
+
+**Effort:** ~40–50h
+**Blocks on:** v2 (URL re-rooting in place).
+**Ships:** Modern NCE Register UI replaces the legacy view at the rehomed URL.
+
+Scope:
+- NCE Register list + filter + detail per NCE FRS v3.1.
+- Five views: My Assignments / All NCEs / Pending Verification / Report NCE (link only — form is v5) / Analytics (link only — page is v6).
+- Inline row expansion with tabs (Event Details / Investigation / CAPA(n) / History).
+- Row actions and batch actions per FRS.
+- Summary cards (Critical / Major / Minor / Overdue).
+
+Out of scope:
+- Create / Report flow (v5).
+- Analytics page (v6).
+- CAPA Register (v7).
+
+**Customer-visible value:** "NCE list and detail are modernized. Same data, much better UX."
+
+---
+
+### v5 — NCE Create/Report flow
+
+**Effort:** ~30–40h
+**Blocks on:** v4 (Register lives under modern UI).
+**Ships:** Modern NCE creation flow with 11 trigger points wired in.
+
+Scope:
+- NCE Report form per FRS v3.1 §5.
+- 11 trigger points: sample rejection, partial rejection, result rejection w/wo retest, test cancellation, order cancellation, referral rejection, pathology, QC invalidation, disposal.
+- Context preloading from triggering artifact.
+- Inline form (no modal) per OpenELIS sidenav-submenus convention.
+- Update Results Entry "Report NCE" button to point at the new form (button itself stays; v9 swaps it for the inline panel).
+
+Out of scope:
+- Inline NCE form on Results Entry page (v9 — Phase-1 button stays for now).
+
+**Customer-visible value:** "All 11 NCE trigger points work; the Report NCE button writes through the modern flow."
+
+---
+
+### v6 — NCE Analytics page
+
+**Effort:** ~30–40h
+**Blocks on:** v4 (NCE Register in place); v5 helpful but not required.
+**Ships:** 4 KPI cards, 9 charts, 6 reports per `nce-analytics.md` v3.0.
+
+Scope:
+- 4 KPI tiles (Total NCEs / Avg Resolution / CAPA Effectiveness / Recurrence Rate).
+- 9 charts (Pareto, trend, category breakdown, severity breakdown, trigger breakdown).
+- 6 formal reports (Summary, CAPA Effectiveness, Root Cause, User Performance, Trend Analysis, Rejection Quality).
+- Lives under QA → QMS → NCE Register → Analytics (per qa-menu IA).
+
+**Customer-visible value:** "Lab leadership has a real NCE/CAPA analytics dashboard."
+
+---
+
+### v7 — CAPA Register
+
+**Effort:** ~25–35h
+**Blocks on:** v4 (uses the same NCE infrastructure); could land before v6 if priorities shift.
+**Ships:** Standalone CAPA list per `capa-register-outline.md` (with the post-Q&A scope additions).
+
+Scope:
+- 5 summary tiles (In Progress / Pending / Overdue / Pending Effectiveness Review / Completed last 90d).
+- Filter/sort by all documented dimensions.
+- Row expansion with effectiveness review status.
+- Bulk reassign + bulk Mark-Complete (single shared note).
+- Drill-through to parent NCE.
+- Linked-recurrence badge on closed-recurrence parents.
+
+**Customer-visible value:** "QA Officer has a single view of all CAPAs across all NCEs."
+
+---
+
+### v8 — QI Dashboard full + QI Configuration + Pillar-3 detail pages
+
+**Effort:** ~50–60h
+**Blocks on:** v1 (QI MVP exists for the swap).
+**Ships:** Full Pillar-3 functionality replacing the MVP in place.
+
+Scope:
+- QI Dashboard full version replaces MVP at the same URL (in-place swap; user prefs persist).
+- QI Configuration admin page per `qi-configuration-outline.md`.
+- Disable cascade implementation (tile/detail/alerts/NCE auto-gen all respect the toggle).
+- Per-test override table on Rejection Rate.
+- Detail pages for Rejection Rate + Amendment Rate (heatmap, Pareto, per-test breakdown).
+- TAT tile keeps deep-linking to existing TAT report.
+
+Out of scope:
+- Critical Callback Compliance (v9).
+
+**Customer-visible value:** "QIs are fully configurable; detail pages have heatmaps and Pareto analysis."
+
+---
+
+### v9 — Critical Callback Compliance opt-in
+
+**Effort:** ~30–40h
+**Blocks on:** v8 (QI Configuration page exists for the toggle); v5 (NCE Create flow handles the new subcategory).
+**Ships:** Optional fourth Pillar-3 QI for labs that perform critical-result callbacks.
+
+Scope:
+- Schema audit confirmed (CC-Q1) — schema may need extension for caller / recipient / read-back / ack-time fields.
+- Migration if needed.
+- NCE Report FRS v3.2 sub-revision adding the Critical Callback Failure subcategory + trigger.
+- QI tile + detail page.
+- Disabled by default in QI Configuration; labs opt-in.
+
+**Customer-visible value:** "Labs that need to track critical-result callback compliance now can."
+
+---
+
+### v10 — EQA V2 part 1: cycle/scheme model + participant + lab performance
+
+**Effort:** ~45–55h
+**Blocks on:** EQA V2 spec corpus is implementation-ready (currently specced but not yet built per memory entry).
+**Ships:** Cycle/scheme data model + 2 of 5 EQA V2 stories.
+
+Scope:
+- New cycle/scheme tables + migrations (model arrives with V2 build).
+- **My EQA** (participant view).
+- **EQA Lab Performance** dashboard (renamed from "Lab Performance Dashboard" per DEC07).
+- `/rest/eqa/cycles/latest-performance` wrapper.
+- QA Overview EQA tile lights up; Q2 of the five-question strip lights up.
+
+Out of scope (deferred to v11):
+- Follow-Up Queue.
+- Analyst Competency.
+- EQA Program Management rehome.
+
+**Customer-visible value:** "Participants can submit PT and see their performance scorecard; labs see cumulative performance across cycles."
+
+---
+
+### v11 — EQA V2 part 2: oversight tools
+
+**Effort:** ~40–50h
+**Blocks on:** v10.
+**Ships:** Remaining 3 EQA V2 stories.
+
+Scope:
+- **Follow-Up Queue** (failed-cycle actions tracked to resolution).
+- **Analyst Competency** (per-analyst competency per test; auto-suspension triggers on failure).
+- **EQA Program Management** rehome (`eqa.provider`-scoped visibility).
+
+**Customer-visible value:** "EQA oversight surfaces are fully built. Provider-side scoping respected."
+
+---
+
+### v12 — Results Entry inline NCE upgrade
+
+**Effort:** ~10–15h
+**Blocks on:** v5 (NCE Create flow exists — handler swap targets the new inline panel from `nce-results-entry.md` v3.0).
+**Ships:** Swaps the interim "Report NCE" button on Results Entry for the full inline panel.
+
+Scope:
+- Sample Action radios (Continue with NCE flag / Reject sample) at point-of-capture.
+- Auto-delta-check panel.
+- Mandatory trigger #4 (result rejection without retest) cannot be dismissed.
+- NCE flag badge on result rows with linked NCEs.
+- QA Officer training material refresh (small).
+
+**Customer-visible value:** "Analysts get the full v3.0 inline NCE experience at point of capture."
+
+---
+
+### v13+ — Original v2 backlog
+
+Deferred items from `qa-menu-roadmap.md` §11:
+
+- QC Lot Management.
+- Accreditation Binder PDF export.
+- Time-boxable Inspector/Auditor credentials.
+- Multi-site / multi-lab rollup.
+- Document Control module.
+- Equipment Management module.
+- Risk Register.
+- Internal Audit Tracker (full version).
+
+Each of these is a candidate v13, v14, v15, … to be sequenced based on customer demand.
+
+---
+
+## Total v0.5–v12 effort summary
+
+| Version | Effort (h) | Cumulative (h) | Notes |
+|---|---|---|---|
+| **v0.5 — IA Rehome + In-Progress Integration** | **30–46** | **30–46** | NEW — supersedes most of original v2 rehome scope |
+| v1 — QA menu + KPI MVP | 45–55 | 75–101 | Unchanged scope; lands on v0.5 IA |
+| v2 — E-Sig Log + Test Accreditation Management | 25–35 (core) | 100–136 | Reduced — most rehomes moved to v0.5; community may lead accreditation |
+| v3 — TBD post-NCE-v2 | TBD | — | Reconsider once NCE v2 scope is confirmed |
+| v4–v7 — Reconsider | TBD | — | NCE Register modernization / Create flow / Analytics / CAPA Register may collapse into NCE v2 |
+| v8 — QI Dashboard full + Config + details | 50–60 | — | Unchanged |
+| v9 — Critical Callback opt-in | 30–40 | — | Unchanged |
+| v10 — EQA V2 part 1 | 45–55 | — | Unchanged |
+| v11 — EQA V2 part 2 | 40–50 | — | Unchanged |
+| v12 — Results Entry inline | 10–15 | — | Unchanged |
+
+**Total: TBD pending NCE v2 scope clarification.** Pre-NCE-v2 versions (v0.5 + v1 + v2 + v8 onwards) total ~275–355h core team, with possible community contribution on v2's accreditation work reducing core team load by ~15–25h.
+
+Average slice: **~30–50h** for confirmed versions. NCE-related versions (v3–v7) await NCE v2 scope confirmation before re-estimating.
+
+---
+
+## Re-ordering
+
+The slice graph is mostly linear with a few flexible orderings:
+
+- **v3 (Accreditation Status) can ship before v2 (NCE rehome + Audit Trail rehome)** if customers ask. v3 doesn't depend on v2; it's just listed second because v2 is faster value to ship.
+- **v6 (NCE Analytics) can swap with v7 (CAPA Register)** depending on whether QA Officers ask first for analytics or for the CAPA list.
+- **v9 (Critical Callback) can be deferred indefinitely** if no customer asks. It's an opt-in feature.
+- **v10 + v11 (EQA V2)** are gated by EQA V2 spec corpus being implementation-ready. If that's not the case at the time we get there, both versions slide.
+
+Hard dependencies (must-not-reorder) are called out per-version above.
+
+---
+
+## How this changes the existing artifacts
+
+1. **`qa-menu-roadmap.md`** — keep for context (the 6-sprint structure remains the conceptual organization). Add a header note pointing to this versioning plan as the canonical delivery sequence.
+2. **`qa-menu-roadmap.xlsx`** — Sprint Plan rows get a new `Version` column mapping each row to v1–v12.
+3. **`qa-mvp-kpi-rollup-outline.md`** — content unchanged but it's now the v1 spec (was Sprint 2-MVP).
+4. **`effort-estimate-with-claude.md`** — keep for sprint-level estimate; add a note pointing to this versioning plan for the per-version breakdown.
+5. **All other outline files** — content unchanged; their version assignment is documented in this plan.
+
+---
+
+## Revision history
+
+| Version | Date | Notes |
+|---|---|---|
+| 0.1 | 2026-04-23 | Initial thin-slice plan. v1 = QA menu + QA Overview placeholder + QI Dashboard MVP (~50h). 12 slices total, ~33–43h average. Total ~400–510h matches original 6-sprint estimate. |
+| 0.2 | 2026-05-01 | Inserted **v0.5** before v1 per user request: IA-rehome version that consolidates existing + in-progress QA features (Westgard / EQA / NCE v2 / Audit Trail) plus FUTURE-feature placeholders for Reagent QC + Analyzer Manual QC (per Piotr's four-QC-feature framing). Madagascar GRIST UAT alignment baked in. v2 reframed: Test Accreditation Management (per `test-accreditation-frs.md`) replaces the lab-attested-registry approach; community may lead the build. v3–v7 marked TBD pending NCE v2 scope clarification. |

--- a/designs/quality/qa-qc-narrative.md
+++ b/designs/quality/qa-qc-narrative.md
@@ -1,0 +1,250 @@
+# Quality in the Lab — A Narrative Walk-Through of QA & QC in OpenELIS
+
+**Audience:** Anyone who needs to understand why a clinical lab cares so much about quality control — engineers, designers, project managers, donors, partner labs, QA officers new to the discipline.
+**Author:** Casey Iiams-Hauser
+**Date:** 2026-05-01
+**Companion docs:** `qa-menu-roadmap.md`, `qa-v0.5-rehome-outline.md`, Piotr Mankowski's landscape review (Slack #oe-madagascar-internal, 2026-05-01)
+
+---
+
+## Preamble — what is "quality" in a lab, really?
+
+A clinical laboratory's job is to give doctors numbers they can trust. A potassium of 4.2. A hemoglobin of 13.6. A culture growing E. coli. Nothing about the lab matters more than that those numbers are right.
+
+The trouble is, *being right* is hard to prove from the inside. The lab can't simply do the test again and check — that's the same machine, the same reagent, the same analyst, on the same day. To know your numbers are trustworthy, you need to look at the lab from four different angles, each answering a slightly different question:
+
+1. **Are the numbers from this analyzer-test-control-lot tuple still in tolerance?** *(Westgard / Internal QC.)*
+2. **Has this reagent lot been verified before we use it?** *(Reagent QC.)*
+3. **Did the technician run a daily control on this instrument today?** *(Analyzer Manual QC.)*
+4. **Do our results match what an external program says they should be?** *(EQA / Proficiency Testing.)*
+
+These are four separate lenses on the same question — *is the lab making valid measurements?* — and a serious lab does all four. ISO 15189 §7.7, the international standard for medical-lab quality, expects all four. The Madagascar GRIST requirements derive from §7.7. So do CAP and CLIA and the inspection regimes labs around the world live under.
+
+When something goes wrong — a control out of range, a missed reagent verification, a failed EQA cycle — the lab has to investigate, fix, and prove the fix worked. That investigation is called an **NCE** (Non-Conformity Event). The fix is called a **CAPA** (Corrective and Preventive Action). The proof-of-fix is called an **Effectiveness Review**. These are how the lab learns.
+
+The whole thing — the four lenses plus the NCE/CAPA cycle plus the records that prove all of it happened — is what people in the field call the lab's **QMS**, its Quality Management System. It's what an inspector audits. It's what an accreditor signs off on. It's what a hospital trusts.
+
+This narrative is seven acts. The first four are the four lenses. The fifth is what happens when one of the lenses sees something wrong. The sixth is how the QA Officer keeps an eye on all of it day-to-day. The seventh is the morning of an inspection.
+
+---
+
+## Act 1 — *The drift before the disaster* (Westgard / Internal QC)
+
+It's 6:47 AM in the chemistry lab. The first analyst on shift, Maria, hasn't taken off her coat yet. Before any patient sample touches the Architect ci8200, she runs three small bottles labeled *Level 1*, *Level 2*, *Level 3*. These are **control samples** — bottles of liquid with **known**, expected values for every analyte the analyzer measures. The lab gets them from the manufacturer in big lots; today's bottles are from lot 22417C, which the lab has been using for two months.
+
+Maria doesn't watch the controls run. She makes coffee. By the time she comes back, the analyzer has reported potassium on the Level 1 control as 4.36 mmol/L. The expected value, established six weeks ago when the lot opened, is 4.30 with a standard deviation of 0.04. So today's run sits at +1.5 standard deviations from the mean.
+
+That's fine. Anything within ±2 SD is fine, on its own. But Maria opens the **Levey-Jennings chart** — a running scatter plot of every Level 1 result for the last 20 days — and pauses. The last four mornings have been at +1.0, +1.4, +1.2, and +1.5 SD. Each individually unremarkable; together, a slow drift in the same direction.
+
+This is what **Westgard rules** are for. The system flags the pattern: "**4-1s**: four consecutive results on the same side of the mean, all > 1 SD." Not a critical violation, but a *warning* — the analyzer is starting to drift. If the drift continues, by next week some patient results will be biased high in a way no individual run will detect.
+
+Maria recalibrates the analyzer. Reruns Level 1. It comes back at 4.30, dead-on. She signs off the morning's QC. She makes a note in the system: "Recalibrated Architect ci8200 channel 4 (potassium) at 06:58 — 4-1s warning observed on lot 22417C, dawn shift."
+
+Patient samples can now run. Nothing went out wrong. The drift was caught before any patient was affected.
+
+This is **Westgard / Internal QC**. The lab uses control samples — substances with known expected values — and statistical rules to ask, every day: *are the numbers from this analyzer, on this test, with this control lot, still in tolerance?* The Westgard rules are the multi-rule statistical framework the field uses: 1-2s (warning), 1-3s (critical), 2-2s, R-4s, 4-1s, 10-x. Each rule has a specific failure mode it's designed to catch.
+
+In OpenELIS, Westgard rules and Levey-Jennings charts live under the Statistical QC pillar of the new Quality Assurance menu, in the QC Dashboard.
+
+---
+
+## Act 2 — *A new lot arrives* (Reagent QC) — *future feature*
+
+Tuesday afternoon, a courier drops off a flat box at Receiving. Inside: ten boxes of glucose reagent, lot **GL-26-04-117**, each box good for about 400 tests. The lab has been using lot 116; this is the next lot.
+
+Reagents are how analyzers actually run tests. The glucose enzyme reagent is what reacts with the patient's serum to produce a measurable color change. Different lots are made on different days, with slightly different enzyme batches, and a careful lab does not assume the new lot performs identically to the old one. Even small differences in reagent activity can shift patient results in clinically meaningful ways.
+
+So before the lab uses a single drop of lot 117 on a patient sample, the system requires **lot verification**: run a set of known control samples on the new lot and confirm that results match the old lot within a tolerance. The system tells Maria: "**New reagent lot GL-26-04-117. Run 4 verification samples (Levels 1, 2, 3, plus a peer-comparison reference) before clinical use.**"
+
+She queues the verification samples on the analyzer. Twenty minutes later, the system compares the four results to expected values and to lot 116's recent mean. All four within tolerance. The system marks lot 117 verified, records who verified it (Maria), at what time, on which analyzer. Lot 116 stays available until it's depleted; from this point, either lot can run patient samples.
+
+If the verification had failed — say, the Level 2 control read 0.5 mmol/L higher than expected — the system would have blocked lot 117 from clinical use until the lab investigated. Most often the answer is "ship the lot back, ask the manufacturer for a replacement." Sometimes the answer is "lot is fine, our analyzer's calibration is off; recalibrate." Either way the system tracks the question being asked, who asked it, what the answer was.
+
+This is **Reagent QC**. The lens is: *has this reagent lot been verified before we use it on patients?* The mechanism is per-lot QC frequency tracking — a list, per lot, of which verifications are required and when. The data model is small (which lot, which controls, which analyzer, which user, which timestamp), but the consequence of skipping it is large: a bad lot can ruin a week of patient results before anyone notices.
+
+In OpenELIS, Reagent QC is in design (`designs/quality/batch-workplan-reagent-qc.md` in DIGI-UW/openelis-work). Until it ships, the lab does this verification informally — a paper log, a lab supervisor's email reminders, an institutional habit. The placeholder leaf under the Statistical QC pillar in the new QA menu cross-links to the design doc so users can see where this is going.
+
+---
+
+## Act 3 — *The first thing the inspector asks* (Analyzer Manual QC) — *future feature*
+
+7:00 AM, cytology bench. James, the day-shift cytotechnologist, sits down at the microscope. Before he looks at a single patient slide, he pulls a calibration slide out of a small drawer — a glass slide etched with a graticule of known dimensions. He places it on the stage, focuses, and confirms that the 100µm marking on the graticule reads 100µm in the eyepiece reticle. He clicks **PASS** on a tablet next to the microscope.
+
+That's it. That's the entire workflow.
+
+The system records: James, this microscope, today's date, PASS. If James had clicked FAIL — say, the calibration was off — the system would have blocked test orders on this microscope until a supervisor cleared it. James would have called maintenance.
+
+It seems trivial. It is not. The first thing a CAP inspector asks when they walk into a lab is some version of: *show me your daily QC log for this instrument*. They want to see, for every day the lab claims to have run patient samples on this microscope, that someone signed off PASS or FAIL. Not "I think we did it." Not "I'm sure the night shift handled it." A signed log. Per instrument. Per day.
+
+This is **Analyzer Manual QC**. The lens is: *did the technician run a control on this instrument today, and did it pass?* Different instruments have different daily checks — a microscope has a calibration slide, a hematology analyzer has a precision check on a control sample, a refrigerator has a temperature reading. The system holds them all to the same shape: a daily PASS/FAIL log with a signer, a timestamp, and a block on instrument use if FAIL.
+
+It's the simplest of the four QC features. But the simplest is often the easiest to forget, and forgetting it is what fails inspections. The design doc lives at `designs/quality/analyzer-manual-qc.md` in DIGI-UW/openelis-work. The placeholder leaf under Statistical QC in the new QA menu links there.
+
+---
+
+## Act 4 — *The blind test from headquarters* (EQA / Proficiency Testing)
+
+In April, a small box arrives at the lab from CAP — the College of American Pathologists, the largest accreditor for clinical labs in the United States. Inside: five tubes of plasma, labeled with sample IDs but not with expected values. CAP knows what's in them. The lab does not.
+
+These are **EQA samples** — External Quality Assessment, also called Proficiency Testing or PT samples. The lab runs them through its analyzers exactly as if they were patient samples. The results don't go on any patient report. Instead, in May, the lab submits them back to CAP. In June, CAP grades the lab's results: how close was each one to the true value? Where did the lab fall in the distribution of all participating labs' results?
+
+This is the only one of the four lenses that is truly external. The first three (Westgard, Reagent QC, Manual QC) are the lab checking *itself*. EQA is somebody else checking the lab. If the lab's potassium control is happily reporting 4.30 every day but a third of all other labs running the same EQA sample report 4.40 — the lab might be subtly wrong in a way none of its internal controls can detect. That's why §7.7 of ISO 15189 mandates EQA participation: it's the only lens that can catch *systematic, lab-wide* error.
+
+The lab pays CAP for participation. CAP pays an entire department of staff to design samples, ship them, grade them, and publish the results. Several times a year, every clinical lab in the world that wants to be accredited goes through this cycle.
+
+In OpenELIS, when a sample arrives marked `isEqaSample = true`, the system handles it exactly like any other sample with one critical exception: it does not let the result go on a real patient report. Results route to an EQA submission file instead. This was already done in OpenELIS V1 — the `isEqaSample` flag works today. The full EQA V2 build (My EQA, Lab Performance dashboard, Follow-Up Queue, Analyst Competency, Program Management) is in spec, with implementation in v10–v11 of the QA menu roadmap. Until then, the lab uses the existing EQA module under the new EQA pillar.
+
+When the lab fails an EQA cycle — say, two of the five samples come back unsatisfactory — that triggers the next act.
+
+---
+
+## Act 5 — *When QC fails* (NCE → CAPA → Effectiveness Review)
+
+A signal from any of the four lenses can start this story. For ours: Maria's morning Westgard 4-1s violation from Act 1 came back the next day as a 1-3s — a single result more than 3 SD from the mean, which is a critical violation. Patient samples get held. Maria opens an **NCE** (Non-Conformity Event).
+
+An NCE is an investigation record. It captures the *what happened* (1-3s violation on Architect ci8200, channel 4, lot 22417C), the *immediate action* (samples held; recalibrate; rerun controls), the *trigger source* (which of 11 documented OpenELIS triggers fired this — in this case, QC invalidation), and the *severity* (Critical). It assigns to a person to investigate. It rides the affected sample as a flag downstream, so a clinician reading the eventual report sees that this result came from a run with a QC issue.
+
+Maria investigates. She finds it: the chemistry fridge's overnight temperature dipped to 2°C three nights in a row. The reagent isn't supposed to go below 4°C. The cold-stress shifted the enzyme kinetics enough to bias the potassium readings high. Root cause identified.
+
+She authors a **CAPA** — Corrective And Preventive Action. Two actions, actually: corrective ("Replace fridge thermometer; thermometer has been drifting"), and preventive ("Add daily temperature log, pre-printed on the lab's morning checklist; log auto-uploaded to the system"). Each CAPA gets an owner, a due date, and a category (Equipment / Process Change in this case).
+
+Three weeks later, the corrective action is done — new thermometer in, daily log running, no further temperature excursions. The CAPA goes to **Closed — Pending Verification**.
+
+Thirty days after that, the system prompts the QA Officer for an **Effectiveness Review**. She looks at the QC data for the past month: 28 days of in-control morning Westgard runs, no further drift, no 1-3s violations on the Architect for any analyte. She checks the new daily fridge log: 30 readings, all within range. She marks the CAPA *Effective*. The original NCE moves to **Closed — Verified**.
+
+If she had marked the CAPA *Not Effective* — say, drift had recurred — the system would automatically open a new NCE linked to the original, marked as a *recurrence*. The original moves to **Closed — Recurrence**. The investigation continues.
+
+This is **NCE / CAPA / Effectiveness Review**: the lab's learning loop. Every QC failure, every wrong patient result, every missed daily check — they all flow through this loop. Run it well and the lab gets quietly better, year over year. Run it poorly and the same problem keeps biting, and an inspector will eventually notice the pattern.
+
+In OpenELIS, NCE is the Carbon-React modernization currently being built ("NCE v2"). It rehomes under the QMS & Improvement pillar of the new QA menu. CAPA and Effectiveness Review live inside the NCE detail.
+
+---
+
+## Act 6 — *The QA Officer's morning* (Quality Indicators)
+
+7:50 AM, QA Officer's office. Sara has been the lab's QA Officer for three years. She has three children, an espresso machine, and a habit of starting every morning by opening one page on her computer.
+
+That page is the **QI Dashboard** under the Quality Indicators pillar of the new QA menu. Four tiles — five once Critical Callback Compliance is opted in:
+
+- **Average TAT** (turnaround time): 18h 47m, down 32 minutes from last month. *Acceptable.* She clicks in: Microbiology is the slowest at 61 hours, which makes sense — culture and sensitivity has biological time built in. Chemistry is at 18 hours; that's good, last summer it crept above 24 and she had to chase three sections to clean up holding times.
+- **Rejection Rate**: 1.7%, down from 2.0% last month. *Within target* (target < 2%). She drills in: hemolysis is still the top reason at 38%, but Hematology — the worst category — has come down from 4.1% to 3.2% since the phlebotomy retraining she ordered three months ago. The retraining worked.
+- **Amendment Rate**: 0.31%, up slightly from 0.26%. *Approaching action threshold* (target < 0.5%). Eight results amended this month after release. She doesn't drill in yet — the count is small enough that she'll wait another week before investigating.
+- **NCE Pulse**: 5 critical NCEs pending acknowledgment. *Red.* All five are within their acknowledgment SLA, but she clicks in to check: three are from yesterday (a fridge incident, a hemolysis cluster, and a wrong-tube event from the ER); two are from earlier in the week and have been assigned. None are stuck. She acknowledges the three from yesterday so the analysts know they're seen.
+
+That's most of her daily check. Eight minutes, four numbers, a sense of the lab's health.
+
+The point of the QI Dashboard is not to surface emergencies — those route through alerts and pages directly. The point is to surface the *slow drift*: the rejection rate creeping up over months, the TAT slowly degrading on a busy section, the amendment rate edging toward the action threshold one week at a time. These patterns are invisible at the per-result level. They reveal themselves on the dashboard.
+
+In OpenELIS, this dashboard is the v1 (MVP) deliverable of the new QA menu — the first net-new feature after the IA reorganization in v0.5. It launches with four tiles. Critical Callback Compliance opts in via QI Configuration in v8 for labs that need the fifth tile.
+
+---
+
+## Act 7 — *The morning of the inspection*
+
+8:30 AM, Wednesday. The inspector arrives. She is from CAP, has been doing this for fifteen years, has seen every lab story imaginable. She has two hours scheduled with Sara before she rotates to the analyzer floor.
+
+In the old workflow — pre-QA-menu — Sara would have had a binder. Or two binders. Or a folder of PDFs. The QC log lived in the Validation module, the EQA cycle results in a separate report, the NCE list under a top-level menu nobody could find, the audit trail in the Admin menu, the accreditation certificates in a filing cabinet behind her desk. To answer the inspector's question — *show me your evidence that this lab is operating in a state of quality control* — Sara would have spent ten minutes navigating, exporting, and reassembling.
+
+In the new workflow — with the QA menu in place — Sara opens it once.
+
+**Quality Assurance → QA Overview.** The page renders five questions ISO 15189:2022 expects every lab to be able to answer at any moment, with the lab's current answer next to each one:
+
+> 1. **Are runs in control?** ✓ 47 of 47 runs in control, last review 2 days ago.
+> 2. **How did EQA perform last cycle?** ✓ 4 of 4 schemes acceptable, cycle 2026-Q1 graded.
+> 3. **Are QIs on target?** ⚠ 4 of 5 indicators within target — Amendment Rate amber.
+> 4. **Open critical NCEs?** ✗ 5 critical pending acknowledgment — all within SLA.
+> 5. **Accreditation status?** ⚠ ISO 15189 + CAP COM current; CAP GEN inspection due in 47 days.
+
+Below the questions, four pillar tiles. Below those, a single click takes the inspector to the underlying detail for any answer she wants to verify. *Show me a Westgard violation from last week.* Click → QC Dashboard → Alerts. *Show me your most recent EQA scorecard.* Click → EQA → Lab Performance. *Show me how that critical NCE from last Friday was resolved.* Click → NCE Register → detail → CAPA tab → Effectiveness Review.
+
+The inspector leaves at 10:32 AM. She tells Sara, on the way out, that she has rarely seen a lab that could navigate its own quality story this fast. The inspection writes up clean.
+
+This is what the QA menu — every act of this story put together in one navigable surface — is for. Each individual feature already exists or is on its way; what was missing was the coherent home that lets a QA Officer or an inspector see the whole picture in three clicks.
+
+ISO 15189 §7.7 is satisfied. CAP is satisfied. The lab passes.
+
+The patients — the actual point of all of this — never knew anything was happening. Their potassium results came back right.
+
+That's the whole job.
+
+---
+
+## How this connects to what we're building
+
+The seven acts of this narrative map directly to the QA menu architecture:
+
+| Act | Feature | Pillar in new QA menu | Status today |
+|---|---|---|---|
+| 1 | Westgard / Internal QC | Statistical QC → QC Dashboard | Merged into OpenELIS-Global-2 |
+| 2 | Reagent QC | Statistical QC → Reagent QC *(future)* | Design doc only |
+| 3 | Analyzer Manual QC | Statistical QC → Analyzer Manual QC *(future)* | Design doc only |
+| 4 | EQA | EQA pillar | V1 done (`isEqaSample` flag); V2 in v10–v11 |
+| 5 | NCE / CAPA / Effectiveness | QMS & Improvement → NCE Register | NCE v2 in progress |
+| 6 | QI Dashboard | Quality Indicators → QI Dashboard | MVP in v1; full in v8 |
+| 7 | The whole picture (QA Overview) | QA Overview (top of the QA menu) | v1 (MVP) ships an early version; full in v8 |
+
+v0.5 — the first version of the QA menu that lands — gives every existing and in-progress feature a coherent home. v1 (MVP) adds the QI Dashboard. Subsequent versions fill in the rest. By the time v12 ships, every act in this story has a working surface in the system.
+
+---
+
+## Image generation prompts (one per act)
+
+A consistent visual style across the seven images keeps the narrative cohesive. The recommended style:
+
+> **Warm documentary photograph, soft natural light, shallow depth of field, muted color palette, 16:9 aspect ratio, focus on hands or environment over faces, 35mm film aesthetic.**
+
+Each prompt below builds on that base. Add the style line to every prompt, or set it as a system-style if your image generator supports persistent style instructions.
+
+---
+
+### Act 1 — *The drift before the disaster*
+
+> A close-up of a desktop computer screen in a clinical chemistry laboratory at dawn, displaying a Levey-Jennings control chart — a horizontal line graph of small dots scattered around a central mean line, with three of the rightmost dots clearly trending upward toward a +2 SD reference band. A coffee cup sits next to the keyboard. The light is cool blue from the window, warm yellow from the screen. A white-coated arm reaches into the frame from the left, holding a small bottle labeled "QC Level 1 — Lot 22417C." [Style line above.]
+
+---
+
+### Act 2 — *A new lot arrives*
+
+> A medical laboratory technician's hands unboxing ten neatly stacked boxes of reagent kits on a stainless-steel benchtop. Each box is labeled with a barcode and a lot number "GL-26-04-117." A tablet on the bench displays a checklist titled "Lot Verification Required" with four unchecked boxes. Soft afternoon light from a side window. The technician's face is out of frame; only blue-gloved hands and the boxes are visible. [Style line above.]
+
+---
+
+### Act 3 — *The first thing the inspector asks*
+
+> A cytotechnologist seated at a binocular microscope at a clinical lab bench, viewed from a three-quarter rear angle so their face is not visible. They are placing a thin glass calibration slide onto the microscope stage. A tablet to the right of the microscope shows a simple two-button interface: a large green "PASS" button and a smaller red "FAIL" button, with the heading "Daily Manual QC — Microscope #3 — 2026-05-01." Soft warm overhead light. [Style line above.]
+
+---
+
+### Act 4 — *The blind test from headquarters*
+
+> A small white cardboard shipping box, opened, sitting on a clinical lab bench. Inside the box, five identical plasma sample tubes with bright orange caps, each labeled with a printed sample ID like "PT-26-Q2-A03" but no expected value. A folded letter from "College of American Pathologists" partially visible underneath. A hand in a blue glove reaches in to lift one of the tubes. Cool natural light from a north-facing window. [Style line above.]
+
+---
+
+### Act 5 — *When QC fails*
+
+> A whiteboard or large notebook page in a quality officer's office, titled "NCE-20260105-0023 — Investigation" at the top. Beneath the title, a hand-drawn cause-and-effect diagram (fishbone) with branches labeled "Equipment / Reagent / Method / Personnel / Environment." Sticky notes and a temperature log printout are taped near the bottom. A coffee mug and a half-eaten croissant on the desk. Warm afternoon light through window blinds, casting horizontal stripes across the wall. [Style line above.]
+
+---
+
+### Act 6 — *The QA Officer's morning*
+
+> A QA Officer's desk in a clinical laboratory, photographed from a slight side angle. On a 27-inch monitor, a clean dashboard interface with four large rectangular tiles arranged in a 2×2 grid: "Average TAT — 18h 47m," "Rejection Rate — 1.7%," "Amendment Rate — 0.31%," "NCE Pulse — 5 critical." Each tile shows a small trend arrow. Beside the monitor, a ceramic mug of espresso, a notebook open to a half-written page, and a small framed photograph of a child's drawing. Warm morning light from a window behind the monitor. [Style line above.]
+
+---
+
+### Act 7 — *The morning of the inspection*
+
+> Two women in business-professional attire seated together at a small round meeting table in a clinical laboratory's office, viewed from a respectful distance so neither face is fully visible. One holds a CAP-branded clipboard; the other gestures at a laptop screen between them. The laptop displays a clean web page with a sidebar menu reading "Quality Assurance" and a main panel labeled "QA Overview" with five rows, each showing a question and an answer with a small status icon (✓ ⚠ ✗). On the wall behind them, framed accreditation certificates. Soft daylight from a large window. The mood is calm, professional, even slightly warm. [Style line above.]
+
+---
+
+## Optional bonus image — *the whole story in one frame*
+
+If you want a single hero image for the top of a presentation or an article, this one stitches the four QC lenses into a single composition:
+
+> A laboratory bench photographed from directly above, divided into four quadrants by faint dividers. Quadrant 1 (top-left): a Levey-Jennings chart on a tablet, with control bottles. Quadrant 2 (top-right): an unboxed reagent kit with a tablet showing "Lot Verification." Quadrant 3 (bottom-left): a microscope with a calibration slide and a "PASS / FAIL" tablet. Quadrant 4 (bottom-right): an EQA shipping box with sealed sample tubes. In the very center, where the quadrants meet, a single coffee mug sits as if forgotten there, anchoring the composition. Even, warm overhead light. [Style line above.]
+
+---
+
+*End of narrative.*

--- a/mockup-viewer/public/designs/quality/qa-menu-v0.5.html
+++ b/mockup-viewer/public/designs/quality/qa-menu-v0.5.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QA Menu v0.5 — Preview (IA rehome + in-progress)</title>
+
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+
+  <style>
+    :root { --rail-w: 256px; --header-h: 48px; }
+    * { box-sizing: border-box; }
+    body { margin: 0; font-family: 'IBM Plex Sans', system-ui, sans-serif; background: #f4f4f4; color: #161616; }
+
+    .app-header { height: var(--header-h); background: #161616; color: #fff; display: flex; align-items: center; padding: 0 1rem; gap: 1rem; position: sticky; top: 0; z-index: 50; }
+    .app-header .brand { font-size: 0.875rem; font-weight: 500; letter-spacing: 0.04em; }
+    .app-header .brand .sub { opacity: 0.7; font-weight: 400; margin-left: 0.5rem; }
+    .app-header .spacer { flex: 1; }
+    .app-header .user-chip { font-size: 0.8125rem; opacity: 0.85; padding: 0.25rem 0.5rem; border: 1px solid #393939; }
+
+    .layout { display: flex; min-height: calc(100vh - var(--header-h)); }
+    .rail { width: var(--rail-w); flex: 0 0 var(--rail-w); background: #fff; border-right: 1px solid #e0e0e0; display: flex; flex-direction: column; position: sticky; top: var(--header-h); height: calc(100vh - var(--header-h)); overflow-y: auto; }
+    .main { flex: 1; padding: 1.5rem 2rem; max-width: 100%; overflow-x: auto; }
+
+    .rail-title { padding: 1rem 1rem 0.5rem 1rem; font-size: 0.75rem; letter-spacing: 0.06em; color: #525252; text-transform: uppercase; }
+    .rail-bucket { display: flex; align-items: center; width: 100%; padding: 0.625rem 1rem; font-size: 0.875rem; color: #161616; background: transparent; border: 0; border-left: 3px solid transparent; cursor: pointer; text-align: left; font-family: inherit; }
+    .rail-bucket:hover { background: #e5e5e5; }
+    .rail-bucket.current { background: #edf5ff; border-left-color: #0f62fe; font-weight: 600; }
+    .rail-bucket.is-new { color: #0043ce; }
+    .rail-bucket .icon { margin-right: 0.625rem; flex: 0 0 20px; display: inline-flex; justify-content: center; }
+    .rail-bucket .label { flex: 1; }
+    .rail-bucket .new-tag { font-size: 0.625rem; background: #defbe6; color: #0e6027; padding: 0.0625rem 0.375rem; border-radius: 8px; margin-left: 0.375rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .rail-bucket .chev { flex: 0 0 16px; opacity: 0.6; font-size: 0.75rem; transition: transform 0.12s; margin-left: 0.25rem; }
+    .rail-bucket.expanded .chev { transform: rotate(180deg); }
+    .rail-children { display: none; background: #fafafa; border-top: 1px solid #f0f0f0; }
+    .rail-bucket.expanded + .rail-children { display: block; }
+
+    .rail-pillar { display: flex; align-items: center; width: 100%; padding: 0.5rem 1rem 0.5rem 2.25rem; font-size: 0.8125rem; background: transparent; border: 0; cursor: pointer; text-align: left; font-family: inherit; color: #161616; font-weight: 500; }
+    .rail-pillar:hover { background: #e8e8e8; }
+    .rail-pillar.current { background: #e0e0e0; }
+    .rail-pillar .chev { font-size: 0.625rem; margin-left: auto; opacity: 0.6; transition: transform 0.12s; }
+    .rail-pillar.expanded .chev { transform: rotate(180deg); }
+
+    .rail-pillar-children { display: none; }
+    .rail-pillar.expanded + .rail-pillar-children { display: block; }
+    .rail-page { display: flex; align-items: center; width: 100%; padding: 0.4375rem 1rem 0.4375rem 3.5rem; font-size: 0.8125rem; color: #525252; background: transparent; border: 0; border-left: 3px solid transparent; cursor: pointer; text-align: left; font-family: inherit; }
+    .rail-page:hover { background: #ececec; }
+    .rail-page.current { background: #edf5ff; border-left-color: #0f62fe; font-weight: 600; color: #161616; }
+    .rail-page .pill { margin-left: auto; font-size: 0.625rem; padding: 0.0625rem 0.375rem; border-radius: 8px; letter-spacing: 0.04em; text-transform: uppercase; }
+    .rail-page .pill.new { background: #defbe6; color: #0e6027; }
+    .rail-page .pill.rehome { background: #d0e2ff; color: #002d9c; }
+    .rail-page .pill.future { background: #f4f4f4; color: #6f6f6f; }
+    .rail-page .pill.in-progress { background: #fff1c2; color: #6f4700; }
+
+    .crumb { font-size: 0.8125rem; color: #525252; margin-bottom: 0.5rem; }
+    .crumb a { color: #0f62fe; text-decoration: none; cursor: pointer; }
+    .crumb a:hover { text-decoration: underline; }
+    .crumb .sep { margin: 0 0.375rem; }
+    .crumb .current { color: #161616; font-weight: 500; }
+
+    h1.page-title { font-size: 1.75rem; font-weight: 300; margin: 0 0 0.25rem 0; letter-spacing: -0.01em; }
+    p.page-sub { color: #525252; margin: 0 0 1.5rem 0; font-size: 0.9375rem; }
+
+    .preview-note {
+      background: #fdf6dd; border-left: 3px solid #f1c21b;
+      padding: 0.625rem 0.875rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #684e00;
+    }
+    .preview-note code { background: rgba(0,0,0,0.06); padding: 0.0625rem 0.25rem; }
+
+    /* Pillar landing tile grid */
+    .leaf-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 1rem; }
+    .leaf-tile {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+      cursor: pointer; transition: background 0.12s;
+      display: flex; flex-direction: column; gap: 0.5rem;
+    }
+    .leaf-tile:hover { background: #fafafa; border-color: #0f62fe; }
+    .leaf-tile h3 { font-size: 0.9375rem; font-weight: 600; margin: 0; display: flex; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
+    .leaf-tile p { font-size: 0.8125rem; color: #525252; margin: 0; line-height: 1.5; }
+    .leaf-tile .tag { font-size: 0.625rem; padding: 0.0625rem 0.375rem; border-radius: 8px; letter-spacing: 0.04em; text-transform: uppercase; }
+    .leaf-tile .tag.new { background: #defbe6; color: #0e6027; }
+    .leaf-tile .tag.rehome { background: #d0e2ff; color: #002d9c; }
+    .leaf-tile .tag.future { background: #f4f4f4; color: #6f6f6f; }
+    .leaf-tile .tag.in-progress { background: #fff1c2; color: #6f4700; }
+    .leaf-tile.future { background: #f7f7f7; border-style: dashed; }
+    .leaf-tile.future:hover { background: #f4f4f4; border-color: #c6c6c6; }
+    .leaf-tile .deep-link { font-size: 0.75rem; color: #0f62fe; margin-top: auto; padding-top: 0.5rem; }
+    .leaf-tile.future .deep-link { color: #525252; }
+
+    /* Rehome stub note */
+    .rehome-note {
+      background: #d0e2ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #002d9c;
+    }
+    .rehome-note strong { color: #002d9c; }
+    .rehome-note code { background: rgba(0,0,0,0.06); padding: 0.0625rem 0.25rem; font-size: 0.8125rem; }
+
+    .future-note {
+      background: #f4f4f4; border-left: 3px solid #8d8d8d;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #393939;
+    }
+    .future-note strong { color: #161616; }
+
+    .in-progress-note {
+      background: #fff1c2; border-left: 3px solid #f1c21b;
+      padding: 0.75rem 1rem; margin-bottom: 1.25rem;
+      font-size: 0.8125rem; color: #6f4700;
+    }
+
+    .stub-app-frame {
+      background: #fafafa; border: 1px dashed #c6c6c6; padding: 2rem;
+      text-align: center; color: #6f6f6f; font-size: 0.875rem;
+    }
+    .stub-app-frame .frame-title { font-weight: 600; color: #393939; margin-bottom: 0.25rem; }
+
+    .design-doc-link {
+      display: inline-block; padding: 0.5rem 0.875rem; background: #fff;
+      border: 1px solid #c6c6c6; color: #0f62fe; font-size: 0.875rem;
+      cursor: pointer; font-family: inherit; text-decoration: none;
+      margin-top: 0.5rem;
+    }
+    .design-doc-link:hover { background: #f4f4f4; border-color: #0f62fe; }
+
+    /* GRIST alignment block */
+    .grist-block {
+      background: #fff; border: 1px solid #e0e0e0; padding: 1.25rem;
+      margin-top: 1.5rem;
+    }
+    .grist-block h3 { margin: 0 0 0.75rem 0; font-size: 0.9375rem; }
+    .grist-block table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+    .grist-block th, .grist-block td { padding: 0.5rem 0.75rem; text-align: left; border-bottom: 1px solid #f0f0f0; }
+    .grist-block th { background: #f4f4f4; font-weight: 500; color: #525252; font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .grist-block .req-id { font-family: 'IBM Plex Mono', monospace; font-size: 0.75rem; }
+    .grist-block .pass { color: #198038; font-weight: 600; }
+    .grist-block .partial { color: #f1c21b; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect, Fragment } = React;
+
+    /*
+     * v0.5 — IA rehome + in-progress integration.
+     *
+     * What ships in v0.5:
+     *   - New top-level "Quality Assurance" sidenav group
+     *   - Statistical QC pillar:
+     *       - QC Dashboard (rehomed from /analyzers/qc/db — fully merged today)
+     *       - QC Alerts (rehomed)
+     *       - Reagent QC (FUTURE placeholder, design-doc cross-link)
+     *       - Analyzer Manual QC (FUTURE placeholder, design-doc cross-link)
+     *   - EQA pillar (rehomed; existing V1 EQA functionality)
+     *   - QMS & Improvement pillar:
+     *       - NCE Register (NCE v2 in progress — landing site for the modernization)
+     *       - Audit Trail (rehomed from Admin; was missing from menu per Beth)
+     *
+     * What does NOT ship in v0.5:
+     *   - QA Overview landing page → v1 (MVP)
+     *   - QI Dashboard MVP → v1 (MVP)
+     *   - Electronic Signature Log → v2
+     *   - Accreditation management → v2 (community-led; uses test-accreditation specs)
+     *   - Modern NCE Create/Report flow / Analytics / CAPA Register → reconsider after NCE v2 lands
+     *
+     * v0.5's job is purely IA: give the existing + in-progress features a coherent home so
+     * the Madagascar GRIST UAT (LO-07-02 / -03 / -04) can pass and so v1 (MVP) lands on
+     * a stable container.
+     */
+
+    const TOP_LEVEL = [
+      { slug: 'home', label: 'Home', icon: '🏠' },
+      { slug: 'order', label: 'Order', icon: '📋' },
+      { slug: 'results', label: 'Results', icon: '🧪' },
+      { slug: 'patient', label: 'Patient', icon: '👤' },
+      { slug: 'sample', label: 'Sample', icon: '🩸' },
+      { slug: 'qa', label: 'Quality Assurance', icon: '⚖️', isNew: true,
+        children: [
+          { slug: 'qc', label: 'Statistical QC', kind: 'pillar', children: [
+            { slug: 'dashboard', label: 'QC Dashboard',  tag: 'rehome' },
+            { slug: 'alerts',    label: 'QC Alerts',     tag: 'rehome' },
+            { slug: 'reagent-qc', label: 'Reagent QC',   tag: 'future' },
+            { slug: 'manual-qc',  label: 'Analyzer Manual QC', tag: 'future' },
+          ] },
+          { slug: 'eqa', label: 'EQA', kind: 'pillar', children: [
+            { slug: 'eqa-home', label: 'EQA (existing)', tag: 'rehome' },
+          ] },
+          { slug: 'qms', label: 'QMS & Improvement', kind: 'pillar', children: [
+            { slug: 'nce-register', label: 'NCE Register', tag: 'in-progress' },
+            { slug: 'audit-trail',  label: 'Audit Trail',  tag: 'rehome' },
+          ] },
+        ] },
+      { slug: 'reports', label: 'Reports', icon: '📊' },
+      { slug: 'admin', label: 'Administration', icon: '⚙️' },
+    ];
+
+    function parseHash() {
+      const raw = window.location.hash.replace(/^#/, '') || '/qa/qc';
+      const parts = raw.split('/').filter(Boolean);
+      if (parts[0] !== 'qa') return { kind: 'qc-landing' };
+      const pillar = parts[1];
+      const leaf = parts[2];
+      if (!pillar) return { kind: 'qc-landing' };
+      if (!leaf) return { kind: 'pillar-landing', pillar };
+      return { kind: 'leaf', pillar, leaf };
+    }
+    function useRoute() {
+      const [route, setRoute] = useState(parseHash());
+      useEffect(() => {
+        const onHash = () => setRoute(parseHash());
+        window.addEventListener('hashchange', onHash);
+        return () => window.removeEventListener('hashchange', onHash);
+      }, []);
+      return route;
+    }
+    const go = h => { window.location.hash = h; };
+
+    function AppHeader() {
+      return (
+        <div className="app-header">
+          <span className="brand">OpenELIS Global<span className="sub">— v0.5 preview (IA rehome)</span></span>
+          <span className="spacer"></span>
+          <span className="user-chip">Casey · QA Officer</span>
+        </div>
+      );
+    }
+
+    function Rail({ route }) {
+      const isQA = ['pillar-landing','leaf','qc-landing'].includes(route.kind);
+      const expandedPillar = route.pillar || (route.kind === 'qc-landing' ? 'qc' : null);
+
+      const isCurrentLeaf = (pillar, slug) => {
+        if (route.kind !== 'leaf') return false;
+        return route.pillar === pillar && route.leaf === slug;
+      };
+
+      return (
+        <aside className="rail">
+          <div className="rail-title">Navigation</div>
+          {TOP_LEVEL.map(item => (
+            <Fragment key={item.slug}>
+              {item.children ? (
+                <Fragment>
+                  <button className={`rail-bucket ${isQA ? 'expanded current' : ''} ${item.isNew ? 'is-new' : ''}`}>
+                    <span className="icon">{item.icon}</span>
+                    <span className="label">{item.label}</span>
+                    {item.isNew && <span className="new-tag">New</span>}
+                    <span className="chev">▾</span>
+                  </button>
+                  <div className="rail-children">
+                    {item.children.map(p => {
+                      const isExpanded = expandedPillar === p.slug;
+                      return (
+                        <Fragment key={p.slug}>
+                          <button className={`rail-pillar ${isExpanded ? 'expanded current' : ''}`}
+                            onClick={() => go(`/qa/${p.slug}`)}>
+                            <span>{p.label}</span>
+                            <span className="chev">▾</span>
+                          </button>
+                          <div className="rail-pillar-children" style={{ display: isExpanded ? 'block' : 'none' }}>
+                            {p.children.map(leaf => (
+                              <button key={leaf.slug}
+                                className={`rail-page ${isCurrentLeaf(p.slug, leaf.slug) ? 'current' : ''}`}
+                                onClick={() => go(`/qa/${p.slug}/${leaf.slug}`)}>
+                                <span>{leaf.label}</span>
+                                {leaf.tag === 'new' && <span className="pill new">New</span>}
+                                {leaf.tag === 'rehome' && <span className="pill rehome">moved</span>}
+                                {leaf.tag === 'future' && <span className="pill future">future</span>}
+                                {leaf.tag === 'in-progress' && <span className="pill in-progress">in progress</span>}
+                              </button>
+                            ))}
+                          </div>
+                        </Fragment>
+                      );
+                    })}
+                  </div>
+                </Fragment>
+              ) : (
+                <button className="rail-bucket">
+                  <span className="icon">{item.icon}</span>
+                  <span className="label">{item.label}</span>
+                </button>
+              )}
+            </Fragment>
+          ))}
+        </aside>
+      );
+    }
+
+    function Crumb({ items }) {
+      return (
+        <div className="crumb">
+          {items.map((it, i) => (
+            <Fragment key={i}>
+              {i > 0 && <span className="sep">›</span>}
+              {it.target && i < items.length - 1
+                ? <a onClick={() => go(it.target)}>{it.label}</a>
+                : <span className={i === items.length - 1 ? 'current' : ''}>{it.label}</span>}
+            </Fragment>
+          ))}
+        </div>
+      );
+    }
+
+    function PreviewNote() {
+      return (
+        <div className="preview-note">
+          <strong>v0.5 (IA rehome + in-progress)</strong> ships before v1 (MVP). It gives every
+          existing QA-adjacent feature (Westgard / QC Dashboard, EQA, Audit Trail) a coherent home
+          and adds the in-progress NCE v2 to the new menu. Two FUTURE placeholders
+          (Reagent QC, Analyzer Manual QC) cross-link to design docs per Piotr's four-QC-feature
+          framing. ~30–46h estimated. Unblocks the Madagascar GRIST UAT (LO-07-02/03/04).
+        </div>
+      );
+    }
+
+    /* --------------------------- Pillar landings --------------------------- */
+
+    function QCLanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'Statistical QC' }]} />
+          <h1 className="page-title">Statistical QC</h1>
+          <p className="page-sub">Internal control monitoring + the future-feature surfaces from Piotr's four-QC-feature framing.</p>
+          <PreviewNote />
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/qc/dashboard')}>
+              <h3>QC Dashboard <span className="tag rehome">Rehomed</span></h3>
+              <p>Internal control monitoring with Westgard rules + Levey-Jennings charts. Existing UI; new URL.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile" onClick={() => go('/qa/qc/alerts')}>
+              <h3>QC Alerts <span className="tag rehome">Rehomed</span></h3>
+              <p>Westgard rule violations across analyzers. Existing UI; rehomed from QC Dashboard sub-tab.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile future" onClick={() => go('/qa/qc/reagent-qc')}>
+              <h3>Reagent QC <span className="tag future">Future</span></h3>
+              <p>Per-lot reagent QC frequency tracking. Design doc on GitHub; build not yet scheduled.</p>
+              <div className="deep-link">Read design ↗</div>
+            </div>
+            <div className="leaf-tile future" onClick={() => go('/qa/qc/manual-qc')}>
+              <h3>Analyzer Manual QC <span className="tag future">Future</span></h3>
+              <p>Daily PASS/FAIL log per instrument. Design doc on GitHub; build not yet scheduled.</p>
+              <div className="deep-link">Read design ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    function EQALanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'EQA' }]} />
+          <h1 className="page-title">EQA (Proficiency Testing)</h1>
+          <p className="page-sub">External quality assessment — V1 EQA functionality, rehomed under Quality Assurance.</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 rehome:</strong> existing EQA pages keep their UI and behavior;
+            their URL prefix changes from <code>/eqa/...</code> to <code>/qa/eqa/...</code>.
+            The <code>isEqaSample</code> flag flow continues to validate as it does today.
+            EQA V2 (cycle/scheme model + Lab Performance dashboard + Follow-Up Queue + Analyst Competency + Program Management)
+            arrives in v10–v11.
+          </div>
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/eqa/eqa-home')}>
+              <h3>EQA <span className="tag rehome">Rehomed</span></h3>
+              <p>The existing OpenELIS EQA pages — sample submissions, scheme management — at the new URL.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    function QMSLanding() {
+      return (
+        <Fragment>
+          <Crumb items={[{ label: 'Quality Assurance', target: '/qa/qc' }, { label: 'QMS & Improvement' }]} />
+          <h1 className="page-title">QMS &amp; Improvement</h1>
+          <p className="page-sub">Quality management surfaces. v0.5 lands the in-progress NCE v2 here and pulls Audit Trail in from Admin.</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 changes:</strong> NCE Register lands as the destination URL for the
+            <strong> in-progress NCE v2</strong> Carbon-React modernization. Audit Trail rehomes
+            from Admin (Admin cross-link preserved). Electronic Signature Log arrives in v2.
+            Accreditation management arrives in v2 — community may lead the build using the
+            existing <code>test-accreditation-frs.md</code> spec.
+          </div>
+
+          <div className="leaf-grid">
+            <div className="leaf-tile" onClick={() => go('/qa/qms/nce-register')}>
+              <h3>NCE Register <span className="tag in-progress">In progress</span></h3>
+              <p>Non-conformity events. Carbon-React modernization (NCE v2) lands here when it ships.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+            <div className="leaf-tile" onClick={() => go('/qa/qms/audit-trail')}>
+              <h3>Audit Trail <span className="tag rehome">Rehomed</span></h3>
+              <p>Configuration / record-change audit log, rehomed from Admin. Admin cross-link preserved.</p>
+              <div className="deep-link">Open ↗</div>
+            </div>
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Rehome stubs --------------------------- */
+
+    const REHOME = {
+      'qc/dashboard':  { title: 'QC Dashboard',                        old: '/analyzers/qc/db',           desc: 'Internal control monitoring with Westgard rules + Levey-Jennings charts.' },
+      'qc/alerts':     { title: 'QC Alerts',                           old: '/analyzers/qc/db/alerts',    desc: 'Westgard rule violations across analyzers.' },
+      'eqa/eqa-home':  { title: 'EQA',                                 old: '/eqa',                       desc: 'External quality assessment / proficiency testing.' },
+      'qms/audit-trail': { title: 'Audit Trail',                       old: '/admin/audit-trail',         desc: 'Configuration and record-change audit log.' },
+    };
+
+    function RehomeStub({ pillar, leaf }) {
+      const meta = REHOME[`${pillar}/${leaf}`];
+      const pillarLabel = pillar === 'qc' ? 'Statistical QC' : pillar === 'eqa' ? 'EQA' : 'QMS & Improvement';
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: pillarLabel, target: `/qa/${pillar}` },
+            { label: meta.title }
+          ]} />
+          <h1 className="page-title">{meta.title}</h1>
+          <p className="page-sub">{meta.desc}</p>
+
+          <div className="rehome-note">
+            <strong>v0.5 rehome — UI unchanged.</strong> This page renders the existing OpenELIS
+            UI; only the URL and breadcrumb changed. Old path <code>{meta.old}</code> issues a 301
+            redirect to the new URL for one major release.
+            {leaf === 'audit-trail' && <Fragment><br /><br />Cross-link preserved from <code>Admin → Audit Trail</code> so administrators with muscle memory still find it.</Fragment>}
+          </div>
+
+          <div className="stub-app-frame">
+            <div className="frame-title">[ Existing OpenELIS {meta.title} UI renders here ]</div>
+            Same component, same data, same controls.<br />
+            v0.5 mockup omits the page body intentionally — only the IA position changed.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Future placeholders --------------------------- */
+
+    const FUTURE = {
+      'reagent-qc': {
+        title: 'Reagent QC',
+        designDoc: 'designs/quality/batch-workplan-reagent-qc.md',
+        designDocUrl: 'https://github.com/DIGI-UW/openelis-work/blob/main/designs/quality/batch-workplan-reagent-qc.md',
+        question: 'Has this reagent lot been verified before we use it on patients?',
+        summary: 'Per-lot QC frequency tracking. Before a new reagent lot is used clinically, the system requires a documented set of verification samples comparing the new lot against the old lot or a peer-comparison reference. The data model holds which lots, which controls, which analyzer, which user, and which timestamp.',
+        why: 'Without lot verification, a bad reagent lot can ruin a week of patient results before anyone notices. Most labs do this informally today (paper logs, supervisor reminders); shipping it as a system feature catches the cases where the informal process fails.',
+      },
+      'manual-qc': {
+        title: 'Analyzer Manual QC',
+        designDoc: 'designs/quality/analyzer-manual-qc.md',
+        designDocUrl: 'https://github.com/DIGI-UW/openelis-work/blob/main/designs/quality/analyzer-manual-qc.md',
+        question: 'Did the technician run a daily control on this instrument today, and did it pass?',
+        summary: 'Daily PASS/FAIL log per instrument. Different instruments have different daily checks (a microscope has a calibration slide, a hematology analyzer has a precision check on a control sample, a refrigerator has a temperature reading). The system holds them all to one shape: a daily PASS/FAIL log with a signer, a timestamp, and a block on instrument use if FAIL.',
+        why: 'The first thing a CAP inspector asks when they walk into a lab is some version of "show me your daily QC log for this instrument." A signed log per instrument per day, every day. Forgetting it is what fails inspections.',
+      },
+    };
+
+    function FutureStub({ leaf }) {
+      const meta = FUTURE[leaf];
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: 'Statistical QC', target: '/qa/qc' },
+            { label: meta.title }
+          ]} />
+          <h1 className="page-title">{meta.title}</h1>
+          <p className="page-sub">Future feature — design exists; build not yet scheduled.</p>
+
+          <div className="future-note">
+            <strong>One of Piotr's four QC features.</strong> The lens this feature provides:
+            <em> {meta.question}</em><br /><br />
+            {meta.summary}<br /><br />
+            <strong>Why it matters:</strong> {meta.why}
+          </div>
+
+          <div style={{ background: '#fff', padding: '1.5rem', border: '1px solid #e0e0e0' }}>
+            <h3 style={{ margin: '0 0 0.5rem 0', fontSize: '0.875rem', fontWeight: 600 }}>Design document</h3>
+            <p style={{ margin: '0 0 0.5rem 0', fontSize: '0.8125rem', color: '#525252' }}>
+              The full design specification is on GitHub at <code>DIGI-UW/openelis-work</code>:
+            </p>
+            <p style={{ margin: '0', fontFamily: 'IBM Plex Mono, monospace', fontSize: '0.8125rem', color: '#0f62fe' }}>
+              {meta.designDoc}
+            </p>
+            <a className="design-doc-link" href={meta.designDocUrl} target="_blank" rel="noopener">
+              Read design doc on GitHub ↗
+            </a>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: '0.8125rem', color: '#6f6f6f' }}>
+            <strong>Why this page exists in v0.5:</strong> the four-QC-feature mental model is
+            preserved in the IA from day one. UAT testers (Madagascar GRIST LO-07-03 specifically)
+            can reference these placeholder pages to mark the relevant requirement bullets PARTIAL
+            with a documented future-feature link, instead of leaving the requirement in limbo.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- NCE Register (in-progress) --------------------------- */
+
+    function NCERegister() {
+      return (
+        <Fragment>
+          <Crumb items={[
+            { label: 'Quality Assurance', target: '/qa/qc' },
+            { label: 'QMS & Improvement', target: '/qa/qms' },
+            { label: 'NCE Register' }
+          ]} />
+          <h1 className="page-title">NCE Register</h1>
+          <p className="page-sub">Non-conformity events. NCE v2 (Carbon-React modernization) lands here when it ships.</p>
+
+          <div className="in-progress-note">
+            <strong>NCE v2 is in active development.</strong> This URL is the landing site
+            for the modernized register. v0.5 hides the legacy top-level NCE menu entry and
+            301-redirects <code>/non-conform/*</code> to <code>/qa/qms/nce/*</code>. When NCE v2
+            ships into the develop branch, it appears at this URL automatically. Until then,
+            this page renders the existing legacy NCE workflow at the new URL.
+            <br /><br />
+            <strong>Open question (per Casey + Piotr / Mozzy):</strong> does the in-progress NCE v2
+            cover the modern register (formerly v4), the create/report flow with 11 trigger
+            points (formerly v5), and the analytics page (formerly v6) — or just the register?
+            Confirm before v0.5 ships so the post-v0.5 v4–v6 plan is accurate.
+          </div>
+
+          <div className="stub-app-frame">
+            <div className="frame-title">[ Existing OpenELIS NCE workflow renders here today; NCE v2 swaps in when it ships ]</div>
+            Same data; UI evolves with the NCE v2 build.
+          </div>
+        </Fragment>
+      );
+    }
+
+    /* --------------------------- Madagascar GRIST alignment --------------------------- */
+
+    function GristAlignment() {
+      return (
+        <div className="grist-block">
+          <h3>Madagascar GRIST UAT alignment (per Piotr's proposal, Slack 2026-05-01)</h3>
+          <p style={{ margin: '0 0 0.75rem 0', fontSize: '0.8125rem', color: '#525252' }}>
+            v0.5 directly enables the three QC-related Madagascar UAT requirements to pass UAT
+            with a documented Round-2 rewrite per requirement.
+          </p>
+          <table>
+            <thead>
+              <tr><th>Req</th><th>Title</th><th>v0.5 path</th><th>Round-2 rewrite</th></tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td className="req-id">LO-07-02</td>
+                <td>Internal Control</td>
+                <td><code>/qa/qc/dashboard</code></td>
+                <td><span className="pass">PASS</span> — point test at QC Dashboard, seed a 1-3s violation via harness fixture.</td>
+              </tr>
+              <tr>
+                <td className="req-id">LO-07-03</td>
+                <td>Calibration samples</td>
+                <td><code>/qa/eqa/eqa-home</code> (EQA bullet) +<br /><code>/qa/qc/manual-qc</code> + <code>/qa/qc/reagent-qc</code> (PARTIAL)</td>
+                <td><span className="partial">SPLIT</span> — EQA bullet validates against existing V1 EQA path; instrument-verification + reagent-batch bullets marked PARTIAL with cross-links to the FUTURE-feature design docs.</td>
+              </tr>
+              <tr>
+                <td className="req-id">LO-07-04</td>
+                <td>Invalid quality indicators</td>
+                <td><code>/qa/qc/alerts</code></td>
+                <td><span className="pass">PASS</span> — 3-step pass-through against the rehomed Alerts tab; piggybacks on LO-07-02's seeded violation.</td>
+              </tr>
+            </tbody>
+          </table>
+          <p style={{ margin: '0.75rem 0 0 0', fontSize: '0.75rem', color: '#6f6f6f' }}>
+            Source: Piotr Mankowski's "Concrete proposal for aligning the three reqs"
+            (#oe-madagascar-internal, 2026-05-01).
+          </p>
+        </div>
+      );
+    }
+
+    /* --------------------------- App --------------------------- */
+
+    function App() {
+      const route = useRoute();
+      let body;
+
+      const showGrist = route.kind === 'qc-landing' || (route.kind === 'pillar-landing' && route.pillar === 'qc');
+
+      if (route.kind === 'qc-landing') body = <QCLanding />;
+      else if (route.kind === 'pillar-landing') {
+        if (route.pillar === 'qc') body = <QCLanding />;
+        else if (route.pillar === 'eqa') body = <EQALanding />;
+        else if (route.pillar === 'qms') body = <QMSLanding />;
+        else body = <QCLanding />;
+      }
+      else if (route.kind === 'leaf') {
+        const key = `${route.pillar}/${route.leaf}`;
+        if (REHOME[key]) body = <RehomeStub pillar={route.pillar} leaf={route.leaf} />;
+        else if (route.pillar === 'qc' && (route.leaf === 'reagent-qc' || route.leaf === 'manual-qc'))
+          body = <FutureStub leaf={route.leaf} />;
+        else if (route.pillar === 'qms' && route.leaf === 'nce-register')
+          body = <NCERegister />;
+        else body = <QCLanding />;
+      }
+      else body = <QCLanding />;
+
+      return (
+        <Fragment>
+          <AppHeader />
+          <div className="layout">
+            <Rail route={route} />
+            <main className="main">
+              {body}
+              {showGrist && <GristAlignment />}
+            </main>
+          </div>
+        </Fragment>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -632,6 +632,19 @@ export const MOCKUP_REGISTRY = [
     jira: ['OGC-554', 'OGC-527'],
     tags: ['quality', 'QC', 'environmental', 'vector', 'field-blank', 'trip-blank', 'duplicate', 'spike-recovery'],
   },
+  {
+    name: 'QA Menu v0.5 (IA Rehome)',
+    category: 'quality',
+    component: null,
+    description: 'IA rehome for all existing QA-adjacent features — lands before v1 MVP. Three pillars: Statistical QC / EQA / QMS & Improvement. Rehomes QC Dashboard, EQA, NCE Register, and Audit Trail under a top-level Quality Assurance sidenav; 301 redirects on all legacy URLs. Madagascar GRIST UAT: LO-07-02 PASS, LO-07-03 SPLIT, LO-07-04 PASS.',
+    specPath: 'designs/quality/qa-menu-v0.5.md',
+    htmlUrl: 'designs/quality/qa-menu-v0.5.html',
+    added: '2026-05-01',
+    status: 'draft',
+    githubIssue: null,
+    jira: [],
+    tags: ['quality', 'QA-menu', 'IA', 'rehome', 'tech-debt', 'QC', 'EQA', 'NCE', 'audit-trail', 'Madagascar', 'GRIST'],
+  },
 
   // ─── Vector Surveillance ───
   {


### PR DESCRIPTION
FRS v1.0: three-pillar QA sidenav (Statistical QC / EQA / QMS & Improvement). Rehomes QC Dashboard, EQA, NCE Register, Audit Trail; 301 redirects on all legacy URLs. GRIST UAT alignment: LO-07-02 PASS, LO-07-03 SPLIT, LO-07-04 PASS. Effort: ~30-46h.

Companion files: rehome outline, QA/QC narrative, versioning plan v0.2.
Gallery: https://digi-uw.github.io/openelis-work/#/quality/qa-menu-v0.5

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
