### PR TITLE
feat(admin-config): Test Rules Authoring Redesign — MVP

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -31,6 +31,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Admin Shell | [preview](designs/admin-config/admin-shell.html) | [admin-shell.md](designs/admin-config/admin-shell.md) |
 | Admin Pattern Library | [preview](designs/admin-config/admin-pattern-library.html) | [admin-pattern-library.md](designs/admin-config/admin-pattern-library.md) |
 | Admin Phase 5 Roadmap | — | [admin-phase5-roadmap.md](designs/admin-config/admin-phase5-roadmap.md) |
+| Test Rules Authoring — MVP | [list view ⬢](designs/admin-config/test-rules-list-view-preview.html) · [reflex editor](designs/admin-config/reflex-tests-redesign-preview.html) · [calc formula bar](designs/admin-config/calculated-values-redesign-v2-preview.html) · [calc decision table](designs/admin-config/calc-decision-table-preview.html) · [algorithm canvas (Ph2)](designs/admin-config/algorithm-as-graph-preview.html) | [test-rules-mvp-frs.md](designs/admin-config/test-rules-mvp-frs.md) |
 
 ## Vector Surveillance
 

--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -2311,3 +2311,21 @@
     gallery: "https://digi-uw.github.io/openelis-work/#/quality/qa-release-budget-calculator"
   added: "2026-05-04"
   status: draft
+
+- id: test-rules-mvp
+  type: html
+  path: designs/admin-config/test-rules-list-view-preview.html
+  spec: designs/admin-config/test-rules-mvp-frs.md
+  category: admin-config
+  description: "Unified Test Rules authoring page replacing legacy Reflex Tests Management and Calculated Value Tests Management. List view with inline expansion; dedicated editors for Reflex (WHEN/THEN), Numeric Calc (formula bar), and Coded Calc (decision table). Algorithm canvas is Phase 2 reference. All five previews are cross-linked."
+  related:
+    - designs/admin-config/reflex-tests-redesign-preview.html
+    - designs/admin-config/calculated-values-redesign-v2-preview.html
+    - designs/admin-config/calc-decision-table-preview.html
+    - designs/admin-config/algorithm-as-graph-preview.html
+  links:
+    github: null
+    jira: null
+    gallery: "https://digi-uw.github.io/openelis-work/#/admin-config/test-rules-mvp"
+  added: "2026-05-12"
+  status: draft

--- a/designs/admin-config/algorithm-as-graph-preview.html
+++ b/designs/admin-config/algorithm-as-graph-preview.html
@@ -1,0 +1,831 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Algorithm-as-Graph — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Top-level tabs */
+    .top-tabs {
+      display: flex; gap: 0; margin-bottom: 1rem; border-bottom: 1px solid #e0e0e0;
+    }
+    .top-tab {
+      padding: 10px 18px; cursor: pointer; font-size: 14px; color: #525252;
+      background: transparent; border: none; border-bottom: 2px solid transparent;
+      font-weight: 500;
+    }
+    .top-tab.active { color: #0f62fe; border-bottom-color: #0f62fe; font-weight: 600; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+
+    /* Algorithm header */
+    .algo-header {
+      background: #fff; padding: 1rem 1.25rem; border: 1px solid #e0e0e0;
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: -1px;
+    }
+    .algo-header .info { display: flex; flex-direction: column; }
+    .algo-header h2 { margin: 0; font-size: 20px; font-weight: 400; }
+    .algo-header .meta { font-size: 12px; color: #6f6f6f; margin-top: 4px; }
+    .algo-toolbar {
+      display: flex; gap: 0.5rem; align-items: center;
+    }
+
+    /* Canvas panel */
+    .canvas-panel {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.5rem;
+      overflow-x: auto;
+    }
+    .canvas-toolbar {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 0.25rem 0.5rem 0.5rem;
+      font-size: 12px; color: #525252;
+    }
+    .canvas-toolbar .legend { display: flex; gap: 0.75rem; align-items: center; }
+    .legend-swatch {
+      display: inline-flex; align-items: center; gap: 4px; font-size: 11px;
+    }
+    .legend-swatch .box {
+      width: 12px; height: 12px; border: 1.5px solid;
+    }
+
+    /* SVG node styling controlled inline */
+    .node-rect { transition: stroke 0.15s, fill 0.15s; }
+    .node-rect.selected { stroke: #fa4d56 !important; stroke-width: 3 !important; }
+    .node-clickable:hover .node-rect { fill: #f4f9ff; }
+
+    /* Selected step editor (below canvas) */
+    .step-editor {
+      background: #fff; padding: 1.25rem; border: 1px solid #e0e0e0; border-top: 2px solid #fa4d56;
+    }
+    .step-editor h4 {
+      margin: 0 0 0.5rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .step-editor h4 .pill {
+      background: #fff1f1; color: #a2191f; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .step-editor .meta {
+      font-size: 12px; color: #6f6f6f; margin-bottom: 0.75rem;
+    }
+
+    /* Decision table */
+    .decision-table {
+      width: 100%; border-collapse: collapse; font-size: 13px; background: #fff;
+    }
+    .decision-table th, .decision-table td {
+      padding: 8px 12px; border: 1px solid #e0e0e0; text-align: left;
+      vertical-align: top;
+    }
+    .decision-table thead th {
+      background: #f4f4f4; font-size: 11px; text-transform: uppercase;
+      letter-spacing: 0.5px; color: #525252;
+    }
+    .decision-table .col-when { background: #fff8e1; color: #b28600; }
+    .decision-table .col-then { background: #defbe6; color: #0e6027; }
+    .decision-table .col-next { background: #edf5ff; color: #0043ce; }
+    .decision-table .dt-cell { font-family: 'IBM Plex Mono', monospace; font-size: 12px; }
+    .decision-table tbody tr:hover { background: #fafafa; }
+    .dt-link {
+      color: #0f62fe; cursor: pointer; text-decoration: underline; text-decoration-style: dotted;
+    }
+
+    /* Side info panel */
+    .info-grid {
+      display: grid; grid-template-columns: 2fr 1fr; gap: 1rem; margin-top: 1rem;
+    }
+    .info-panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .info-panel h4 {
+      margin: 0 0 0.5rem; font-size: 13px; font-weight: 600;
+    }
+    .info-panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500; margin-left: 6px;
+    }
+    .info-panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 130px; font-size: 12px; color: #161616; }
+    .sim-row select, .sim-row input {
+      flex: 1; padding: 4px 8px; font-size: 12px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-trace {
+      background: #f4f4f4; padding: 0.5rem; font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px; line-height: 1.6; margin-top: 0.5rem;
+    }
+    .sim-trace .step { display: flex; gap: 6px; }
+    .sim-trace .step-num {
+      flex: 0 0 18px; background: #0f62fe; color: #fff; border-radius: 999px;
+      width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center;
+      font-size: 10px;
+    }
+    .sim-trace .outcome {
+      background: #defbe6; color: #0e6027; padding: 2px 8px; border-radius: 4px;
+      font-weight: 600;
+    }
+    .sim-trace .terminal {
+      background: #fff1f1; color: #6f0000; padding: 2px 8px; border-radius: 4px;
+      font-weight: 600;
+    }
+
+    /* Multi-step calc */
+    .step-list {
+      display: flex; flex-direction: column; gap: 0.5rem;
+    }
+    .calc-step {
+      background: #fff; border: 1px solid #e0e0e0; padding: 0.75rem;
+      display: grid; grid-template-columns: 32px 1fr 100px; gap: 0.75rem; align-items: center;
+    }
+    .calc-step.selected { border-color: #fa4d56; border-left-width: 3px; }
+    .calc-step .num {
+      background: #0f62fe; color: #fff; border-radius: 999px;
+      width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 600; font-size: 13px;
+    }
+    .calc-step .body { display: flex; flex-direction: column; gap: 2px; }
+    .calc-step .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .calc-step .name code {
+      background: #f4f4f4; padding: 1px 6px; border-radius: 3px;
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #0043ce;
+      margin-left: 6px;
+    }
+    .calc-step .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #525252;
+      padding: 4px 8px; background: #fafafa; border-left: 2px solid #c6c6c6;
+    }
+    .calc-step .value {
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      color: #0e6027; font-weight: 600; text-align: right;
+    }
+    .calc-step.final {
+      background: #defbe6; border-color: #198038;
+    }
+    .calc-step.final .num { background: #198038; }
+    .calc-step.final .value { font-size: 22px; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Algorithm-as-Graph &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #fff8e1; border-bottom: 1px solid #f1c21b; padding: 8px 2rem; font-size: 13px; color: #6b4a00;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Algorithm editor</strong> · <span style="background: #f1c21b; color: #6b4a00; padding: 1px 8px; border-radius: 3px; font-size: 11px; font-weight: 700;">PHASE 2</span>
+    &nbsp;<span style="color: #6b4a00;">— what would open when you click an Algorithm or Multi-step calc row in the list view. Not built in MVP; included as forward-compat reference.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // SHARED — token coloring of formula text
+    // ========================================================================
+    const KNOWN_TESTS = ['T1','T2','T3','SCr','Bili','INR','Na','HIV_Screen','HIV_Conf','HIV_Tie'];
+    const KNOWN_FNS   = ['min','max','log','ln','round','if','eq'];
+    const KEYWORDS    = ['AND','OR','NOT','IN'];
+    const PREDICATES  = ['isNormal','isOutsideNormal','isAboveNormal','isBelowNormal','isCritical','isCriticallyHigh','isCriticallyLow','isFlagged','isReactive','isPositive','isFemale','isMale'];
+    function tokenize(text) {
+      const re = /("[^"]*")|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=|\+|-|\*|\/)|([(),])|(\s+)|(.)/g;
+      const out = []; let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({k:'str', t:m[1]});
+        else if (m[2]) out.push({k:'num', t:m[2]});
+        else if (m[3]) {
+          const id = m[3];
+          if (KEYWORDS.includes(id.toUpperCase())) out.push({k:'bool', t:id});
+          else if (PREDICATES.includes(id)) out.push({k:'pred', t:id});
+          else if (KNOWN_TESTS.includes(id)) out.push({k:'var', t:id});
+          else if (KNOWN_FNS.includes(id)) out.push({k:'fn', t:id});
+          else out.push({k:'var', t:id}); // assume var for mockup
+        }
+        else if (m[4]) out.push({k:'op', t:m[4]});
+        else if (m[5]) out.push({k:'paren', t:m[5]});
+        else if (m[6]) out.push({k:'ws', t:m[6]});
+        else out.push({k:'other', t:m[7]});
+      }
+      return out;
+    }
+    function Tokenized({ text }) {
+      return <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>
+        {tokenize(text).map((t, i) =>
+          <span key={i} className={t.k === 'ws' ? '' : 'tok-' + t.k}>{t.t}</span>
+        )}
+      </span>;
+    }
+
+    // ========================================================================
+    // HIV 3-TEST ALGORITHM
+    // ========================================================================
+
+    // Node positions on the SVG canvas
+    const HIV_NODES = [
+      { id: 'T1',   kind: 'decision', title: 'Test 1: Screen',     subtitle: 'Determine HIV-1/2 (Whole Blood)', x: 460, y: 60, w: 200, h: 60 },
+      { id: 'EN',   kind: 'end-neg',  title: 'END: HIV Negative',   subtitle: 'Report final result',           x: 160, y: 200, w: 200, h: 50 },
+      { id: 'T2',   kind: 'decision', title: 'Test 2: Confirmatory',subtitle: 'Uni-Gold HIV (Whole Blood)',    x: 600, y: 195, w: 200, h: 60 },
+      { id: 'EP1',  kind: 'end-pos',  title: 'END: HIV Positive',   subtitle: 'Report final result',           x: 360, y: 335, w: 200, h: 50 },
+      { id: 'T3',   kind: 'decision', title: 'Test 3: Tiebreaker',  subtitle: 'SD Bioline (Whole Blood)',       x: 760, y: 330, w: 200, h: 60 },
+      { id: 'EP2',  kind: 'end-pos',  title: 'END: HIV Positive',   subtitle: 'Report + retest 14 days',       x: 560, y: 470, w: 200, h: 50 },
+      { id: 'EI',   kind: 'end-inc',  title: 'END: Inconclusive',   subtitle: 'Retest in 14 days',             x: 880, y: 470, w: 200, h: 50 },
+    ];
+    const HIV_EDGES = [
+      { from: 'T1',  to: 'T2',  label: 'Reactive',        side: 'right' },
+      { from: 'T1',  to: 'EN',  label: 'Non-Reactive',    side: 'left' },
+      { from: 'T2',  to: 'EP1', label: 'Reactive',        side: 'left' },
+      { from: 'T2',  to: 'T3',  label: 'Non-Reactive',    side: 'right' },
+      { from: 'T3',  to: 'EP2', label: 'Reactive',        side: 'left' },
+      { from: 'T3',  to: 'EI',  label: 'Non-Reactive',    side: 'right' },
+    ];
+
+    function nodeColor(kind) {
+      if (kind === 'decision') return { stroke: '#0f62fe', fill: '#fff' };
+      if (kind === 'end-pos')  return { stroke: '#198038', fill: '#defbe6' };
+      if (kind === 'end-neg')  return { stroke: '#525252', fill: '#f4f4f4' };
+      if (kind === 'end-inc')  return { stroke: '#b28600', fill: '#fff8e1' };
+      return { stroke: '#8d8d8d', fill: '#fff' };
+    }
+
+    function CanvasNode({ node, selected, onClick }) {
+      const c = nodeColor(node.kind);
+      return (
+        <g className="node-clickable" transform={`translate(${node.x}, ${node.y})`} onClick={onClick} style={{ cursor: 'pointer' }}>
+          <rect className={'node-rect' + (selected ? ' selected' : '')}
+                x={0} y={0} width={node.w} height={node.h} rx={6}
+                fill={c.fill} stroke={c.stroke} strokeWidth={1.5} />
+          <text x={node.w/2} y={22} textAnchor="middle" fontSize={13} fontWeight={600} fill="#161616">
+            {node.title}
+          </text>
+          <text x={node.w/2} y={42} textAnchor="middle" fontSize={11} fill="#6f6f6f">
+            {node.subtitle}
+          </text>
+        </g>
+      );
+    }
+
+    function CanvasEdge({ nodes, from, to, label }) {
+      const f = nodes.find(n => n.id === from);
+      const t = nodes.find(n => n.id === to);
+      const fx = f.x + f.w / 2;
+      const fy = f.y + f.h;
+      const tx = t.x + t.w / 2;
+      const ty = t.y;
+      // Bezier control points for a clean S-curve
+      const cy1 = fy + (ty - fy) * 0.6;
+      const cy2 = ty - (ty - fy) * 0.4;
+      const path = `M ${fx},${fy} C ${fx},${cy1} ${tx},${cy2} ${tx},${ty}`;
+      const midX = (fx + tx) / 2;
+      const midY = (fy + ty) / 2;
+      return (
+        <g>
+          <path d={path} fill="none" stroke="#8d8d8d" strokeWidth={1.5} markerEnd="url(#arrow)" />
+          <rect x={midX - 50} y={midY - 11} width={100} height={20} rx={3}
+                fill="#fff" stroke="#e0e0e0" />
+          <text x={midX} y={midY + 3} textAnchor="middle" fontSize={11} fontWeight={600}
+                fill="#525252" fontFamily="IBM Plex Mono">{label}</text>
+        </g>
+      );
+    }
+
+    // Decision table data for each clickable decision node
+    const HIV_TABLES = {
+      T1: {
+        title: 'Test 1: Screen (Determine HIV-1/2)',
+        meta: '3 outcomes · trigger sample = Whole Blood · per WHO 2019 algorithm for high-prevalence settings',
+        rows: [
+          { when: '"Reactive"',     then: '(record positive screen, proceed)',                     next: { id: 'T2', label: 'Test 2: Confirmatory' } },
+          { when: '"Weak Reactive"',then: '(record as ambiguous, proceed with caution)',           next: { id: 'T2', label: 'Test 2: Confirmatory' } },
+          { when: '"Non-Reactive"', then: 'Set HIV status: Negative; Add note: "Screening non-reactive"', next: { id: 'EN', label: 'END: HIV Negative' } },
+        ],
+      },
+      T2: {
+        title: 'Test 2: Confirmatory (Uni-Gold HIV)',
+        meta: '2 outcomes · only reached if Test 1 was Reactive or Weak Reactive',
+        rows: [
+          { when: '"Reactive"',     then: 'Set HIV status: Positive; Add external note with date and lot.', next: { id: 'EP1', label: 'END: HIV Positive' } },
+          { when: '"Non-Reactive"', then: '(record discordance, proceed to tiebreaker)',                next: { id: 'T3',  label: 'Test 3: Tiebreaker' } },
+        ],
+      },
+      T3: {
+        title: 'Test 3: Tiebreaker (SD Bioline)',
+        meta: '2 outcomes · only reached if Test 1 Reactive AND Test 2 Non-Reactive (discordant)',
+        rows: [
+          { when: '"Reactive"',     then: 'Set HIV status: Positive; Order retest in 14 days for serological confirmation.', next: { id: 'EP2', label: 'END: Positive + retest' } },
+          { when: '"Non-Reactive"', then: 'Set HIV status: Inconclusive; Order retest in 14 days.',  next: { id: 'EI',  label: 'END: Inconclusive' } },
+        ],
+      },
+    };
+
+    function HIVAlgorithm() {
+      const [selectedNode, setSelectedNode] = useState('T1');
+      const [simResult1, setSimResult1] = useState('Reactive');
+      const [simResult2, setSimResult2] = useState('Non-Reactive');
+      const [simResult3, setSimResult3] = useState('Reactive');
+
+      // Trace through the algorithm
+      const trace = [];
+      let final = null;
+      trace.push({ step: 'Test 1: Screen', input: simResult1, kind: 'decision' });
+      if (simResult1 === 'Non-Reactive') {
+        final = { kind: 'end-neg', label: 'HIV Negative' };
+      } else {
+        trace.push({ step: 'Test 2: Confirmatory', input: simResult2, kind: 'decision' });
+        if (simResult2 === 'Reactive') {
+          final = { kind: 'end-pos', label: 'HIV Positive' };
+        } else {
+          trace.push({ step: 'Test 3: Tiebreaker', input: simResult3, kind: 'decision' });
+          if (simResult3 === 'Reactive') {
+            final = { kind: 'end-pos', label: 'HIV Positive (with 14-day retest)' };
+          } else {
+            final = { kind: 'end-inc', label: 'Inconclusive (retest in 14 days)' };
+          }
+        }
+      }
+
+      const t = HIV_TABLES[selectedNode];
+
+      return (
+        <div>
+          <div className="algo-header">
+            <div className="info">
+              <h2>HIV 3-test national algorithm</h2>
+              <div className="meta">
+                Reflex Algorithm · 3 decision nodes · 4 final states · per WHO 2019 guidance for high-prevalence settings · last edited 2026-04-30 by p.diallo
+              </div>
+            </div>
+            <div className="algo-toolbar">
+              <span className="cds--tag cds--tag--green">Active</span>
+              <span className="cds--tag cds--tag--purple">Algorithm</span>
+              <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>Export DMN</button>
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 12 }}>Save changes</button>
+            </div>
+          </div>
+
+          <div className="canvas-panel">
+            <div className="canvas-toolbar">
+              <div className="legend">
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#0f62fe', background: '#fff' }}></span> Decision step (click to edit)</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#198038', background: '#defbe6' }}></span> Positive end state</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#525252', background: '#f4f4f4' }}></span> Negative end state</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#b28600', background: '#fff8e1' }}></span> Inconclusive end state</span>
+              </div>
+              <div>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 11 }}>+ Add step</button>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 11, marginLeft: 4 }}>Auto-arrange</button>
+              </div>
+            </div>
+            <svg viewBox="0 0 1120 560" style={{ width: '100%', height: 560, background: '#fff' }}>
+              <defs>
+                <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 L10,5 L0,10 Z" fill="#8d8d8d" />
+                </marker>
+              </defs>
+              {HIV_EDGES.map((e, i) => (
+                <CanvasEdge key={i} nodes={HIV_NODES} from={e.from} to={e.to} label={e.label} />
+              ))}
+              {HIV_NODES.map(node => (
+                <CanvasNode
+                  key={node.id}
+                  node={node}
+                  selected={node.id === selectedNode}
+                  onClick={() => setSelectedNode(node.id)}
+                />
+              ))}
+            </svg>
+          </div>
+
+          {/* Selected step editor */}
+          {t && (
+            <div className="step-editor">
+              <h4>{t.title} <span className="pill">Selected step</span></h4>
+              <div className="meta">{t.meta}</div>
+              <table className="decision-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 40 }}>#</th>
+                    <th className="col-when">When the result is…</th>
+                    <th className="col-then">Action</th>
+                    <th className="col-next" style={{ width: 240 }}>Next step</th>
+                    <th style={{ width: 30 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.rows.map((r, i) => (
+                    <tr key={i}>
+                      <td>{i + 1}</td>
+                      <td className="dt-cell"><Tokenized text={r.when} /></td>
+                      <td style={{ fontSize: 12 }}>{r.then}</td>
+                      <td className="dt-cell">
+                        <span className="dt-link" onClick={() => r.next.id !== selectedNode && setSelectedNode(r.next.id)}>
+                          → {r.next.label}
+                        </span>
+                      </td>
+                      <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div style={{ marginTop: 8 }}>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>+ Add outcome</button>
+                <span className="compact-hint" style={{ display: 'inline-block', marginLeft: 12 }}>
+                  Each outcome can point to another decision step, a final state, or "no further action."
+                </span>
+              </div>
+            </div>
+          )}
+
+          <div className="info-grid">
+            <div className="info-panel">
+              <h4>Simulator <span className="pill green">Sandbox</span></h4>
+              <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                Set hypothetical results for each test. The simulator traces the path through the algorithm.
+              </span>
+              <div className="sim-row">
+                <label>Test 1: Screen</label>
+                <select value={simResult1} onChange={e => setSimResult1(e.target.value)}>
+                  <option>Reactive</option><option>Weak Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-row">
+                <label>Test 2: Confirm</label>
+                <select value={simResult2} onChange={e => setSimResult2(e.target.value)} disabled={simResult1 === 'Non-Reactive'}>
+                  <option>Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-row">
+                <label>Test 3: Tiebreaker</label>
+                <select value={simResult3} onChange={e => setSimResult3(e.target.value)}
+                        disabled={simResult1 === 'Non-Reactive' || simResult2 === 'Reactive'}>
+                  <option>Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-trace">
+                {trace.map((s, i) => (
+                  <div key={i} className="step">
+                    <span className="step-num">{i + 1}</span>
+                    <span>{s.step}: result = <span className="tok-str">"{s.input}"</span></span>
+                  </div>
+                ))}
+                <div className="step" style={{ marginTop: 6 }}>
+                  <span className="step-num" style={{ background: final.kind === 'end-pos' ? '#198038' : final.kind === 'end-inc' ? '#b28600' : '#525252' }}>✓</span>
+                  <span className={final.kind === 'end-inc' ? 'terminal' : 'outcome'}>{final.label}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="info-panel">
+              <h4>Coverage &amp; conflicts</h4>
+              <div style={{ fontSize: 12, lineHeight: 1.6 }}>
+                <div style={{ color: '#0e6027' }}>✓ All Test 1 outcomes handled (3 of 3)</div>
+                <div style={{ color: '#0e6027' }}>✓ All Test 2 outcomes handled (2 of 2)</div>
+                <div style={{ color: '#0e6027' }}>✓ All Test 3 outcomes handled (2 of 2)</div>
+                <div style={{ color: '#0e6027' }}>✓ Every path terminates at a final state</div>
+                <div style={{ color: '#0e6027' }}>✓ No unreachable nodes</div>
+                <div style={{ color: '#b28600', marginTop: 6 }}>⚠ "Weak Reactive" from Test 1 routes to Test 2 same as "Reactive" — confirm with lab director if a distinct path is needed.</div>
+              </div>
+              <h4 style={{ marginTop: '0.75rem' }}>Audit</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                Created 2024-08-12 (p.diallo) · 14 revisions · last reviewed 2026-04-30
+              </div>
+              <h4 style={{ marginTop: '0.75rem' }}>References</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                WHO 2019 — Consolidated guidelines on HIV testing services<br/>
+                Ministry of Health national algorithm v3.2 (2024)
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // MELD-Na MULTI-STEP CALCULATION
+    // ========================================================================
+
+    const MELD_STEPS = [
+      // step number, name (used as variable in later steps), formula string, depends-on, units, function
+      { id: 's1', name: 'SCr_adj',          formula: 'max(min(SCr, 4.0), 1.0)',                                                      deps: ['SCr'],                  units: 'mg/dL', desc: 'Capped 1.0–4.0 (SCr above 4.0 capped per OPTN policy)' },
+      { id: 's2', name: 'Bili_adj',         formula: 'max(Bili, 1.0)',                                                                deps: ['Bili'],                 units: 'mg/dL', desc: 'Min 1.0 (log not defined < 1)' },
+      { id: 's3', name: 'INR_adj',          formula: 'max(INR, 1.0)',                                                                 deps: ['INR'],                  units: '',      desc: 'Min 1.0 (log not defined < 1)' },
+      { id: 's4', name: 'MELD_base',        formula: 'round(0.957 * ln(SCr_adj) + 0.378 * ln(Bili_adj) + 1.12 * ln(INR_adj) + 0.643) * 10', deps: ['SCr_adj','Bili_adj','INR_adj'], units: 'score', desc: 'MELD score before Na adjustment (OPTN 2002)' },
+      { id: 's5', name: 'MELD_na_unround',  formula: 'if(MELD_base >= 11, MELD_base + 1.32*(137-Na) - 0.033*MELD_base*(137-Na), MELD_base)', deps: ['MELD_base','Na'], units: 'score', desc: 'Na adjustment only when MELD_base ≥ 11 (UNOS 2016)' },
+      { id: 's6', name: 'MELD_Na',          formula: 'min(40, max(6, round(MELD_na_unround)))',                                       deps: ['MELD_na_unround'],     units: 'score', desc: 'Final score capped 6–40 (OPTN allocation policy)', final: true },
+    ];
+
+    function computeMeld(inputs) {
+      const SCr = +inputs.SCr, Bili = +inputs.Bili, INR = +inputs.INR, Na = +inputs.Na;
+      const SCr_adj = Math.max(Math.min(SCr, 4.0), 1.0);
+      const Bili_adj = Math.max(Bili, 1.0);
+      const INR_adj = Math.max(INR, 1.0);
+      const MELD_base = Math.round(0.957 * Math.log(SCr_adj) + 0.378 * Math.log(Bili_adj) + 1.12 * Math.log(INR_adj) + 0.643) * 10;
+      const MELD_na_unround = MELD_base >= 11
+        ? MELD_base + 1.32*(137-Na) - 0.033*MELD_base*(137-Na)
+        : MELD_base;
+      const MELD_Na = Math.min(40, Math.max(6, Math.round(MELD_na_unround)));
+      return { SCr_adj, Bili_adj, INR_adj, MELD_base, MELD_na_unround, MELD_Na };
+    }
+
+    // Position the step DAG horizontally
+    const MELD_NODES = [
+      // inputs (left)
+      { id: 'SCr',      kind: 'input',  label: 'SCr',  x: 40,  y: 40 },
+      { id: 'Bili',     kind: 'input',  label: 'Bili', x: 40,  y: 100 },
+      { id: 'INR',      kind: 'input',  label: 'INR',  x: 40,  y: 160 },
+      { id: 'Na',       kind: 'input',  label: 'Na',   x: 40,  y: 220 },
+      // step 1-3 (caps)
+      { id: 's1',       kind: 'step',   label: 'SCr_adj',         x: 200, y: 40 },
+      { id: 's2',       kind: 'step',   label: 'Bili_adj',        x: 200, y: 100 },
+      { id: 's3',       kind: 'step',   label: 'INR_adj',         x: 200, y: 160 },
+      // step 4
+      { id: 's4',       kind: 'step',   label: 'MELD_base',       x: 420, y: 100 },
+      // step 5
+      { id: 's5',       kind: 'step',   label: 'MELD_na_unround', x: 660, y: 160 },
+      // step 6 final
+      { id: 's6',       kind: 'final',  label: 'MELD_Na',         x: 900, y: 160 },
+    ];
+    const MELD_EDGES = [
+      { from: 'SCr',  to: 's1' },
+      { from: 'Bili', to: 's2' },
+      { from: 'INR',  to: 's3' },
+      { from: 's1',   to: 's4' },
+      { from: 's2',   to: 's4' },
+      { from: 's3',   to: 's4' },
+      { from: 's4',   to: 's5' },
+      { from: 'Na',   to: 's5' },
+      { from: 's5',   to: 's6' },
+    ];
+
+    function MeldNode({ node, selected, onClick }) {
+      const c = node.kind === 'input' ? { fill: '#fff1f1', stroke: '#a2191f' }
+             : node.kind === 'final' ? { fill: '#defbe6', stroke: '#198038' }
+             : { fill: '#fff', stroke: '#0f62fe' };
+      const w = node.kind === 'final' ? 130 : 110;
+      return (
+        <g transform={`translate(${node.x}, ${node.y})`}
+           onClick={onClick} style={{ cursor: 'pointer' }}>
+          <rect className={'node-rect' + (selected ? ' selected' : '')}
+                x={0} y={0} width={w} height={40} rx={6}
+                fill={c.fill} stroke={c.stroke} strokeWidth={1.5} />
+          <text x={w/2} y={25} textAnchor="middle"
+                fontSize={13} fontWeight={600}
+                fontFamily="IBM Plex Mono"
+                fill={node.kind === 'input' ? '#a2191f' : node.kind === 'final' ? '#0e6027' : '#0043ce'}>
+            {node.label}
+          </text>
+        </g>
+      );
+    }
+    function MeldEdge({ nodes, from, to }) {
+      const f = nodes.find(n => n.id === from);
+      const t = nodes.find(n => n.id === to);
+      const fw = f.kind === 'final' ? 130 : 110;
+      const tw = t.kind === 'final' ? 130 : 110;
+      const fx = f.x + fw;
+      const fy = f.y + 20;
+      const tx = t.x;
+      const ty = t.y + 20;
+      const midX = (fx + tx) / 2;
+      const path = `M ${fx},${fy} C ${midX},${fy} ${midX},${ty} ${tx},${ty}`;
+      return <path d={path} fill="none" stroke="#8d8d8d" strokeWidth={1.5} markerEnd="url(#arrow-meld)" />;
+    }
+
+    function MELDCalc() {
+      const [selectedStep, setSelectedStep] = useState('s5');
+      const [inputs, setInputs] = useState({ SCr: 1.8, Bili: 2.4, INR: 1.3, Na: 132 });
+      const v = computeMeld(inputs);
+      const setI = (k) => (e) => setInputs(s => ({ ...s, [k]: e.target.value }));
+
+      return (
+        <div>
+          <div className="algo-header">
+            <div className="info">
+              <h2>MELD-Na (Liver allocation score)</h2>
+              <div className="meta">
+                Multi-step calculation · 6 named intermediates · capped 6–40 · per UNOS 2016 policy · last edited 2026-03-22 by p.diallo
+              </div>
+            </div>
+            <div className="algo-toolbar">
+              <span className="cds--tag cds--tag--green">Active</span>
+              <span className="cds--tag cds--tag--purple">Multi-step</span>
+              <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>Export</button>
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 12 }}>Save changes</button>
+            </div>
+          </div>
+
+          <div className="canvas-panel">
+            <div className="canvas-toolbar">
+              <div className="legend">
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#a2191f', background: '#fff1f1' }}></span> Test result input</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#0f62fe', background: '#fff' }}></span> Intermediate (click to edit)</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#198038', background: '#defbe6' }}></span> Final output</span>
+              </div>
+              <div><button className="cds--btn cds--btn--ghost" style={{ fontSize: 11 }}>+ Add step</button></div>
+            </div>
+            <svg viewBox="0 0 1050 290" style={{ width: '100%', height: 290, background: '#fff' }}>
+              <defs>
+                <marker id="arrow-meld" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+                  <path d="M0,0 L10,5 L0,10 Z" fill="#8d8d8d" />
+                </marker>
+              </defs>
+              {MELD_EDGES.map((e, i) => (
+                <MeldEdge key={i} nodes={MELD_NODES} from={e.from} to={e.to} />
+              ))}
+              {MELD_NODES.map(node => (
+                <MeldNode key={node.id} node={node}
+                          selected={node.id === selectedStep}
+                          onClick={() => node.kind !== 'input' && setSelectedStep(node.id)} />
+              ))}
+            </svg>
+          </div>
+
+          <div className="info-grid" style={{ gridTemplateColumns: '1.4fr 1fr' }}>
+            <div className="info-panel">
+              <h4>Steps <span className="pill">In order</span></h4>
+              <div className="step-list">
+                {MELD_STEPS.map((s, i) => {
+                  const value = v[s.name];
+                  const fmt = typeof value === 'number'
+                    ? (Math.abs(value) > 100 ? value.toFixed(0) : value.toFixed(2))
+                    : value;
+                  const selected = selectedStep === s.id;
+                  return (
+                    <div key={s.id} className={'calc-step' + (s.final ? ' final' : '') + (selected ? ' selected' : '')}
+                         onClick={() => setSelectedStep(s.id)} style={{ cursor: 'pointer' }}>
+                      <div className="num">{i + 1}</div>
+                      <div className="body">
+                        <div className="name">
+                          {s.name}
+                          <code>= {s.units || '—'}</code>
+                        </div>
+                        <div className="formula">
+                          <Tokenized text={s.formula} />
+                        </div>
+                        <div className="compact-hint" style={{ fontStyle: 'normal' }}>{s.desc}</div>
+                      </div>
+                      <div className="value">{fmt}</div>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="compact-hint" style={{ marginTop: 6 }}>
+                Each step gets its own formula bar, units, and inline value. Edits to one step propagate through dependent steps automatically.
+              </div>
+            </div>
+
+            <div className="info-panel">
+              <h4>Simulator <span className="pill green">Sandbox</span></h4>
+              <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                Enter patient labs. Every step recomputes live; the dependency graph above lights up the path.
+              </span>
+              <div className="sim-row">
+                <label>SCr (Creatinine)</label>
+                <input type="number" step="0.1" value={inputs.SCr} onChange={setI('SCr')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mg/dL</span>
+              </div>
+              <div className="sim-row">
+                <label>Bili (Bilirubin)</label>
+                <input type="number" step="0.1" value={inputs.Bili} onChange={setI('Bili')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mg/dL</span>
+              </div>
+              <div className="sim-row">
+                <label>INR</label>
+                <input type="number" step="0.1" value={inputs.INR} onChange={setI('INR')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}></span>
+              </div>
+              <div className="sim-row">
+                <label>Na (Sodium)</label>
+                <input type="number" step="1" value={inputs.Na} onChange={setI('Na')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mmol/L</span>
+              </div>
+
+              <div style={{ background: '#defbe6', padding: '0.75rem 1rem', marginTop: 12, borderLeft: '3px solid #198038' }}>
+                <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: '#0e6027', fontWeight: 600 }}>
+                  Final MELD-Na
+                </div>
+                <div style={{ fontSize: 32, fontWeight: 600, color: '#0e6027', fontFamily: "'IBM Plex Mono', monospace" }}>
+                  {v.MELD_Na}
+                </div>
+                <div style={{ fontSize: 11, color: '#525252', marginTop: 4 }}>
+                  MELD_base = {v.MELD_base} · Na-adjusted = {v.MELD_na_unround.toFixed(2)} · capped to {v.MELD_Na}
+                </div>
+              </div>
+
+              <h4 style={{ marginTop: '0.75rem' }}>Validation tests</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                <div>✓ SCr=1.0, Bili=1.0, INR=1.0, Na=140 → 6 (passes)</div>
+                <div>✓ SCr=2.0, Bili=3.0, INR=1.5, Na=130 → 21 (passes)</div>
+                <div>✓ SCr=5.0 (caps to 4.0), Bili=10, INR=2.5, Na=125 → 35 (passes)</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [tab, setTab] = useState('hiv');
+      const [briefOpen, setBriefOpen] = useState(true);
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Algorithm Editor</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Algorithm Editor <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>complex branching · DMN-inspired</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> When a rule has more than one decision point, promote
+              it to an <em>algorithm</em> — a named container of multiple decision tables wired
+              together by a workflow graph. Each node on the canvas is one decision table (Reflex)
+              or one named intermediate (Calculated Values). Click a node to open its editor below.
+              Conditions in the decision-table cells use <strong>semantic predicates</strong>
+              (<span className="tok-pred">isOutsideNormal</span>, <span className="tok-pred">isCritical</span>,{' '}
+              <span className="tok-pred">isReactive</span>, etc.) that compile to numeric expressions
+              using the Test Catalog's reference and critical ranges — so a range change in the
+              catalog updates every rule automatically. The simulator traces the path. Coverage and
+              conflict checks run across the whole graph. Algorithms are exportable as DMN —
+              the OMG standard that Camunda, FHIR Clinical Reasoning, and most modern CDS tools speak.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          <div className="top-tabs">
+            <button className={'top-tab' + (tab === 'hiv' ? ' active' : '')} onClick={() => setTab('hiv')}>
+              Reflex Algorithm — HIV 3-test national cascade
+            </button>
+            <button className={'top-tab' + (tab === 'meld' ? ' active' : '')} onClick={() => setTab('meld')}>
+              Multi-step Calculation — MELD-Na liver score
+            </button>
+          </div>
+
+          {tab === 'hiv' && <HIVAlgorithm />}
+          {tab === 'meld' && <MELDCalc />}
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What this view adds to the v2 design:</strong> Single-rule editing stays in the
+            Reflex / Calculated Values list pages. <em>Algorithm</em> is a new top-level concept that
+            composes multiple rules into a directed graph. The workflow canvas is the orchestration
+            layer (BPMN-style); decision tables and formula bars stay as the leaf editors. This is
+            the standard "DMN + BPMN-lite" combination that Camunda, Red Hat KIE, and FHIR Clinical
+            Reasoning all use to model complex clinical protocols. The trade-off: algorithms are
+            heavier to author than a single rule, so the system should only nudge users toward
+            algorithm mode when they have ≥ 2 decision points that depend on each other.
+            For genuinely terminal complexity (newborn screening with 60 conditions, multi-site
+            harmonization, ISO-15189 audit), the next layer up is full CQL — out of scope for this
+            preview but the algorithm AST should compile to CQL when needed.
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/designs/admin-config/calc-decision-table-preview.html
+++ b/designs/admin-config/calc-decision-table-preview.html
@@ -1,0 +1,1183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Decision-Table Calculation — TB GenoType Interpretation — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-param { color: #6929c4; font-weight: 600; }  /* analyzer parameter */
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+
+    /* List view */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    table.cds--data-table { width: 100%; background: #fff; border: 1px solid #e0e0e0; border-top: none; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    .type-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 4px;
+      text-transform: uppercase; letter-spacing: 0.4px;
+    }
+    .type-chip.numeric { background: #defbe6; color: #0e6027; }
+    .type-chip.coded   { background: #e8daff; color: #491d8b; }
+
+    /* Expanded editor — decision table for coded calc */
+    .expanded {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-stack {
+      display: flex; flex-direction: column; gap: 0.75rem;
+    }
+
+    /* Collapsible card — used for catalog data and simulator */
+    .collapsible {
+      background: #fff; border: 1px solid #e0e0e0;
+    }
+    .collapsible-head {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.75rem 1rem; cursor: pointer; user-select: none;
+      background: #fafafa; border-bottom: 1px solid #e0e0e0;
+      width: 100%; border-left: none; border-right: none; border-top: none;
+      font-family: inherit; font-size: inherit; text-align: left;
+    }
+    .collapsible-head:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .collapsible-head.collapsed { border-bottom-color: transparent; }
+    .collapsible-head:hover { background: #f4f4f4; }
+    .collapsible-head .caret { font-size: 11px; color: #525252; }
+    .collapsible-head .title { font-size: 14px; font-weight: 600; flex: 0 0 auto; }
+    .collapsible-head .summary {
+      font-size: 12px; color: #6f6f6f; flex: 1; min-width: 0;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .collapsible-head .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .collapsible-head .pill.gray { background: #f4f4f4; color: #525252; }
+    .collapsible-head .pill.green { background: #defbe6; color: #0e6027; }
+    .collapsible-body { padding: 1rem; }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.coded  { background: #e8daff; color: #491d8b; }
+    .panel h4 .pill.green  { background: #defbe6; color: #0e6027; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* Output picker for coded destination */
+    .output-card {
+      background: #f4f9ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem;
+    }
+    .output-card .label { font-size: 10px; color: #0043ce; font-weight: 700; letter-spacing: 0.5px; }
+    .output-card .name { font-size: 16px; font-weight: 600; margin: 4px 0; }
+    .output-card .meta { font-size: 11px; color: #525252; font-family: 'IBM Plex Mono', monospace; }
+    .output-card .values {
+      font-size: 11px; color: #525252; margin-top: 4px;
+      display: flex; flex-wrap: wrap; gap: 4px;
+    }
+    .output-card .values .v {
+      background: #fff; border: 1px solid #c6c6c6; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    }
+
+    /* Decision rule cards */
+    .dt-rule {
+      background: #fff; border: 1px solid #c6c6c6; margin-bottom: 0.75rem;
+      border-radius: 4px; overflow: hidden;
+    }
+    .dt-rule-header {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 0.5rem 0.75rem; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0;
+      font-size: 12px;
+    }
+    .dt-rule-header .num {
+      width: 22px; height: 22px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 600;
+    }
+    .dt-rule-header .title { font-weight: 600; color: #161616; flex: 1; }
+    .dt-rule-header .actions { display: flex; gap: 4px; }
+    .dt-rule-header .icon-btn {
+      background: #fff; border: 1px solid #c6c6c6; color: #525252; cursor: pointer; font-size: 14px;
+      padding: 4px 10px; min-width: 32px; min-height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+    }
+    .dt-rule-header .icon-btn:hover { background: #edf5ff; color: #0f62fe; border-color: #0f62fe; }
+    .dt-rule-header .icon-btn:focus-visible { outline: 2px solid #0f62fe; outline-offset: 1px; }
+    .dt-rule-header .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .dt-rule-body { padding: 0.75rem; }
+
+    .compose-row {
+      display: grid; grid-template-columns: 56px 1fr 28px;
+      gap: 0.5rem; align-items: center; margin-bottom: 6px;
+    }
+    .compose-row .joiner {
+      background: #fff8e1; color: #b28600; font-size: 11px; font-weight: 700;
+      text-align: center; padding: 4px 6px; border-radius: 4px;
+      letter-spacing: 0.5px;
+    }
+    .compose-row .joiner.first { background: #d0e2ff; color: #0043ce; }
+    .compose-row select.joiner { padding: 4px 4px; border: 1px solid #c6c6c6; }
+    .compose-row .row-body {
+      display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;
+    }
+    .compose-row .row-body > select,
+    .compose-row .row-body > input {
+      padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .compose-row .row-body select { min-width: 180px; }
+    .compose-row .row-body input { width: 90px; }
+    .delete { background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px; }
+
+    /* THEN bar — picks the resulting coded value */
+    .then-bar {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 8px 10px; margin-top: 8px;
+      background: #defbe6; border-left: 3px solid #198038;
+    }
+    .then-bar .label {
+      font-size: 10px; color: #0e6027; font-weight: 700; letter-spacing: 0.5px;
+    }
+    .then-bar .equals { color: #525252; font-weight: 600; }
+    .then-bar select {
+      padding: 4px 10px; font-size: 14px; font-weight: 600;
+      border: none; border-bottom: 1px solid #198038; background: #fff;
+      color: #0e6027;
+    }
+
+    /* Otherwise row */
+    .otherwise {
+      background: #f4f4f4; border: 1px dashed #8d8d8d;
+      padding: 0.75rem; margin-bottom: 0.75rem; border-radius: 4px;
+    }
+    .otherwise .title {
+      font-size: 11px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px;
+      margin-bottom: 4px;
+    }
+    .otherwise .subtitle {
+      font-size: 11px; color: #6f6f6f; font-style: italic; margin-bottom: 6px;
+    }
+
+    /* + Add rule CTA */
+    .add-cta {
+      display: flex; align-items: center; justify-content: center; gap: 6px;
+      width: 100%; padding: 10px;
+      background: #fff; border: 1.5px dashed #0f62fe;
+      color: #0f62fe; font-size: 13px; font-weight: 600;
+      cursor: pointer; margin-top: 8px;
+    }
+    .add-cta:hover { background: #edf5ff; border-color: #0043ce; }
+    .add-cta .plus {
+      width: 20px; height: 20px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 14px; font-weight: 700;
+    }
+
+    /* Catalog reference panel */
+    .catalog-card {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+    .catalog-card .head {
+      display: flex; justify-content: space-between; align-items: center;
+      font-size: 13px; margin-bottom: 6px;
+    }
+    .catalog-card .head strong { color: #161616; }
+    .catalog-card .meta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; line-height: 1.6; }
+    .catalog-card .params-section {
+      margin-top: 8px; padding-top: 8px; border-top: 1px solid #e0e0e0;
+    }
+    .catalog-card .params-section .title {
+      font-size: 10px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px;
+      margin-bottom: 6px; display: flex; justify-content: space-between;
+    }
+    .catalog-card .params-section .title .source {
+      color: #6929c4; font-weight: 600;
+    }
+    .param-row {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 4px 8px; background: #fff; border: 1px solid #e0e0e0;
+      margin-bottom: 4px; font-size: 12px;
+    }
+    .param-row .name { color: #6929c4; font-family: 'IBM Plex Mono', monospace; font-weight: 600; }
+    .param-row .kind {
+      background: #f6f2ff; color: #6929c4; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 170px; font-size: 12px; color: #161616; }
+    .sim-row input, .sim-row select {
+      flex: 1; padding: 4px 8px; font-size: 12px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-row .unit { flex: 0 0 50px; font-size: 11px; color: #6f6f6f; }
+    .sim-result {
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+      background: #defbe6; border-left: 3px solid #198038;
+    }
+    .sim-result .head { font-size: 11px; color: #0e6027; text-transform: uppercase; letter-spacing: 0.5px; }
+    .sim-result .value {
+      font-size: 18px; font-weight: 600; color: #0e6027; margin-top: 4px;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .sim-result .which {
+      font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .sim-result.indeterminate { background: #fff8e1; border-color: #f1c21b; }
+    .sim-result.indeterminate .head, .sim-result.indeterminate .value { color: #b28600; }
+
+    /* Test picker — chip-style trigger + dropdown panel */
+    .ip-wrap { position: relative; display: inline-block; max-width: 100%; }
+    .ip-trigger {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 4px 10px; min-height: 30px; max-width: 100%;
+      background: #f4f4f4; border: 1px solid #c6c6c6; border-radius: 4px;
+      font-size: 13px; cursor: pointer; font-family: inherit;
+    }
+    .ip-trigger:hover { background: #e8e8e8; border-color: #8d8d8d; }
+    .ip-trigger:focus { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .ip-trigger.empty { color: #6f6f6f; font-style: italic; }
+    .ip-trigger .caret { color: #525252; font-size: 10px; margin-left: 2px; flex-shrink: 0; }
+    .ip-trigger .ip-label {
+      color: #161616; font-style: normal;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      max-width: 480px;
+    }
+    .ip-trigger .ip-sub {
+      color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+      flex-shrink: 0;
+    }
+    .ip-trigger .clear-btn {
+      background: none; border: none; cursor: pointer; color: #6f6f6f;
+      padding: 0 2px 0 4px; font-size: 14px; line-height: 1;
+    }
+    .ip-trigger .clear-btn:hover { color: #a2191f; }
+    .ip-kind {
+      padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .ip-kind.result { background: #d0e2ff; color: #0043ce; }
+    .ip-kind.param  { background: #f6f2ff; color: #6929c4; }
+
+    .ip-pop {
+      position: absolute; top: calc(100% + 4px); left: 0;
+      min-width: 360px; max-width: 480px;
+      background: #fff; border: 1px solid #8d8d8d; border-radius: 4px;
+      z-index: 100; box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      overflow: hidden;
+    }
+    .ip-pop-search {
+      width: 100%; padding: 10px 12px; border: none; border-bottom: 1px solid #e0e0e0;
+      font-size: 13px; box-sizing: border-box; outline: none;
+      background: #fff;
+    }
+    .ip-pop-search:focus { background: #f4f9ff; }
+    .ip-pop-list { max-height: 280px; overflow-y: auto; }
+    .ip-item {
+      display: flex; align-items: center; gap: 10px;
+      width: 100%; padding: 8px 12px; background: none; border: none;
+      border-top: 1px solid #f4f4f4; cursor: pointer; text-align: left;
+      font-family: inherit; font-size: 13px;
+    }
+    .ip-item:hover { background: #edf5ff; }
+    .ip-item:first-child { border-top: none; }
+    .ip-item-body { flex: 1; min-width: 0; }
+    .ip-item-name { color: #161616; line-height: 1.3; }
+    .ip-item-meta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+      margin-top: 2px; line-height: 1.3;
+    }
+    .ip-pop-empty { padding: 16px; color: #6f6f6f; font-size: 12px; font-style: italic; text-align: center; }
+    .ip-pop-more { padding: 8px 12px; font-size: 11px; color: #6f6f6f; font-style: italic; border-top: 1px solid #f4f4f4; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Calculation with Coded Output &nbsp;|&nbsp; Decision-table mode · Analyzer parameters as inputs &nbsp;|&nbsp; OpenELIS Design Mockup
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Coded Calculation editor (Decision Table)</strong>
+    &nbsp;<span style="color: #6f6f6f;">— what expands inline when you click a calc row with a <em>coded</em> destination. For a <em>numeric</em> destination, see <a href="calculated-values-redesign-v2-preview.html" style="color: #0f62fe;">the formula-bar editor</a>.</span>
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">Loading…</div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    window.addEventListener('load', function () {
+      var missing = [];
+      if (typeof React === 'undefined')    missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined')    missing.push('Babel');
+      var s = document.getElementById('boot-status');
+      if (missing.length && s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Missing dependencies:</strong> ' + missing.join(', ');
+      }
+    });
+  </script>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // CATALOG — with analyzer parameters
+    // ========================================================================
+    const TESTS = {
+      // Sources of input
+      TB_GT: {
+        id: 'TB_GT', name: 'TB GenoType MTBDRplus (LPA)',
+        loinc: '88262-1', type: 'coded',
+        values: ['MTB detected', 'Not detected', 'Indeterminate'],
+        sample: 'Sputum',
+        // Raw analyzer parameters from QC-table linkage
+        analyzerParameters: [
+          { id: 'IC',        name: 'Internal Control valid',  type: 'coded',   values: ['Yes','No'] },
+          { id: 'rpoB_pres', name: 'rpoB band present',       type: 'coded',   values: ['Yes','No'] },
+          { id: 'rpoB_mp',   name: 'rpoB melting point',      type: 'numeric', units: '°C', refRange: [82.5, 86.5] },
+          { id: 'inhA_pres', name: 'inhA mutation present',   type: 'coded',   values: ['Yes','No'] },
+          { id: 'katG_pres', name: 'katG mutation present',   type: 'coded',   values: ['Yes','No'] },
+          { id: 'gyrA_pres', name: 'gyrA mutation present',   type: 'coded',   values: ['Yes','No','Not tested'] },
+        ],
+      },
+      TC: {
+        id: 'TC', name: 'Total Cholesterol', loinc: '2093-3', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [125, 200],
+      },
+      HDL: {
+        id: 'HDL', name: 'HDL Cholesterol', loinc: '2085-9', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [40, 60],
+      },
+      TRIG: {
+        id: 'TRIG', name: 'Triglycerides', loinc: '2571-8', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [0, 150],
+      },
+      // Destination tests
+      TB_INTERP: {
+        id: 'TB_INTERP', name: 'TB GenoType Resistance Interpretation',
+        loinc: 'local', type: 'coded',
+        values: [
+          'Wild type — no resistance detected',
+          'Rifampicin resistance suspected',
+          'Isoniazid resistance suspected',
+          'MDR-TB suspected (RIF + INH)',
+          'Invalid — repeat test',
+          'Indeterminate — review raw values',
+        ],
+        sample: 'Sputum',
+      },
+      LDL: {
+        id: 'LDL', name: 'LDL Cholesterol', loinc: '13457-7', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [0, 100],
+      },
+    };
+
+    // Catalog-based predicates (subset)
+    const PREDICATES = [
+      // Catalog-based numeric
+      { id: 'isNormal',         group: 'catalog', requires: 'refRange', label: 'is within the normal range', short: 'is normal' },
+      { id: 'isOutsideNormal',  group: 'catalog', requires: 'refRange', label: 'is outside the normal range', short: 'is outside normal' },
+      { id: 'isAboveNormal',    group: 'catalog', requires: 'refRange', label: 'is above the normal range', short: 'is above normal' },
+      { id: 'isBelowNormal',    group: 'catalog', requires: 'refRange', label: 'is below the normal range', short: 'is below normal' },
+      // Numeric value
+      { id: 'gt',      group: 'value', requires: 'numeric', valueInput: 'number', label: 'is greater than (>)', short: 'is greater than' },
+      { id: 'gte',     group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at least (≥)',     short: 'is at least' },
+      { id: 'lt',      group: 'value', requires: 'numeric', valueInput: 'number', label: 'is less than (<)',    short: 'is less than' },
+      { id: 'lte',     group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at most (≤)',      short: 'is at most' },
+      { id: 'between', group: 'value', requires: 'numeric', valueInput: 'range',  label: 'is between (inclusive)', short: 'is between' },
+      // Coded
+      { id: 'is',    group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is…',     short: 'is' },
+      { id: 'isNot', group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is not…', short: 'is not' },
+    ];
+
+    // For a given input source (test result or analyzer param), returns its metadata
+    function inputMeta(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return null;
+      if (paramId) return t.analyzerParameters?.find(p => p.id === paramId);
+      return t;
+    }
+    function inputLabel(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return '';
+      if (paramId) {
+        const p = t.analyzerParameters?.find(p => p.id === paramId);
+        return `${t.id}.${p?.id ?? '?'}`;
+      }
+      return testId;
+    }
+    function inputFullName(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return '';
+      if (paramId) {
+        const p = t.analyzerParameters?.find(p => p.id === paramId);
+        return `${t.name} — ${p?.name ?? '?'}`;
+      }
+      return t.name;
+    }
+    function predicatesFor(meta) {
+      if (!meta) return [];
+      return PREDICATES.filter(p => {
+        if (p.requires === 'refRange') return Array.isArray(meta.refRange);
+        if (p.requires === 'numeric')  return meta.type === 'numeric';
+        if (p.requires === 'values')   return Array.isArray(meta.values);
+        return false;
+      });
+    }
+    function predicatePhrase(testId, paramId, predId, value) {
+      const meta = inputMeta(testId, paramId);
+      const p = PREDICATES.find(x => x.id === predId);
+      if (!meta || !p) return '';
+      const labelText = p.label.replace(/…$/, '').replace(/\s*\(.*?\)\s*$/, '').trim();
+      const baseName = paramId ? `${testId} ${meta.name}` : (TESTS[testId]?.name || testId);
+      const base = `${baseName} ${labelText}`;
+      if (!p.valueInput) return base;
+      if (p.valueInput === 'range') return value && value[0] != null && value[1] != null ? `${base} ${value[0]} and ${value[1]} ${meta.units || ''}`.trim() : `${base} …`;
+      if (p.valueInput === 'codedMulti') {
+        const list = Array.isArray(value) ? value : [];
+        if (list.length === 0) return `${base} …`;
+        if (list.length === 1) return `${base} ${list[0]}`;
+        if (list.length === 2) return `${base} ${list[0]} or ${list[1]}`;
+        return `${base} ${list.slice(0, -1).join(', ')}, or ${list[list.length - 1]}`;
+      }
+      return value != null && value !== '' ? `${base} ${value}${meta.units ? ' ' + meta.units : ''}` : `${base} …`;
+    }
+
+    // ========================================================================
+    // INPUT PICKER — chip-style trigger + dropdown with search inside
+    // Searches across test results AND analyzer parameters
+    // ========================================================================
+    function InputPicker({ value, onChange }) {
+      const [open, setOpen] = useState(false);
+      const [q, setQ] = useState('');
+
+      // Build a flat list of selectable inputs (test results + analyzer parameters)
+      const candidates = [];
+      Object.values(TESTS).forEach(t => {
+        if (t.type !== 'reflex' && t.id !== 'TB_INTERP' && t.id !== 'LDL') {
+          // Reported test result
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded · ' + t.values.length + ' values' : (t.units || 'numeric')}${t.sample ? ' · sample: ' + t.sample : ''}`,
+          });
+        }
+        (t.analyzerParameters || []).forEach(p => {
+          candidates.push({
+            kind: 'param', testId: t.id, paramId: p.id,
+            humanName: p.name,
+            parentName: t.name,
+            techId: `${t.id}.${p.id}`,
+            meta: `${p.type === 'coded' ? 'coded · ' + p.values.join(' / ') : (p.units || 'numeric')}${p.refRange ? ' · range ' + p.refRange[0] + '–' + p.refRange[1] : ''}`,
+          });
+        });
+      });
+      const filtered = candidates.filter(c =>
+        q === '' ||
+        (c.humanName + ' ' + (c.parentName || '') + ' ' + c.techId + ' ' + c.meta)
+          .toLowerCase().includes(q.toLowerCase())
+      );
+
+      const pick = (c) => {
+        onChange({ testId: c.testId, paramId: c.paramId });
+        setQ(''); setOpen(false);
+      };
+
+      // Chip display data
+      const selectedHumanName = value
+        ? (value.paramId
+            ? inputMeta(value.testId, value.paramId)?.name
+            : TESTS[value.testId]?.name)
+        : null;
+      const selectedTechId = value
+        ? (value.paramId ? `${value.testId}.${value.paramId}` : value.testId)
+        : null;
+
+      return (
+        <div className="ip-wrap">
+          <button type="button"
+                  className={'ip-trigger' + (value ? '' : ' empty')}
+                  onClick={() => setOpen(o => !o)}
+                  title={value ? `${selectedHumanName} (${selectedTechId})` : 'Pick a test result or analyzer parameter'}>
+            {value && (
+              <span className={'ip-kind ' + (value.paramId ? 'param' : 'result')}>
+                {value.paramId ? 'param' : 'result'}
+              </span>
+            )}
+            <span className="ip-label">{selectedHumanName || 'Pick input…'}</span>
+            {value && (
+              <span className="ip-sub">{selectedTechId}</span>
+            )}
+            {value && (
+              <span className="clear-btn" onClick={(e) => { e.stopPropagation(); onChange(null); setOpen(false); }}>
+                ×
+              </span>
+            )}
+            <span className="caret">{open ? '▴' : '▾'}</span>
+          </button>
+          {open && (
+            <>
+              <div style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+                   onClick={() => setOpen(false)} />
+              <div className="ip-pop">
+                <input type="text" className="ip-pop-search" autoFocus
+                       placeholder="Search by name, test, LOINC, units…"
+                       value={q} onChange={e => setQ(e.target.value)} />
+                <div className="ip-pop-list">
+                  {filtered.slice(0, 14).map((c, i) => (
+                    <button key={i} className="ip-item" onClick={() => pick(c)}>
+                      <span className={'ip-kind ' + c.kind}>{c.kind}</span>
+                      <span className="ip-item-body">
+                        <div className="ip-item-name">
+                          {c.kind === 'param'
+                            ? <><span style={{ color: '#6f6f6f' }}>{c.parentName} →</span> <strong>{c.humanName}</strong></>
+                            : <strong>{c.humanName}</strong>}
+                        </div>
+                        <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                      </span>
+                    </button>
+                  ))}
+                  {filtered.length === 0 && (
+                    <div className="ip-pop-empty">No matches.</div>
+                  )}
+                  {filtered.length > 14 && (
+                    <div className="ip-pop-more">…and {filtered.length - 14} more. Refine your search.</div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // COMPOSE ROW — a single condition inside one decision-table rule
+    // ========================================================================
+    function ConditionRow({ row, joiner, isFirst, onChange, onJoinerChange, onDelete }) {
+      const meta = row.input ? inputMeta(row.input.testId, row.input.paramId) : null;
+      const preds = meta ? predicatesFor(meta) : [];
+      const predDef = row.pred ? PREDICATES.find(p => p.id === row.pred) : null;
+
+      return (
+        <div className="compose-row">
+          {isFirst
+            ? <span className="joiner first">WHEN</span>
+            : <select className="joiner" value={joiner || 'AND'} onChange={e => onJoinerChange(e.target.value)}>
+                <option>AND</option><option>OR</option>
+              </select>}
+          <div className="row-body">
+            <InputPicker value={row.input} onChange={v => onChange({ ...row, input: v, pred: '', value: null })} />
+            {meta && (
+              <select value={row.pred} onChange={e => onChange({ ...row, pred: e.target.value, value: null })}>
+                <option value="">— pick a question —</option>
+                {preds.map(p => <option key={p.id} value={p.id}>{p.label}</option>)}
+              </select>
+            )}
+            {predDef && predDef.valueInput === 'number' && (
+              <>
+                <input type="number" step="any" placeholder="value"
+                       value={row.value ?? ''}
+                       onChange={e => onChange({ ...row, value: e.target.value === '' ? null : +e.target.value })} />
+                {meta.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{meta.units}</span>}
+              </>
+            )}
+            {predDef && predDef.valueInput === 'range' && (() => {
+              const v = row.value || [null, null];
+              return (
+                <>
+                  <input type="number" step="any" placeholder="low"
+                         value={v[0] ?? ''}
+                         onChange={e => onChange({ ...row, value: [e.target.value === '' ? null : +e.target.value, v[1]] })} />
+                  <span style={{ fontSize: 11, color: '#525252' }}>and</span>
+                  <input type="number" step="any" placeholder="high"
+                         value={v[1] ?? ''}
+                         onChange={e => onChange({ ...row, value: [v[0], e.target.value === '' ? null : +e.target.value] })} />
+                  {meta.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{meta.units}</span>}
+                </>
+              );
+            })()}
+            {predDef && predDef.valueInput === 'codedMulti' && (
+              <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 4 }}>
+                {meta.values.map(cv => {
+                  const selected = (row.value || []).includes(cv);
+                  return (
+                    <label key={cv} style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 3, padding: '2px 6px', background: selected ? '#d0e2ff' : '#f4f4f4', borderRadius: 3, cursor: 'pointer' }}>
+                      <input type="checkbox" checked={selected}
+                             onChange={e => {
+                               const cur = row.value || [];
+                               const next = e.target.checked ? [...cur, cv] : cur.filter(x => x !== cv);
+                               onChange({ ...row, value: next });
+                             }} />
+                      {cv}
+                    </label>
+                  );
+                })}
+              </span>
+            )}
+          </div>
+          <button className="delete" onClick={onDelete} title="Remove condition">×</button>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // DECISION RULE — one card in the decision table
+    // ========================================================================
+    function DecisionRule({ num, rule, destinationValues, onChange, onDelete, onMoveUp, onMoveDown, canUp, canDown }) {
+      const setRow = (i, newRow) => onChange({ ...rule, rows: rule.rows.map((r, idx) => idx === i ? newRow : r) });
+      const setJoiner = (i, val) => onChange({ ...rule, joiners: rule.joiners.map((j, idx) => idx === i ? val : j) });
+      const addRow = () => onChange({ ...rule, rows: [...rule.rows, { input: null, pred: '', value: null }], joiners: [...rule.joiners, 'AND'] });
+      const removeRow = (i) => onChange({ ...rule, rows: rule.rows.filter((_, idx) => idx !== i), joiners: rule.joiners.filter((_, idx) => idx !== i) });
+
+      return (
+        <div className="dt-rule">
+          <div className="dt-rule-header">
+            <span className="num">{num}</span>
+            <span className="title">Rule {num}</span>
+            <div className="actions">
+              {canUp   && <button className="icon-btn" onClick={onMoveUp}   title="Move up">▲</button>}
+              {canDown && <button className="icon-btn" onClick={onMoveDown} title="Move down">▼</button>}
+              <button className="icon-btn" style={{ color: '#a2191f' }} onClick={onDelete} title="Delete rule">🗑</button>
+            </div>
+          </div>
+          <div className="dt-rule-body">
+            {rule.rows.map((r, i) => (
+              <ConditionRow
+                key={i}
+                row={r}
+                joiner={rule.joiners[i]}
+                isFirst={i === 0}
+                onChange={nr => setRow(i, nr)}
+                onJoinerChange={v => setJoiner(i, v)}
+                onDelete={() => removeRow(i)}
+              />
+            ))}
+            <button className="cds--btn cds--btn--ghost" onClick={addRow} style={{ fontSize: 11, marginTop: 4 }}>
+              + Add condition
+            </button>
+
+            <div className="then-bar">
+              <span className="label">THEN result is</span>
+              <span className="equals">=</span>
+              <select value={rule.result || ''} onChange={e => onChange({ ...rule, result: e.target.value })}>
+                <option value="">— pick a result —</option>
+                {destinationValues.map(v => <option key={v} value={v}>{v}</option>)}
+              </select>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // EVALUATOR — runs the decision table against sample inputs
+    // ========================================================================
+    function evalRow(row, inputs) {
+      if (!row.input || !row.pred) return null;  // incomplete row — treat as unknown
+      const meta = inputMeta(row.input.testId, row.input.paramId);
+      const key = `${row.input.testId}${row.input.paramId ? '.' + row.input.paramId : ''}`;
+      const v = inputs[key];
+      if (v == null || v === '') return null;
+      const p = row.pred;
+      const val = row.value;
+      switch (p) {
+        case 'isNormal':         return v >= meta.refRange[0] && v <= meta.refRange[1];
+        case 'isOutsideNormal':  return v <  meta.refRange[0] || v >  meta.refRange[1];
+        case 'isAboveNormal':    return v >  meta.refRange[1];
+        case 'isBelowNormal':    return v <  meta.refRange[0];
+        case 'gt':  return val != null && +v >  val;
+        case 'gte': return val != null && +v >= val;
+        case 'lt':  return val != null && +v <  val;
+        case 'lte': return val != null && +v <= val;
+        case 'between': return val && val[0] != null && val[1] != null && +v >= val[0] && +v <= val[1];
+        case 'is':    return Array.isArray(val) && val.includes(v);
+        case 'isNot': return Array.isArray(val) && !val.includes(v);
+        default: return null;
+      }
+    }
+    function evalRule(rule, inputs) {
+      if (rule.rows.length === 0) return null;
+      const results = rule.rows.map(r => evalRow(r, inputs));
+      if (results.some(r => r === null)) return null; // incomplete — can't decide
+      let acc = results[0];
+      for (let i = 1; i < results.length; i++) {
+        const j = rule.joiners[i] || 'AND';
+        acc = (j === 'OR') ? (acc || results[i]) : (acc && results[i]);
+      }
+      return acc;
+    }
+    function evalDecisionTable(rules, otherwise, inputs) {
+      for (let i = 0; i < rules.length; i++) {
+        const r = evalRule(rules[i], inputs);
+        if (r === true) return { matched: i + 1, result: rules[i].result };
+      }
+      // None matched
+      return { matched: 'otherwise', result: otherwise };
+    }
+
+    // ========================================================================
+    // CALCULATIONS LIST DATA
+    // ========================================================================
+    const CALCS = [
+      {
+        id: 'calc-ldl',
+        name: 'LDL Cholesterol (Friedewald)',
+        outputKind: 'numeric',
+        destination: 'LDL',
+        summary: 'LDL = TC − HDL − Triglycerides/5',
+        edited: '2026-04-28 by p.diallo',
+      },
+      {
+        id: 'calc-tb',
+        name: 'TB GenoType Resistance Interpretation',
+        outputKind: 'coded',
+        destination: 'TB_INTERP',
+        summary: 'Maps LPA band pattern + melting points to interpretation (5 categories)',
+        edited: '2026-05-08 by m.kone',
+      },
+    ];
+
+    // ========================================================================
+    // TB EDITOR — the decision-table calc demo
+    // ========================================================================
+    function TBEditor() {
+      const dest = TESTS.TB_INTERP;
+
+      const [catalogOpen, setCatalogOpen] = useState(false);
+      const [simulatorOpen, setSimulatorOpen] = useState(true);
+      const [otherwise, setOtherwise] = useState('Indeterminate — review raw values');
+      const [rules, setRules] = useState([
+        {
+          id: 1,
+          rows: [{ input: { testId: 'TB_GT', paramId: 'IC' }, pred: 'is', value: ['No'] }],
+          joiners: [null],
+          result: 'Invalid — repeat test',
+        },
+        {
+          id: 2,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'rpoB_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'inhA_pres' }, pred: 'is', value: ['No']  },
+            { input: { testId: 'TB_GT', paramId: 'katG_pres' }, pred: 'is', value: ['No']  },
+            { input: { testId: 'TB_GT', paramId: 'rpoB_mp' },   pred: 'between', value: [82.5, 86.5] },
+          ],
+          joiners: [null, 'AND', 'AND', 'AND'],
+          result: 'Wild type — no resistance detected',
+        },
+        {
+          id: 3,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'rpoB_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'rpoB_mp' },   pred: 'isOutsideNormal', value: null },
+          ],
+          joiners: [null, 'AND'],
+          result: 'Rifampicin resistance suspected',
+        },
+        {
+          id: 4,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'inhA_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'katG_pres' }, pred: 'is', value: ['Yes'] },
+          ],
+          joiners: [null, 'OR'],
+          result: 'Isoniazid resistance suspected',
+        },
+      ]);
+
+      const [inputs, setInputs] = useState({
+        'TB_GT.IC':        'Yes',
+        'TB_GT.rpoB_pres': 'Yes',
+        'TB_GT.rpoB_mp':   84.2,
+        'TB_GT.inhA_pres': 'No',
+        'TB_GT.katG_pres': 'No',
+      });
+      const setInput = (k, v) => setInputs(s => ({ ...s, [k]: v }));
+
+      const evalResult = evalDecisionTable(rules, otherwise, inputs);
+
+      const updateRule = (i, r) => setRules(arr => arr.map((x, idx) => idx === i ? r : x));
+      const deleteRule = (i)    => setRules(arr => arr.filter((_, idx) => idx !== i));
+      const addRule = () => setRules(arr => [...arr, {
+        id: Math.max(0, ...arr.map(r => r.id)) + 1,
+        rows: [{ input: null, pred: '', value: null }],
+        joiners: [null],
+        result: '',
+      }]);
+      const move = (i, dir) => setRules(arr => {
+        const j = i + dir;
+        if (j < 0 || j >= arr.length) return arr;
+        const copy = arr.slice();
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+        return copy;
+      });
+
+      return (
+        <tr>
+          <td colSpan={5} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--purple">Coded output · {dest.values.length} possible values</span>
+                <span className="cds--tag cds--tag--warm-gray">Trigger sample: Sputum</span>
+                <span className="cds--tag cds--tag--cool-gray">{rules.length} rules + 1 otherwise</span>
+              </div>
+
+              <div className="editor-stack">
+
+                {/* TOP — Test catalog data (collapsible) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (catalogOpen ? '' : ' collapsed')}
+                          aria-expanded={catalogOpen}
+                          onClick={() => setCatalogOpen(o => !o)}>
+                    <span className="caret">{catalogOpen ? '▾' : '▸'}</span>
+                    <span className="title">Test catalog data</span>
+                    <span className="summary">
+                      {TESTS.TB_GT.name} ({TESTS.TB_GT.id}) · Sputum · {TESTS.TB_GT.analyzerParameters.length} analyzer parameters via QC linkage
+                    </span>
+                    <span className="pill gray">Reference</span>
+                  </button>
+                  {catalogOpen && (
+                    <div className="collapsible-body">
+                      <div className="catalog-card" style={{ margin: 0 }}>
+                        <div className="head">
+                          <span><strong>{TESTS.TB_GT.name}</strong> ({TESTS.TB_GT.id})</span>
+                          <span style={{ fontSize: 10, color: '#6f6f6f' }}>{TESTS.TB_GT.type}</span>
+                        </div>
+                        <div className="meta">
+                          <div>Sample: <strong>{TESTS.TB_GT.sample}</strong> · LOINC <strong>{TESTS.TB_GT.loinc}</strong></div>
+                          <div>Reported values: {TESTS.TB_GT.values.join(', ')}</div>
+                        </div>
+                        <div className="params-section">
+                          <div className="title">
+                            <span>Analyzer parameters</span>
+                            <span className="source">via QC table linkage · {TESTS.TB_GT.analyzerParameters.length} captured</span>
+                          </div>
+                          {TESTS.TB_GT.analyzerParameters.map(p => (
+                            <div key={p.id} className="param-row">
+                              <div>
+                                <div style={{ color: '#161616', fontSize: 13, fontWeight: 600 }}>{p.name}</div>
+                                <div style={{ fontSize: 11, color: '#6929c4', fontFamily: 'monospace' }}>{TESTS.TB_GT.id}.{p.id}</div>
+                              </div>
+                              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
+                                <span className="kind">{p.type}</span>
+                                <span style={{ fontSize: 10, color: '#6f6f6f', fontFamily: 'monospace' }}>
+                                  {p.type === 'coded' ? p.values.join('/') : `${p.units || 'numeric'}${p.refRange ? ` · ${p.refRange[0]}–${p.refRange[1]}` : ''}`}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                        <div style={{ marginTop: 6, fontSize: 11, color: '#0f62fe' }}>
+                          → <a href="#" style={{ color: '#0f62fe' }}>Edit in Test Catalog</a>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* MIDDLE — Rule definition (full width) */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill coded">Decision Table</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="TB GenoType Resistance Interpretation"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4', fontSize: 14 }} />
+                  </div>
+
+                  {/* Destination test card — drives the output type */}
+                  <div className="output-card">
+                    <div className="label">OUTPUT GOES TO</div>
+                    <div className="name">{dest.name} <span style={{ fontWeight: 400, color: '#6f6f6f', fontSize: 13 }}>({dest.id})</span></div>
+                    <div className="meta">Coded result · {dest.values.length} possible values</div>
+                    <div className="values">
+                      {dest.values.map(v => <span key={v} className="v">{v}</span>)}
+                    </div>
+                    <div className="compact-hint" style={{ marginTop: 6 }}>
+                      Because the destination is a coded test, the editor uses a <strong>decision table</strong> instead of a formula bar.
+                      Each row maps a condition to one of the possible result values. <strong>First match wins.</strong>
+                    </div>
+                  </div>
+
+                  {rules.map((rule, i) => (
+                    <DecisionRule
+                      key={rule.id}
+                      num={i + 1}
+                      rule={rule}
+                      destinationValues={dest.values}
+                      onChange={r => updateRule(i, r)}
+                      onDelete={() => deleteRule(i)}
+                      onMoveUp={() => move(i, -1)}
+                      onMoveDown={() => move(i, +1)}
+                      canUp={i > 0}
+                      canDown={i < rules.length - 1}
+                    />
+                  ))}
+
+                  <div className="otherwise">
+                    <div className="title">Otherwise (if no rule above matches)</div>
+                    <div className="subtitle">A catch-all so every input produces a defined output. Required.</div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ fontSize: 11, color: '#0e6027', fontWeight: 700 }}>THEN result is =</span>
+                      <select value={otherwise} onChange={e => setOtherwise(e.target.value)}
+                              style={{ padding: 4, fontSize: 14, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', flex: 1 }}>
+                        {dest.values.map(v => <option key={v} value={v}>{v}</option>)}
+                      </select>
+                    </div>
+                  </div>
+
+                  <button className="add-cta" onClick={addRule}>
+                    <span className="plus">+</span>
+                    <span>Add another rule</span>
+                    <span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f', marginLeft: 6 }}>(evaluated top-down; first match wins)</span>
+                  </button>
+                </div>
+
+                {/* BOTTOM — Simulator (collapsible) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (simulatorOpen ? '' : ' collapsed')}
+                          aria-expanded={simulatorOpen}
+                          onClick={() => setSimulatorOpen(o => !o)}>
+                    <span className="caret">{simulatorOpen ? '▾' : '▸'}</span>
+                    <span className="title">Simulator</span>
+                    <span className="summary">
+                      {typeof evalResult.matched === 'number'
+                        ? `Current inputs → Rule ${evalResult.matched} → ${evalResult.result}`
+                        : `Current inputs → Otherwise → ${evalResult.result}`}
+                    </span>
+                    <span className="pill green">Sandbox</span>
+                  </button>
+                  {simulatorOpen && (
+                    <div className="collapsible-body">
+                      <span className="compact-hint" style={{ display: 'block', marginBottom: 10 }}>
+                        Enter values for each input. The simulator runs the rules top-down and reports the first match.
+                      </span>
+                      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '0.5rem 1.5rem' }}>
+                        {TESTS.TB_GT.analyzerParameters.map(p => {
+                          const k = `TB_GT.${p.id}`;
+                          return (
+                            <div key={p.id} className="sim-row" style={{ marginBottom: 0 }}>
+                              <label>{p.name}</label>
+                              {p.type === 'coded' ? (
+                                <select value={inputs[k] ?? ''} onChange={e => setInput(k, e.target.value)}>
+                                  {p.values.map(v => <option key={v} value={v}>{v}</option>)}
+                                </select>
+                              ) : (
+                                <input type="number" step="0.1" value={inputs[k] ?? ''} onChange={e => setInput(k, e.target.value === '' ? '' : +e.target.value)} />
+                              )}
+                              <span className="unit">{p.units || ''}</span>
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      <div className={'sim-result' + (typeof evalResult.matched === 'string' ? ' indeterminate' : '')}>
+                        <div className="head">Computed result</div>
+                        <div className="value">{evalResult.result || '—'}</div>
+                        <div className="which">
+                          {typeof evalResult.matched === 'number'
+                            ? `Matched Rule ${evalResult.matched} (top-down evaluation)`
+                            : 'No rule matched — fell through to Otherwise.'}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation cases</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState('calc-tb');
+      const [briefOpen, setBriefOpen] = useState(true);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <a href="#">Test Rules</a> / <span>TB GenoType Resistance Interpretation</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Calculated Value — Coded Output <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>decision-table mode · analyzer parameters as inputs</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>What's new here:</strong> A Calculation can write either a <em>numeric</em> result (formula bar)
+              or a <em>coded</em> result (decision table). The choice is driven by the destination test in the Test
+              Catalog. For coded outputs, each rule in the decision table is a Compose-style condition block — same
+              predicate vocabulary as Reflex — paired with a result picker showing the destination test's possible
+              values. First match wins, top-down. A required <em>Otherwise</em> row guarantees every input gets a
+              defined output.
+              <br /><br />
+              Condition inputs aren't limited to test results. <strong>Analyzer parameters</strong> (melting points,
+              band-present flags, internal-control validity, Ct values) are first-class — sourced from the existing
+              QC table that already captures them and associated with the result at import time. The TB GenoType
+              example below references six analyzer parameters and the test's reported result, mixing numeric and
+              coded predicates in one rule.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          <div className="toolbar">
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <input style={{ border: 'none', borderBottom: '1px solid #8d8d8d', padding: '6px 10px', width: 260, fontSize: 14, background: '#f4f4f4' }}
+                     placeholder="Search calculations…" />
+              <span style={{ background: '#f4f4f4', padding: '4px 10px', fontSize: 12, borderRadius: 999, border: '1px solid #e0e0e0' }}>Output: All ▾</span>
+              <span style={{ background: '#f4f4f4', padding: '4px 10px', fontSize: 12, borderRadius: 999, border: '1px solid #e0e0e0' }}>Sample: All ▾</span>
+            </div>
+            <button className="cds--btn cds--btn--primary" style={{ fontSize: 13 }}>+ New calculation</button>
+          </div>
+
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 120 }}>Output</th>
+                  <th>Name / summary</th>
+                  <th style={{ width: 220 }}>Destination</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                </tr>
+              </thead>
+              <tbody>
+                {CALCS.map(c => {
+                  const isExpanded = expandedId === c.id;
+                  const dest = TESTS[c.destination];
+                  return (
+                    <React.Fragment key={c.id}>
+                      <tr style={{ background: isExpanded ? '#edf5ff' : 'transparent', cursor: 'pointer' }}
+                          onClick={() => setExpandedId(isExpanded ? null : c.id)}>
+                        <td>
+                          <button style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                            {isExpanded ? '▾' : '▸'}
+                          </button>
+                        </td>
+                        <td>
+                          <span className={'type-chip ' + c.outputKind}>{c.outputKind}</span>
+                        </td>
+                        <td>
+                          <div className="rule-name">{c.name}</div>
+                          <div style={{ fontSize: 12, color: '#525252', marginTop: 2 }}>{c.summary}</div>
+                        </td>
+                        <td style={{ fontSize: 12 }}>
+                          <div>{dest.name}</div>
+                          <div style={{ color: '#6f6f6f', fontFamily: 'monospace', fontSize: 11 }}>
+                            {c.outputKind === 'coded' ? `coded · ${dest.values.length} values` : `numeric · ${dest.units || ''}`}
+                          </div>
+                        </td>
+                        <td style={{ fontSize: 12, color: '#6f6f6f' }}>{c.edited}</td>
+                      </tr>
+                      {isExpanded && c.id === 'calc-tb' && <TBEditor />}
+                      {isExpanded && c.id !== 'calc-tb' && (
+                        <tr>
+                          <td colSpan={5} style={{ padding: '1rem 2rem', background: '#fafafa', fontSize: 13, color: '#525252' }}>
+                            (Editor for <strong>{c.name}</strong> would render the formula bar pattern from the v2 Calculated Values preview — numeric output uses formula bar; coded output uses decision table.)
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What this preview adds to the MVP scope:</strong> Coded-output Calculations
+            via a decision-table editor (each rule is a Compose-style condition block + a result-value
+            picker; first match wins; required Otherwise row). Analyzer parameters as first-class
+            condition inputs alongside test results (sourced from the existing QC table linkage,
+            associated with results at import time). The same predicate vocabulary works on
+            results and analyzer parameters interchangeably. The output kind is driven by the
+            destination test in the Test Catalog — pick a numeric destination and the editor shows
+            the formula bar from v2; pick a coded destination and it shows this decision table.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/designs/admin-config/calculated-values-redesign-v2-preview.html
+++ b/designs/admin-config/calculated-values-redesign-v2-preview.html
@@ -1,0 +1,1283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calculated Value Rules v2 — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 280px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .browse-btn {
+      background: #fff; padding: 4px 12px; font-size: 12px; border: 1px solid #0f62fe;
+      color: #0f62fe; cursor: pointer;
+    }
+    .browse-btn.open { background: #0f62fe; color: #fff; }
+
+    /* Library drawer */
+    .library-drawer {
+      background: #fff; border: 1px solid #e0e0e0; border-bottom: none;
+      padding: 1rem;
+    }
+    .library-drawer h4 { margin: 0 0 0.5rem; font-size: 13px; }
+    .library-search {
+      width: 320px; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 14px; margin-bottom: 0.75rem;
+    }
+    .library-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.5rem;
+    }
+    .library-card {
+      padding: 0.75rem 1rem; border: 1px solid #e0e0e0; cursor: pointer;
+      transition: border-color 0.15s;
+    }
+    .library-card:hover { border-color: #0f62fe; background: #f4f9ff; }
+    .library-card .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .library-card .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .library-card .src { font-size: 10px; color: #8d8d8d; margin-top: 4px; }
+
+    /* DataTable rules */
+    table.cds--data-table { width: 100%; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    /* Tokenized rendering shared */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-paren { color: #525252; }
+    .tok-unknown {
+      color: #a2191f; text-decoration: underline wavy #da1e28; text-underline-offset: 3px;
+    }
+
+    .rule-summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+
+    /* Expanded editor */
+    .expanded-tile {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      color: #161616; display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+    .panel h4 .pill.warn { background: #fff8e1; color: #b28600; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* Formula bar — textarea + overlay */
+    .formula-bar-wrap {
+      position: relative; background: #fff; border: 1px solid #8d8d8d;
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      padding: 10px 12px;
+      transition: border-color 0.15s;
+    }
+    .formula-bar-wrap:focus-within { border-color: #0f62fe; outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .formula-overlay {
+      position: absolute; top: 10px; left: 12px; right: 12px;
+      pointer-events: none; white-space: pre-wrap; word-wrap: break-word;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: #161616;
+    }
+    .formula-input {
+      position: relative; width: 100%; min-height: 1.4em; resize: vertical;
+      border: none; outline: none; background: transparent;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: transparent; caret-color: #161616;
+    }
+    .formula-prompt {
+      font-size: 11px; color: #525252; margin-top: 4px; display: flex; gap: 0.5rem;
+    }
+    .formula-prompt .err { color: #a2191f; }
+    .formula-prompt .ok { color: #0e6027; }
+
+    /* Autocomplete dropdown */
+    .ac-pop {
+      position: absolute; top: 100%; left: 0; right: 0; margin-top: 2px;
+      background: #fff; border: 1px solid #8d8d8d; max-height: 200px; overflow-y: auto;
+      z-index: 10; font-family: 'IBM Plex Sans', sans-serif; font-size: 13px;
+    }
+    .ac-item {
+      padding: 6px 10px; cursor: pointer; display: flex; justify-content: space-between;
+    }
+    .ac-item:hover, .ac-item.sel { background: #edf5ff; }
+    .ac-item .ac-meta { color: #6f6f6f; font-size: 11px; font-family: 'IBM Plex Mono', monospace; }
+    .ac-item .ac-kind {
+      font-size: 10px; padding: 1px 6px; border-radius: 999px; align-self: center;
+    }
+    .ac-kind.var { background: #d0e2ff; color: #0043ce; }
+    .ac-kind.fn { background: #e8daff; color: #491d8b; }
+    .ac-kind.attr { background: #fff1f1; color: #a2191f; }
+
+    /* Math view */
+    .math-view {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 1rem;
+      display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+      font-size: 15px;
+    }
+    .math-pill {
+      display: inline-flex; flex-direction: column; align-items: flex-start;
+      padding: 4px 10px; border-radius: 4px; line-height: 1.1;
+    }
+    .math-pill.var { background: #d0e2ff; color: #0043ce; }
+    .math-pill.attr { background: #fff1f1; color: #a2191f; }
+    .math-pill.fn { background: #e8daff; color: #491d8b; }
+    .math-pill .label { font-weight: 600; font-size: 14px; }
+    .math-pill .units { font-size: 10px; opacity: 0.75; }
+    .math-op {
+      color: #d12771; font-weight: 700; font-size: 18px; padding: 0 2px;
+    }
+    .math-num {
+      background: #defbe6; color: #0e6027; padding: 4px 10px; border-radius: 4px;
+      font-weight: 600;
+    }
+    .math-fraction {
+      display: inline-flex; flex-direction: column; align-items: center;
+      padding: 0 4px;
+    }
+    .math-fraction .top, .math-fraction .bot { padding: 2px 4px; }
+    .math-fraction .bar { border-top: 2px solid #161616; width: 100%; margin: 2px 0; }
+    .math-paren { font-size: 22px; color: #525252; }
+
+    /* Sample-type scope */
+    .scope-block {
+      background: #f4f4f4; padding: 0.75rem; border: 1px solid #e0e0e0;
+    }
+    .scope-toggle {
+      display: flex; gap: 1rem; margin-bottom: 0.5rem;
+    }
+    .scope-toggle label {
+      font-size: 13px; cursor: pointer; display: flex; align-items: center; gap: 4px;
+    }
+    .scope-chips {
+      display: flex; gap: 4px; flex-wrap: wrap; align-items: center;
+      padding: 6px; background: #fff; border: 1px solid #e0e0e0; min-height: 38px;
+    }
+    .scope-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      background: #d0e2ff; color: #0043ce;
+      padding: 2px 4px 2px 10px; border-radius: 999px;
+      font-size: 12px; font-weight: 600;
+    }
+    .scope-chip .x {
+      cursor: pointer; padding: 0 6px; opacity: 0.6;
+      font-size: 14px; line-height: 1;
+    }
+    .scope-chip .x:hover { opacity: 1; }
+    .scope-add {
+      background: none; border: 1px dashed #8d8d8d; color: #525252;
+      padding: 2px 10px; font-size: 12px; cursor: pointer; border-radius: 999px;
+    }
+    .scope-add:hover { border-color: #0f62fe; color: #0f62fe; }
+    .scope-empty { color: #6f6f6f; font-style: italic; font-size: 12px; }
+    .scope-pop {
+      background: #fff; border: 1px solid #8d8d8d; padding: 4px 0; margin-top: 4px;
+      max-height: 200px; overflow-y: auto; width: 200px;
+    }
+    .scope-pop .opt {
+      padding: 4px 12px; font-size: 13px; cursor: pointer;
+    }
+    .scope-pop .opt:hover { background: #edf5ff; }
+    .scope-pop .opt.checked { color: #0f62fe; font-weight: 600; }
+
+    /* Variable/function side panel */
+    .var-panel { background: #f4f4f4; padding: 0.75rem; }
+    .var-tabs { display: flex; gap: 0; border-bottom: 1px solid #e0e0e0; margin-bottom: 0.5rem; }
+    .var-tab {
+      padding: 6px 12px; cursor: pointer; font-size: 13px; color: #525252;
+      border-bottom: 2px solid transparent;
+    }
+    .var-tab.active { color: #0f62fe; border-bottom-color: #0f62fe; font-weight: 600; }
+    .var-search {
+      width: 100%; padding: 4px 8px; font-size: 13px; border: none;
+      border-bottom: 1px solid #8d8d8d; background: #fff; margin-bottom: 0.5rem;
+    }
+    .var-list { max-height: 220px; overflow-y: auto; }
+    .var-item {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 6px 8px; cursor: pointer; font-size: 13px;
+    }
+    .var-item:hover { background: #e8e8e8; }
+    .var-item .vlabel { display: flex; flex-direction: column; }
+    .var-item .vname { color: #161616; }
+    .var-item .vmeta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; }
+    .var-item .vinsert {
+      background: #0f62fe; color: #fff; border: none; padding: 2px 8px;
+      font-size: 11px; cursor: pointer;
+    }
+
+    /* Live preview */
+    .preview-row {
+      display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem;
+    }
+    .preview-row label { flex: 0 0 180px; font-size: 13px; color: #161616; }
+    .preview-row input {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .preview-row select {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .preview-row .units { flex: 0 0 60px; font-size: 12px; color: #6f6f6f; }
+
+    .computed {
+      background: #defbe6; border-left: 3px solid #198038;
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+    }
+    .computed .label { font-size: 11px; color: #0e6027; text-transform: uppercase; letter-spacing: 0.5px; }
+    .computed .value { font-size: 28px; font-weight: 600; color: #0e6027; font-family: 'IBM Plex Mono', monospace; }
+    .computed .units { font-size: 14px; color: #525252; margin-left: 6px; }
+    .computed .flag { font-size: 12px; color: #525252; margin-top: 4px; }
+
+    /* Flowchart for branching rules */
+    .flow-wrap {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 1.25rem;
+      display: flex; flex-direction: column; align-items: center;
+    }
+    .flow-diamond {
+      background: #fff; border: 2px solid #b28600;
+      transform: rotate(45deg); width: 140px; height: 140px;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .flow-diamond .inner {
+      transform: rotate(-45deg); text-align: center; font-size: 12px; padding: 6px;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .flow-branches {
+      display: flex; gap: 2rem; margin-top: 1.5rem; width: 100%;
+      justify-content: center; align-items: flex-start;
+    }
+    .flow-branch {
+      flex: 1; max-width: 360px; background: #fff; border: 1px solid #e0e0e0;
+      padding: 0.75rem;
+    }
+    .flow-branch .label {
+      font-size: 12px; font-weight: 600; padding: 4px 10px; border-radius: 999px;
+      display: inline-block; margin-bottom: 0.5rem;
+    }
+    .flow-branch.true .label { background: #defbe6; color: #0e6027; }
+    .flow-branch.false .label { background: #d0e2ff; color: #0043ce; }
+    .flow-branch .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+      background: #fafafa; padding: 8px; border-left: 3px solid #c6c6c6;
+    }
+    .flow-arrow {
+      color: #525252; font-size: 20px; margin: 0 0.5rem;
+    }
+
+    /* Validation tests */
+    .vt-row {
+      display: grid; grid-template-columns: 2fr 1fr 1fr 30px; gap: 0.5rem;
+      align-items: center; padding: 6px 0; font-size: 13px;
+      border-bottom: 1px solid #f4f4f4;
+    }
+    .vt-row .vt-name { font-family: 'IBM Plex Mono', monospace; font-size: 11px; }
+    .vt-row .vt-pass { color: #0e6027; font-weight: 600; }
+    .vt-row .vt-fail { color: #a2191f; font-weight: 600; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview v2 — Calculated Value Rules &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Numeric Calculation editor</strong>
+    &nbsp;<span style="color: #6f6f6f;">— what expands inline when you click a calc row with a <em>numeric</em> destination. For a <em>coded</em> destination, see <a href="calc-decision-table-preview.html" style="color: #0f62fe;">the decision-table editor</a>.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo, useRef, useEffect } = React;
+
+    // ========================================================================
+    // DOMAIN DATA
+    // ========================================================================
+    const TEST_RESULTS = [
+      { id: 'TC',     name: 'Total Cholesterol',     loinc: '2093-3',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'HDL',    name: 'HDL Cholesterol',       loinc: '2085-9',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'TRIG',   name: 'Triglycerides',         loinc: '2571-8',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'SCr',    name: 'Serum Creatinine',      loinc: '2160-0',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'NA',     name: 'Sodium',                loinc: '2951-2',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'K',      name: 'Potassium',             loinc: '2823-3',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'CL',     name: 'Chloride',              loinc: '2075-0',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'HCO3',   name: 'Bicarbonate',           loinc: '1963-8',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'ALB',    name: 'Albumin',               loinc: '1751-7',  units: 'g/dL',   sample: 'Serum' },
+      { id: 'CA',     name: 'Calcium, Total',        loinc: '17861-6', units: 'mg/dL',  sample: 'Serum' },
+      { id: 'BIL',    name: 'Bilirubin, Total',      loinc: '1975-2',  units: 'mg/dL',  sample: 'Serum' },
+      { id: 'INR',    name: 'INR',                   loinc: '6301-6',  units: '',       sample: 'Plasma' },
+      { id: 'WT',     name: 'Body Weight',           loinc: '29463-7', units: 'kg',     sample: 'Whole Blood' },
+      { id: 'HT',     name: 'Body Height',           loinc: '8302-2',  units: 'm',      sample: 'Whole Blood' },
+      { id: 'ALT',    name: 'ALT',                   loinc: '1742-6',  units: 'U/L',    sample: 'Serum' },
+      { id: 'AST',    name: 'AST',                   loinc: '1920-8',  units: 'U/L',    sample: 'Serum' },
+    ];
+    const PATIENT_ATTRS = [
+      { id: 'Age', name: 'Age', units: 'years' },
+      { id: 'Sex', name: 'Sex (M/F)', units: '(M/F)' },
+      { id: 'Weight', name: 'Weight', units: 'kg' },
+    ];
+    const FUNCTIONS = [
+      { id: 'min',   name: 'min(a, b)',     desc: 'Smaller of two values' },
+      { id: 'max',   name: 'max(a, b)',     desc: 'Larger of two values' },
+      { id: 'mean',  name: 'mean(a, ...)',  desc: 'Arithmetic mean' },
+      { id: 'log',   name: 'log(x)',        desc: 'Natural log' },
+      { id: 'pow',   name: 'pow(x, n)',     desc: 'x raised to n' },
+      { id: 'round', name: 'round(x, n)',   desc: 'Round to n decimals' },
+      { id: 'if',    name: 'if(cond, a, b)',desc: 'Conditional — true branch a, false branch b' },
+      { id: 'eq',    name: 'eq(a, b)',      desc: 'Equality test' },
+    ];
+
+    const VAR_BY_ID  = Object.fromEntries(TEST_RESULTS.map(v => [v.id, v]));
+    const ATTR_BY_ID = Object.fromEntries(PATIENT_ATTRS.map(v => [v.id, v]));
+    const FN_BY_ID   = Object.fromEntries(FUNCTIONS.map(v => [v.id, v]));
+
+    // ========================================================================
+    // TOKENIZER — for syntax highlighting and linting
+    // ========================================================================
+    function tokenize(text) {
+      const re = /(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|([+\-*\/=<>])|([(),])|(\s+)|(.)/g;
+      const out = [];
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({ kind: 'num', text: m[1] });
+        else if (m[2]) {
+          const id = m[2];
+          if (VAR_BY_ID[id])  out.push({ kind: 'var', text: id });
+          else if (FN_BY_ID[id])   out.push({ kind: 'fn',  text: id });
+          else if (ATTR_BY_ID[id]) out.push({ kind: 'attr',text: id });
+          else out.push({ kind: 'unknown', text: id });
+        }
+        else if (m[3]) out.push({ kind: 'op', text: m[3] });
+        else if (m[4]) out.push({ kind: 'paren', text: m[4] });
+        else if (m[5]) out.push({ kind: 'ws', text: m[5] });
+        else out.push({ kind: 'other', text: m[6] });
+      }
+      return out;
+    }
+
+    function lint(tokens) {
+      const issues = [];
+      const unknowns = tokens.filter(t => t.kind === 'unknown');
+      if (unknowns.length) {
+        issues.push({ kind: 'err', msg: `Unknown identifier${unknowns.length > 1 ? 's' : ''}: ${unknowns.map(u => u.text).join(', ')}` });
+      }
+      // paren balance
+      let depth = 0;
+      for (const t of tokens) {
+        if (t.kind === 'paren' && t.text === '(') depth++;
+        else if (t.kind === 'paren' && t.text === ')') depth--;
+        if (depth < 0) { issues.push({ kind: 'err', msg: 'Unmatched closing paren' }); break; }
+      }
+      if (depth > 0) issues.push({ kind: 'err', msg: `${depth} unclosed paren${depth > 1 ? 's' : ''}` });
+      // unit awareness — sample heuristic: TRIG/5 fine, but Weight + Height would warn
+      // (skipped here in mockup to keep code shorter)
+      return issues;
+    }
+
+    // ========================================================================
+    // SAMPLE-TYPE SCOPE — apply to all sample types, or a selected subset
+    // ========================================================================
+    const ALL_SAMPLE_TYPES = [
+      'Serum', 'Plasma', 'Whole Blood', 'EDTA Tube', 'Dry Tube', 'DBS',
+      'Urines', 'Fluid', 'Sputum', 'Respiratory Swab',
+      'Tissue antemortem', 'Tissue post mortem',
+      'Histopathology specimen', 'Immunohistochemistry specimen'
+    ];
+
+    function SampleScope({ mode, selected, onModeChange, onChange }) {
+      const [popOpen, setPopOpen] = useState(false);
+      const remaining = ALL_SAMPLE_TYPES.filter(s => !selected.includes(s));
+      return (
+        <div className="scope-block">
+          <div style={{ fontSize: 11, color: '#525252', marginBottom: 6, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Applies to
+          </div>
+          <div className="scope-toggle">
+            <label>
+              <input type="radio" checked={mode === 'all'}
+                     onChange={() => onModeChange('all')} />
+              All sample types
+            </label>
+            <label>
+              <input type="radio" checked={mode === 'selected'}
+                     onChange={() => onModeChange('selected')} />
+              Selected sample types
+            </label>
+          </div>
+          {mode === 'selected' && (
+            <>
+              <div className="scope-chips">
+                {selected.length === 0 && <span className="scope-empty">No sample types selected — rule will not fire</span>}
+                {selected.map(s => (
+                  <span key={s} className="scope-chip">
+                    {s}
+                    <span className="x" onClick={() => onChange(selected.filter(x => x !== s))}>×</span>
+                  </span>
+                ))}
+                {remaining.length > 0 && (
+                  <button className="scope-add" onClick={() => setPopOpen(o => !o)}>
+                    + Add sample type ▾
+                  </button>
+                )}
+              </div>
+              {popOpen && (
+                <div className="scope-pop">
+                  {remaining.map(s => (
+                    <div key={s} className="opt" onClick={() => { onChange([...selected, s]); setPopOpen(false); }}>
+                      {s}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="compact-hint">
+                The rule writes the calculated value back to the same sample type the inputs came from.
+                If multiple are selected, the same formula evaluates separately for each sample type.
+              </div>
+            </>
+          )}
+          {mode === 'all' && (
+            <div className="compact-hint">
+              Rule fires whenever every input test has a numeric result, regardless of sample type.
+              Useful when a test can be ordered on multiple specimens (e.g. Creatinine on Serum or Plasma).
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA BAR — textarea with syntax-highlighted overlay
+    // ========================================================================
+    function FormulaBar({ value, onChange, autocompleteAt, suggestions, onPick }) {
+      const tokens = tokenize(value);
+      const issues = lint(tokens);
+      const taRef = useRef(null);
+
+      return (
+        <div>
+          <div className="formula-bar-wrap">
+            <div className="formula-overlay">
+              {tokens.map((t, i) => (
+                <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+              ))}
+              {value === '' && <span style={{ color: '#a8a8a8' }}>Type a formula… (autocomplete on test names, LOINC, functions)</span>}
+            </div>
+            <textarea
+              ref={taRef}
+              className="formula-input"
+              value={value}
+              onChange={e => onChange(e.target.value)}
+              spellCheck={false}
+              rows={Math.max(1, value.split('\n').length)}
+            />
+            {suggestions && suggestions.length > 0 && (
+              <div className="ac-pop">
+                {suggestions.map((s, i) => (
+                  <div key={s.id} className={'ac-item' + (i === 0 ? ' sel' : '')} onClick={() => onPick(s)}>
+                    <span>
+                      <span className={'ac-kind ' + s.kind}>{s.kind === 'fn' ? 'fn' : s.kind === 'attr' ? 'attr' : 'test'}</span>
+                      &nbsp;<strong>{s.id}</strong> &nbsp;<span style={{ color: '#525252' }}>{s.name}</span>
+                    </span>
+                    <span className="ac-meta">{s.meta}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="formula-prompt">
+            {issues.length === 0
+              ? <span className="ok">✓ Valid syntax · {tokens.filter(t=>t.kind==='var').length} variable(s) referenced</span>
+              : issues.map((i, idx) => <span key={idx} className="err">⚠ {i.msg}</span>)}
+            <span style={{ marginLeft: 'auto', color: '#0f62fe', cursor: 'pointer' }}>
+              Press @ for variable picker · Ctrl+Space for functions
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // MATH VIEW — render formula in math notation with colored variable pills
+    // ========================================================================
+    function MathPill({ kind, name, units }) {
+      return (
+        <span className={'math-pill ' + kind}>
+          <span className="label">{name}</span>
+          {units && <span className="units">{units}</span>}
+        </span>
+      );
+    }
+    function MathOp({ op }) { return <span className="math-op">{op}</span>; }
+    function MathNum({ n }) { return <span className="math-num">{n}</span>; }
+    function MathFraction({ top, bot }) {
+      return (
+        <span className="math-fraction">
+          <span className="top">{top}</span>
+          <span className="bar"></span>
+          <span className="bot">{bot}</span>
+        </span>
+      );
+    }
+
+    // LDL: TC − HDL − (Trig / 5)
+    function LDLMathView() {
+      return (
+        <div className="math-view">
+          <MathPill kind="var" name="Total Cholesterol" units="mg/dL" />
+          <MathOp op="−" />
+          <MathPill kind="var" name="HDL" units="mg/dL" />
+          <MathOp op="−" />
+          <MathFraction
+            top={<MathPill kind="var" name="Triglycerides" units="mg/dL" />}
+            bot={<MathNum n="5" />}
+          />
+        </div>
+      );
+    }
+
+    // eGFR: rendered top of formula (the parts before the conditional split)
+    function EGFRMathView() {
+      return (
+        <div className="math-view">
+          <MathNum n="142" />
+          <MathOp op="×" />
+          <span style={{ fontFamily: "'IBM Plex Mono', monospace", color: '#491d8b', fontWeight: 600 }}>min</span>
+          <span className="math-paren">(</span>
+          <MathFraction
+            top={<MathPill kind="var" name="SCr" units="mg/dL" />}
+            bot={<span style={{ fontFamily: 'monospace', color: '#491d8b' }}>κ</span>}
+          />
+          <span style={{ color: '#d12771' }}>,</span>
+          <MathNum n="1" />
+          <span className="math-paren">)</span>
+          <MathOp op="^" />
+          <span style={{ fontFamily: 'monospace', color: '#491d8b' }}>α</span>
+          <MathOp op="×" />
+          <span style={{ fontStyle: 'italic', color: '#6f6f6f' }}>… (κ, α depend on Sex — see branches below)</span>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // VARIABLE / FUNCTION SIDE PANEL
+    // ========================================================================
+    function VariablePanel({ onInsert }) {
+      const [tab, setTab] = useState('tests');
+      const [q, setQ] = useState('');
+      const items = tab === 'tests' ? TEST_RESULTS
+                  : tab === 'attrs' ? PATIENT_ATTRS
+                  : FUNCTIONS;
+      const filtered = items.filter(i =>
+        (i.name + (i.id || '') + (i.desc || '') + (i.loinc || '')).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="var-panel">
+          <div className="var-tabs">
+            <div className={'var-tab' + (tab === 'tests' ? ' active' : '')} onClick={() => setTab('tests')}>Test Results</div>
+            <div className={'var-tab' + (tab === 'attrs' ? ' active' : '')} onClick={() => setTab('attrs')}>Patient Attributes</div>
+            <div className={'var-tab' + (tab === 'fns'   ? ' active' : '')} onClick={() => setTab('fns')}>Functions</div>
+          </div>
+          <input
+            className="var-search"
+            placeholder={'Search ' + (tab === 'tests' ? 'test name, LOINC' : tab === 'attrs' ? 'attribute' : 'function') + '…'}
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="var-list">
+            {filtered.map(item => (
+              <div key={item.id} className="var-item" onClick={() => onInsert(item, tab)}>
+                <div className="vlabel">
+                  <span className="vname">{item.name}</span>
+                  <span className="vmeta">
+                    {tab === 'tests' && `${item.id} · ${item.units} · ${item.sample}${item.loinc ? ' · LOINC ' + item.loinc : ''}`}
+                    {tab === 'attrs' && `${item.id} · ${item.units}`}
+                    {tab === 'fns' && item.desc}
+                  </span>
+                </div>
+                <button className="vinsert">Insert</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // LDL EDITOR — pure arithmetic, formula bar + math view
+    // ========================================================================
+    function LDLEditor() {
+      const [formula, setFormula] = useState('TC - HDL - TRIG / 5');
+      const [tc, setTc] = useState(195);
+      const [hdl, setHdl] = useState(48);
+      const [trig, setTrig] = useState(150);
+      const [advanced, setAdvanced] = useState(false);
+      // Sample-type scope — LDL is valid on Serum or Plasma (fasting)
+      const [scopeMode, setScopeMode] = useState('selected');
+      const [scopeSelected, setScopeSelected] = useState(['Serum', 'Plasma']);
+      const scopeSummary = scopeMode === 'all'
+        ? 'All sample types'
+        : scopeSelected.length === 0 ? 'no sample types — will not fire'
+        : scopeSelected.join(', ');
+
+      const ldl = Math.round(tc - hdl - trig / 5);
+      const flag = ldl < 100 ? 'Optimal (<100)'
+                  : ldl < 130 ? 'Near optimal (100–129)'
+                  : ldl < 160 ? 'Borderline high (130–159)'
+                  : ldl < 190 ? 'High (160–189)'
+                  : 'Very high (≥190)';
+
+      // Mock autocomplete: when current word is a partial identifier
+      const cursorWord = (formula.match(/[A-Za-z_][A-Za-z0-9_]*$/) || [''])[0];
+      const suggestions = cursorWord.length > 0
+        ? [...TEST_RESULTS.map(t => ({ id: t.id, name: t.name, kind: 'var', meta: `${t.units} · ${t.sample}${t.loinc ? ' · '+t.loinc : ''}` })),
+           ...FUNCTIONS.map(f => ({ id: f.id, name: f.name, kind: 'fn', meta: f.desc })),
+           ...PATIENT_ATTRS.map(a => ({ id: a.id, name: a.name, kind: 'attr', meta: a.units }))]
+            .filter(s => s.id.toLowerCase().startsWith(cursorWord.toLowerCase()) && s.id !== cursorWord)
+            .slice(0, 5)
+        : [];
+
+      const insertFromPicker = (item, tab) => {
+        const id = item.id;
+        setFormula(f => (f.endsWith(' ') || f === '') ? f + id : f + ' ' + id);
+      };
+      const onPickAc = (s) => {
+        setFormula(f => f.replace(/[A-Za-z_][A-Za-z0-9_]*$/, s.id));
+      };
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Applies to: {scopeSummary}</span>
+                <span className="cds--tag cds--tag--teal">Output: mg/dL</span>
+              </div>
+
+              <div className="editor-grid">
+                {/* LEFT — formula bar + math view + side panel */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">Formula bar</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="LDL Cholesterol (Friedewald)"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                  </div>
+
+                  <div className="panel-section">
+                    <SampleScope
+                      mode={scopeMode} selected={scopeSelected}
+                      onModeChange={setScopeMode} onChange={setScopeSelected}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Formula
+                    </label>
+                    <FormulaBar
+                      value={formula}
+                      onChange={setFormula}
+                      suggestions={suggestions}
+                      onPick={onPickAc}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Rendered (read-only)
+                    </label>
+                    <LDLMathView />
+                    <div className="compact-hint">
+                      Variables shown with units. Reviewers sign off on this view, not the text.
+                    </div>
+                  </div>
+
+                  <div className="panel-section" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+                    <div>
+                      <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                        Insert from library
+                      </label>
+                      <VariablePanel onInsert={insertFromPicker} />
+                    </div>
+                    <div>
+                      <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                        Output (Final Result)
+                      </label>
+                      <div style={{ padding: 8, background: '#f4f4f4' }}>
+                        <div style={{ marginBottom: 6 }}>
+                          <span style={{ fontSize: 11, color: '#6f6f6f' }}>Destination test</span>
+                          <select defaultValue="LDL"
+                                  style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }}>
+                            <option value="LDL">LDL Cholesterol (LOINC 13457-7)</option>
+                          </select>
+                        </div>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <div style={{ flex: 1 }}>
+                            <span style={{ fontSize: 11, color: '#6f6f6f' }}>Units</span>
+                            <select defaultValue="mg/dL"
+                                    style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }}>
+                              <option>mg/dL</option><option>mmol/L</option>
+                            </select>
+                          </div>
+                          <div style={{ flex: 1 }}>
+                            <span style={{ fontSize: 11, color: '#6f6f6f' }}>Decimals</span>
+                            <input type="number" defaultValue="0"
+                                   style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }} />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* RIGHT — live preview + validation tests */}
+                <div className="panel">
+                  <h4>Live preview <span className="pill green">Sandbox</span></h4>
+                  <div className="panel-section">
+                    <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                      Edit the formula on the left or change inputs here. Output recomputes live.
+                    </span>
+                    <div className="preview-row">
+                      <label>Total Cholesterol (TC)</label>
+                      <input type="number" value={tc} onChange={e => setTc(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>HDL Cholesterol (HDL)</label>
+                      <input type="number" value={hdl} onChange={e => setHdl(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Triglycerides (TRIG)</label>
+                      <input type="number" value={trig} onChange={e => setTrig(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+
+                    <div className="computed">
+                      <div className="label">Computed LDL</div>
+                      <div>
+                        <span className="value">{ldl}</span>
+                        <span className="units">mg/dL</span>
+                      </div>
+                      <div className="flag">Flag: {flag}</div>
+                      {trig >= 400 && (
+                        <div className="cds--inline-notification cds--inline-notification--warning"
+                             style={{ marginTop: 8, padding: '6px 10px', fontSize: 12 }}>
+                          ⚠ Friedewald is not valid when Triglycerides ≥ 400 mg/dL. Direct LDL recommended.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 6 }}>
+                      Validation tests &nbsp;
+                      <button onClick={() => setAdvanced(a => !a)}
+                              style={{ fontSize: 11, background: 'none', border: 'none', color: '#0f62fe', cursor: 'pointer' }}>
+                        {advanced ? 'Hide' : 'Show all'}
+                      </button>
+                    </label>
+                    <div className="vt-row" style={{ fontWeight: 600, fontSize: 11, color: '#525252', borderBottom: '1px solid #e0e0e0' }}>
+                      <span>Inputs</span><span>Expected</span><span>Got</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">TC=195, HDL=48, Trig=150</span>
+                      <span>117</span><span className="vt-pass">117 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">TC=240, HDL=35, Trig=200</span>
+                      <span>165</span><span className="vt-pass">165 ✓</span><span></span>
+                    </div>
+                    {advanced && (
+                      <>
+                        <div className="vt-row">
+                          <span className="vt-name">TC=180, HDL=60, Trig=90</span>
+                          <span>102</span><span className="vt-pass">102 ✓</span><span></span>
+                        </div>
+                        <div className="vt-row">
+                          <span className="vt-name">TC=220, HDL=40, Trig=420</span>
+                          <span>—</span><span className="vt-fail">— (skip: Trig≥400)</span><span></span>
+                        </div>
+                      </>
+                    )}
+                    <button className="cds--btn cds--btn--ghost" style={{ marginTop: 6, fontSize: 12 }}>+ Add validation case</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation tests</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // eGFR EDITOR — branching, formula bar + flowchart panel
+    // ========================================================================
+    function EGFREditor() {
+      const [formula, setFormula] = useState(
+        "if(eq(Sex, F),\n  142 * pow(min(SCr/0.7, 1), -0.241) * pow(max(SCr/0.7, 1), -1.200) * pow(0.9938, Age) * 1.012,\n  142 * pow(min(SCr/0.9, 1), -0.302) * pow(max(SCr/0.9, 1), -1.200) * pow(0.9938, Age))"
+      );
+      const [scr, setScr] = useState(1.1);
+      const [age, setAge] = useState(54);
+      const [sex, setSex] = useState('F');
+      // eGFR: Serum and Plasma both valid for creatinine
+      const [scopeMode, setScopeMode] = useState('selected');
+      const [scopeSelected, setScopeSelected] = useState(['Serum', 'Plasma']);
+      const scopeSummary = scopeMode === 'all'
+        ? 'All sample types'
+        : scopeSelected.length === 0 ? 'no sample types — will not fire'
+        : scopeSelected.join(', ');
+
+      const k = sex === 'F' ? 0.7 : 0.9;
+      const a1 = sex === 'F' ? -0.241 : -0.302;
+      const sexBoost = sex === 'F' ? 1.012 : 1;
+      const egfr = Math.round(
+        142 * Math.pow(Math.min(scr/k, 1), a1) * Math.pow(Math.max(scr/k, 1), -1.2) * Math.pow(0.9938, age) * sexBoost
+      );
+      const stage = egfr >= 90 ? 'G1 (≥90)'
+                  : egfr >= 60 ? 'G2 (60–89)'
+                  : egfr >= 45 ? 'G3a (45–59)'
+                  : egfr >= 30 ? 'G3b (30–44)'
+                  : egfr >= 15 ? 'G4 (15–29)' : 'G5 (<15)';
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Applies to: {scopeSummary}</span>
+                <span className="cds--tag cds--tag--teal">Output: mL/min/1.73m²</span>
+                <span className="cds--tag cds--tag--purple">Branching · 2 paths</span>
+              </div>
+
+              <div className="editor-grid">
+                {/* LEFT — formula bar */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">Formula bar</span> <span className="pill warn">Branching detected</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="eGFR (CKD-EPI 2021, race-free)"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                  </div>
+
+                  <div className="panel-section">
+                    <SampleScope
+                      mode={scopeMode} selected={scopeSelected}
+                      onModeChange={setScopeMode} onChange={setScopeSelected}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Formula
+                    </label>
+                    <FormulaBar value={formula} onChange={setFormula} suggestions={[]} onPick={() => {}} />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Branch view <span className="compact-hint" style={{ display: 'inline' }}>— appears automatically when formula uses <code>if()</code></span>
+                    </label>
+                    <div className="flow-wrap">
+                      <div className="flow-diamond"><div className="inner">eq(<span className="tok-attr">Sex</span>, F)</div></div>
+                      <div className="flow-branches">
+                        <div className="flow-branch true">
+                          <div className="label">True · Female</div>
+                          <div className="formula">
+                            <span className="tok-num">142</span> <span className="tok-op">*</span> <span className="tok-fn">pow</span>(<span className="tok-fn">min</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.7</span>, <span className="tok-num">1</span>), <span className="tok-num">-0.241</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-fn">max</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.7</span>, <span className="tok-num">1</span>), <span className="tok-num">-1.200</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-num">0.9938</span>, <span className="tok-attr">Age</span>) <span className="tok-op">*</span> <span className="tok-num">1.012</span>
+                          </div>
+                        </div>
+                        <div className="flow-branch false">
+                          <div className="label">False · Male</div>
+                          <div className="formula">
+                            <span className="tok-num">142</span> <span className="tok-op">*</span> <span className="tok-fn">pow</span>(<span className="tok-fn">min</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.9</span>, <span className="tok-num">1</span>), <span className="tok-num">-0.302</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-fn">max</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.9</span>, <span className="tok-num">1</span>), <span className="tok-num">-1.200</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-num">0.9938</span>, <span className="tok-attr">Age</span>)
+                          </div>
+                        </div>
+                      </div>
+                      <div style={{ marginTop: '0.75rem' }}>
+                        <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>+ Add branch (e.g. pediatric)</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* RIGHT — live preview */}
+                <div className="panel">
+                  <h4>Live preview <span className="pill green">Sandbox</span></h4>
+                  <div className="panel-section">
+                    <div className="preview-row">
+                      <label>Serum Creatinine (SCr)</label>
+                      <input type="number" step="0.1" value={scr} onChange={e => setScr(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Age</label>
+                      <input type="number" value={age} onChange={e => setAge(+e.target.value || 0)} />
+                      <span className="units">years</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Sex</label>
+                      <select value={sex} onChange={e => setSex(e.target.value)}>
+                        <option value="F">F</option><option value="M">M</option>
+                      </select>
+                      <span className="units"></span>
+                    </div>
+
+                    <div className="computed">
+                      <div className="label">Computed eGFR</div>
+                      <div>
+                        <span className="value">{egfr}</span>
+                        <span className="units">mL/min/1.73m²</span>
+                      </div>
+                      <div className="flag">CKD stage: {stage}</div>
+                      <div className="flag" style={{ color: '#525252' }}>
+                        Branch taken: <strong>{sex === 'F' ? 'True · Female' : 'False · Male'}</strong>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 6 }}>
+                      Validation tests
+                    </label>
+                    <div className="vt-row" style={{ fontWeight: 600, fontSize: 11, color: '#525252', borderBottom: '1px solid #e0e0e0' }}>
+                      <span>Inputs</span><span>Expected</span><span>Got</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=1.1, Age=54, Sex=F</span>
+                      <span>61</span><span className="vt-pass">61 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=0.9, Age=40, Sex=M</span>
+                      <span>105</span><span className="vt-pass">105 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=2.4, Age=68, Sex=F</span>
+                      <span>21</span><span className="vt-pass">21 ✓</span><span></span>
+                    </div>
+                    <button className="cds--btn cds--btn--ghost" style={{ marginTop: 6, fontSize: 12 }}>+ Add validation case</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation tests</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // RULE LIST DATA — with rich tokenized summaries
+    // ========================================================================
+    const RULES = [
+      { id: 1, name: 'BMI', status: 'active',
+        formula: 'WT / pow(HT, 2)',
+        destination: 'BMI (kg/m²)', scope: 'all',  scopeList: [],
+        edited: '2026-04-12 by m.kone' },
+      { id: 2, name: 'LDL Cholesterol (Friedewald)', status: 'active',
+        formula: 'TC - HDL - TRIG / 5',
+        destination: 'LDL Cholesterol (mg/dL)', scope: 'selected', scopeList: ['Serum', 'Plasma'],
+        edited: '2026-04-28 by p.diallo' },
+      { id: 3, name: 'eGFR (CKD-EPI 2021)', status: 'active', branching: true,
+        formula: 'if(eq(Sex, F), 142 * pow(min(SCr/0.7,1), -0.241) * ..., 142 * pow(min(SCr/0.9,1), -0.302) * ...)',
+        destination: 'eGFR (mL/min/1.73m²)', scope: 'selected', scopeList: ['Serum', 'Plasma'],
+        edited: '2026-03-04 by p.diallo' },
+      { id: 4, name: 'Anion Gap', status: 'active',
+        formula: 'NA - (CL + HCO3)',
+        destination: 'Anion Gap (mmol/L)', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-02-18 by m.kone' },
+      { id: 5, name: 'Corrected Calcium', status: 'active',
+        formula: 'CA + 0.8 * (4 - ALB)',
+        destination: 'Corrected Calcium (mg/dL)', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-04-21 by m.kone' },
+      { id: 6, name: 'AST/ALT Ratio (De Ritis)', status: 'active',
+        formula: 'AST / ALT',
+        destination: 'AST/ALT Ratio', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-03-30 by m.kone' },
+      { id: 7, name: 'MELD-Na', status: 'disabled', branching: true,
+        formula: 'round(...) + ... (capped 6–40)',
+        destination: 'MELD Score', scope: 'selected', scopeList: ['Serum'],
+        edited: '2025-11-09 by p.diallo' },
+      { id: 8, name: 'Albumin Conversion mg/dL → g/L', status: 'active',
+        formula: 'ALB * 10',
+        destination: 'Albumin g/L', scope: 'all', scopeList: [],
+        edited: '2026-01-15 by m.kone' },
+    ];
+
+    function FormulaSummary({ text }) {
+      const tokens = tokenize(text);
+      return (
+        <span className="rule-summary">
+          {tokens.map((t, i) => (
+            <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+          ))}
+        </span>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA LIBRARY DRAWER (replaces the rigid templates strip)
+    // ========================================================================
+    const LIBRARY = [
+      { name: 'BMI',                    formula: 'Weight / Height²',                   src: 'WHO' },
+      { name: 'LDL (Friedewald)',       formula: 'TC − HDL − Trig/5',                  src: 'Friedewald 1972' },
+      { name: 'LDL (Martin-Hopkins)',   formula: 'TC − HDL − Trig/adjFactor(Trig,nonHDL)', src: 'Martin 2013' },
+      { name: 'eGFR (CKD-EPI 2021)',    formula: '142 × min(SCr/κ,1)^α × … × Age × Sex',src: 'NKF-ASN 2021' },
+      { name: 'eGFR (MDRD)',            formula: '175 × SCr^-1.154 × Age^-0.203 × …',  src: 'Levey 1999' },
+      { name: 'Cockcroft-Gault CrCl',   formula: '(140−Age)×Wt / (72×SCr) × 0.85 if F',src: 'Cockcroft 1976' },
+      { name: 'Anion Gap',              formula: 'Na − (Cl + HCO₃)',                   src: 'standard' },
+      { name: 'Corrected Calcium',      formula: 'Ca + 0.8 × (4 − Albumin)',           src: 'Payne 1973' },
+      { name: 'MELD-Na',                formula: 'MELD + 1.32×(137−Na) − 0.033×MELD×(137−Na)', src: 'OPTN' },
+      { name: 'Child-Pugh score',       formula: 'sum of 5 categorical points',        src: 'Pugh 1973' },
+      { name: 'A:G Ratio',              formula: 'Alb / (Total Protein − Alb)',        src: 'standard' },
+      { name: 'Globulin',               formula: 'Total Protein − Albumin',            src: 'standard' },
+      { name: 'Bilirubin direct→indirect', formula: 'Total Bili − Direct Bili',        src: 'standard' },
+      { name: 'BUN/Creatinine ratio',   formula: 'BUN / Creatinine',                   src: 'standard' },
+      { name: 'Free water deficit',     formula: '0.6 × Wt × (Na/140 − 1)',            src: 'Adrogue 2000' },
+      { name: 'Fractional excretion Na', formula: '(UNa×Cr) / (PNa×UCr) × 100',         src: 'standard' },
+    ];
+
+    function LibraryDrawer({ onClose }) {
+      const [q, setQ] = useState('');
+      const filtered = LIBRARY.filter(t =>
+        (t.name + t.formula + t.src).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="library-drawer">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <h4>Formula library &nbsp;<span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f' }}>{LIBRARY.length} entries · search by name, citation, or formula text</span></h4>
+            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#525252', fontSize: 16 }}>✕</button>
+          </div>
+          <input
+            className="library-search"
+            placeholder="Search formulas (e.g. 'eGFR', 'Friedewald', 'Calcium')…"
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="library-grid">
+            {filtered.map(tpl => (
+              <div key={tpl.name} className="library-card">
+                <div className="name">{tpl.name}</div>
+                <div className="formula">{tpl.formula}</div>
+                <div className="src">{tpl.src}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 11, color: '#6f6f6f' }}>
+            Picking a template prefills the formula bar and copies its validation cases. You can edit either freely afterward.
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState(2); // LDL pre-expanded
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [libraryOpen, setLibraryOpen] = useState(false);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Calculated Value Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Calculated Value Rules
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>v2 design brief:</strong> Formula bar with syntax highlighting, autocomplete,
+              and inline linting is the primary input — power users type, beginners discover via
+              the side panel. A read-only <em>math view</em> renders the same formula in proper
+              notation with units (the QA artifact reviewers sign off on). When the formula uses
+              <code> if()</code>, a flowchart panel appears showing each branch separately. Templates
+              live behind a searchable library, not a rigid strip. <strong>Sample-type scope</strong>
+              lets the rule apply to <em>all</em> sample types or to a <em>selected subset</em> —
+              e.g. LDL fires on both Serum and Plasma; eGFR fires on Serum and Plasma; BMI applies
+              to all sample types. The list view shows the scope on each rule.
+              Both LDL (arithmetic) and eGFR (branching) editors are pre-expanded so you can compare.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search rules by name, test, or destination…" />
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Sample: All ▾</span>
+              <span className="filter-pill">Destination: All ▾</span>
+            </div>
+            <div>
+              <button className={'browse-btn' + (libraryOpen ? ' open' : '')}
+                      onClick={() => setLibraryOpen(o => !o)}
+                      style={{ marginRight: 8 }}>
+                Browse formula library
+              </button>
+              <button className="cds--btn cds--btn--primary">+ New calculation</button>
+            </div>
+          </div>
+
+          {libraryOpen && <LibraryDrawer onClose={() => setLibraryOpen(false)} />}
+
+          {/* Rule list */}
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 90 }}>Status</th>
+                  <th>Rule</th>
+                  <th>Destination</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                  <th style={{ width: 60 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {RULES.map(rule => (
+                  <React.Fragment key={rule.id}>
+                    <tr style={{ background: expandedId === rule.id ? '#edf5ff' : 'transparent' }}>
+                      <td>
+                        <button
+                          onClick={() => setExpandedId(expandedId === rule.id ? null : rule.id)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                          {expandedId === rule.id ? '▾' : '▸'}
+                        </button>
+                      </td>
+                      <td>
+                        {rule.status === 'active'
+                          ? <span className="cds--tag cds--tag--green">Active</span>
+                          : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                        {rule.branching && <span className="cds--tag cds--tag--purple" style={{ marginLeft: 4 }}>Branching</span>}
+                      </td>
+                      <td>
+                        <div className="rule-name">{rule.name}</div>
+                        <FormulaSummary text={rule.formula} />
+                      </td>
+                      <td style={{ fontSize: 13 }}>
+                        <div>{rule.destination}</div>
+                        <div style={{ fontSize: 11, color: '#6f6f6f', marginTop: 2 }}>
+                          {rule.scope === 'all'
+                            ? <span style={{ color: '#0043ce' }}>→ all sample types</span>
+                            : <>→ {rule.scopeList.map((s, i) => (
+                                <span key={s} className="cds--tag cds--tag--cool-gray" style={{ marginRight: 2, fontSize: 10 }}>{s}</span>
+                              ))}</>}
+                        </div>
+                      </td>
+                      <td style={{ fontSize: 12, color: '#6f6f6f' }}>{rule.edited}</td>
+                      <td>
+                        <span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span>
+                      </td>
+                    </tr>
+                    {expandedId === rule.id && rule.id === 2 && <LDLEditor />}
+                    {expandedId === rule.id && rule.id === 3 && <EGFREditor />}
+                    {expandedId === rule.id && rule.id !== 2 && rule.id !== 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#f4f4f4', fontSize: 13, color: '#525252' }}>
+                          (Editor for <strong>{rule.name}</strong> would render in the same formula-bar layout.
+                          {rule.branching ? ' Flowchart panel would appear because this rule uses if().' : ' No flowchart panel — pure arithmetic.'})
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What changed vs. v1:</strong> Chip canvas removed as the primary input — typing in
+            the formula bar is faster and beginners still get discovery through the side panel.
+            Math-view rendering moved beneath the bar as the read-only QA artifact. Flowchart panel
+            now appears <em>only</em> when the formula uses <code>if()</code> — eGFR and MELD-Na get
+            it, BMI and LDL don't. Templates moved from a fixed six-card strip into a searchable
+            library drawer with citations (Friedewald 1972, NKF-ASN 2021, Cockcroft 1976, etc.).
+            Both the formula bar and the math view are <em>views on the same AST</em> — typing
+            updates both, picking a template populates both.
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/designs/admin-config/reflex-tests-redesign-preview.html
+++ b/designs/admin-config/reflex-tests-redesign-preview.html
@@ -1,0 +1,2379 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reflex Test Rules — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 280px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .browse-btn {
+      background: #fff; padding: 4px 12px; font-size: 12px; border: 1px solid #0f62fe;
+      color: #0f62fe; cursor: pointer;
+    }
+    .browse-btn.open { background: #0f62fe; color: #fff; }
+
+    /* Library drawer */
+    .library-drawer {
+      background: #fff; border: 1px solid #e0e0e0; border-bottom: none;
+      padding: 1rem;
+    }
+    .library-drawer h4 { margin: 0 0 0.5rem; font-size: 13px; }
+    .library-search {
+      width: 320px; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 14px; margin-bottom: 0.75rem;
+    }
+    .library-grid {
+      display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.5rem;
+    }
+    .library-card {
+      padding: 0.75rem 1rem; border: 1px solid #e0e0e0; cursor: pointer;
+    }
+    .library-card:hover { border-color: #0f62fe; background: #f4f9ff; }
+    .library-card .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .library-card .shape {
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .library-card .src { font-size: 10px; color: #8d8d8d; margin-top: 4px; }
+
+    /* DataTable */
+    table.cds--data-table { width: 100%; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }  /* semantic predicate (raw form) */
+    .phrase {
+      display: inline-flex; align-items: baseline; gap: 4px;
+      background: #f4f9ff; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Sans', sans-serif; font-size: 12px;
+      color: #161616; margin: 0 2px;
+    }
+    .phrase strong { font-weight: 600; color: #161616; }
+    .phrase em { color: #0072c3; font-style: normal; font-weight: 500; }
+    .tok-unknown {
+      color: #a2191f; text-decoration: underline wavy #da1e28; text-underline-offset: 3px;
+    }
+
+    /* Searchable test/panel picker (in ActionRow) */
+    .tp-picker { position: relative; flex: 1 1 100%; min-width: 280px; }
+    .tp-input-wrap {
+      display: flex; align-items: center; gap: 6px;
+      background: #f4f4f4; border-bottom: 1px solid #8d8d8d; padding: 4px 8px;
+    }
+    .tp-input-wrap:focus-within { border-color: #0f62fe; background: #fff; }
+    .tp-input {
+      flex: 1; border: none; outline: none; background: transparent;
+      font-size: 13px; padding: 2px 0;
+    }
+    .tp-selected {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: #d0e2ff; color: #0043ce; padding: 2px 8px; border-radius: 4px;
+      font-size: 12px; font-weight: 600;
+    }
+    .tp-selected .clear { cursor: pointer; opacity: 0.7; }
+    .tp-selected .clear:hover { opacity: 1; }
+    .tp-selected .kind {
+      background: #fff; color: #0043ce; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .tp-pop {
+      position: absolute; top: 100%; left: 0; right: 0; z-index: 30; margin-top: 2px;
+      background: #fff; border: 1px solid #8d8d8d;
+      max-height: 320px; overflow-y: auto;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    .tp-scope {
+      display: flex; gap: 1rem; padding: 8px 10px; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0; font-size: 12px;
+    }
+    .tp-scope label { cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+    .tp-scope .warn-pill {
+      background: #fff8e1; color: #b28600; font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 3px; margin-left: 4px;
+    }
+    .tp-warn {
+      background: #fff8e1; color: #6b4a00; padding: 6px 10px;
+      font-size: 11px; border-bottom: 1px solid #f1c21b;
+    }
+    .tp-section {
+      padding: 6px 10px; background: #fafafa;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+      color: #525252; font-weight: 600;
+    }
+    .tp-item {
+      padding: 6px 10px; cursor: pointer; display: flex; align-items: center; gap: 8px;
+      border-top: 1px solid #f4f4f4; font-size: 13px;
+    }
+    .tp-item:hover { background: #edf5ff; }
+    .tp-item .label { flex: 1; }
+    .tp-item .label .name { color: #161616; }
+    .tp-item .label .meta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; margin-top: 2px; }
+    .tp-item .sample-chip {
+      background: #f4f4f4; color: #525252; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px;
+    }
+    .tp-item .kind-chip {
+      background: #d0e2ff; color: #0043ce; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .tp-item .kind-chip.panel { background: #e8daff; color: #491d8b; }
+    .tp-empty { padding: 12px; color: #6f6f6f; font-size: 12px; text-align: center; font-style: italic; }
+
+    /* Prominent + Add CTA — used for adding conditions and actions */
+    .add-cta {
+      display: flex; align-items: center; justify-content: center; gap: 6px;
+      width: 100%; padding: 10px;
+      background: #fff; border: 1.5px dashed #0f62fe;
+      color: #0f62fe; font-size: 13px; font-weight: 600;
+      cursor: pointer; margin-top: 8px;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .add-cta:hover { background: #edf5ff; border-color: #0043ce; }
+    .add-cta .plus {
+      width: 20px; height: 20px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 14px; font-weight: 700;
+    }
+    .add-cta:hover .plus { background: #0043ce; }
+    .add-cta .hint {
+      font-weight: 400; font-size: 11px; color: #6f6f6f; margin-left: 8px;
+    }
+
+    /* Compose mode — row-list builder */
+    .compose-block {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.75rem;
+    }
+    .compose-row {
+      display: grid; grid-template-columns: 56px 140px 1fr 28px;
+      gap: 0.5rem; align-items: center; margin-bottom: 6px;
+    }
+    .compose-row .joiner {
+      background: #fff8e1; color: #b28600; font-size: 11px; font-weight: 700;
+      text-align: center; padding: 4px 6px; border-radius: 4px;
+      letter-spacing: 0.5px;
+    }
+    .compose-row .joiner.first {
+      background: #d0e2ff; color: #0043ce;
+    }
+    .compose-row select {
+      padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #fff; font-size: 13px;
+    }
+    .compose-row .pred-pick {
+      display: flex; gap: 4px; align-items: center;
+    }
+    .compose-row .pred-pick .tok-pred {
+      background: #cfeaff; padding: 4px 10px; border-radius: 4px; font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+    }
+    .compose-row .delete {
+      background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px;
+    }
+    .mode-tabs {
+      display: inline-flex; border: 1px solid #c6c6c6; border-radius: 4px; overflow: hidden;
+      margin-left: 0.5rem;
+    }
+    .mode-tabs button {
+      background: #fff; border: none; padding: 4px 12px; font-size: 12px; cursor: pointer;
+    }
+    .mode-tabs button.active { background: #0f62fe; color: #fff; }
+
+    /* Predicate index panel */
+    .pred-index {
+      background: #f4f4f4; padding: 0.75rem; border: 1px solid #e0e0e0;
+    }
+    .pred-test {
+      background: #fff; padding: 0.5rem 0.75rem; margin-bottom: 6px; border: 1px solid #e0e0e0;
+    }
+    .pred-test .head {
+      font-family: 'IBM Plex Mono', monospace; font-weight: 600;
+      color: #0043ce; font-size: 13px; margin-bottom: 4px;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .pred-test .meta {
+      font-size: 10px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+    }
+    .pred-list {
+      display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px;
+    }
+    .pred-pill {
+      background: #cfeaff; color: #0072c3; padding: 2px 8px; border-radius: 4px;
+      font-size: 11px; font-weight: 600; cursor: pointer; font-family: 'IBM Plex Mono', monospace;
+      display: inline-flex; align-items: center; gap: 3px;
+    }
+    .pred-pill:hover { background: #0072c3; color: #fff; }
+    .pred-pill .why {
+      font-size: 9px; opacity: 0.7; font-family: 'IBM Plex Sans', sans-serif;
+      font-weight: 400;
+    }
+
+    .rule-summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+    .rule-when-then {
+      display: flex; align-items: center; gap: 0.5rem; margin-top: 4px;
+      flex-wrap: wrap;
+    }
+    .rule-when-then .when, .rule-when-then .then {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+    .rule-when-then .label {
+      font-size: 10px; padding: 2px 6px; border-radius: 999px; font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    .rule-when-then .label.w { background: #fff8e1; color: #b28600; }
+    .rule-when-then .label.t { background: #defbe6; color: #0e6027; }
+    .rule-when-then .arrow { color: #525252; }
+
+    /* Expanded editor */
+    .expanded-tile {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-grid {
+      display: grid; grid-template-columns: 1.1fr 1fr; gap: 1.25rem;
+    }
+    .editor-stack {
+      display: flex; flex-direction: column; gap: 0.75rem;
+    }
+
+    /* Collapsible card — for catalog data and simulator */
+    .collapsible {
+      background: #fff; border: 1px solid #e0e0e0;
+    }
+    .collapsible-head {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.75rem 1rem; cursor: pointer; user-select: none;
+      background: #fafafa; border-bottom: 1px solid #e0e0e0;
+      width: 100%; border-left: none; border-right: none; border-top: none;
+      font-family: inherit; font-size: inherit; text-align: left;
+    }
+    .collapsible-head:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .collapsible-head.collapsed { border-bottom-color: transparent; }
+    .collapsible-head:hover { background: #f4f4f4; }
+    .collapsible-head .caret { font-size: 11px; color: #525252; }
+    .collapsible-head .col-title { font-size: 14px; font-weight: 600; flex: 0 0 auto; }
+    .collapsible-head .col-summary {
+      font-size: 12px; color: #6f6f6f; flex: 1; min-width: 0;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .collapsible-head .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .collapsible-head .pill.gray { background: #f4f4f4; color: #525252; }
+    .collapsible-head .pill.green { background: #defbe6; color: #0e6027; }
+    .collapsible-body { padding: 1rem; }
+
+    /* === Unified InputPicker — chip-trigger + dropdown panel === */
+    .ip-wrap { position: relative; display: inline-block; max-width: 100%; }
+    .ip-trigger {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 4px 10px; min-height: 30px; max-width: 100%;
+      background: #f4f4f4; border: 1px solid #c6c6c6; border-radius: 4px;
+      font-size: 13px; cursor: pointer; font-family: inherit;
+    }
+    .ip-trigger:hover { background: #e8e8e8; border-color: #8d8d8d; }
+    .ip-trigger:focus, .ip-trigger:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .ip-trigger.empty { color: #6f6f6f; font-style: italic; }
+    .ip-trigger.error { border-color: #da1e28; background: #fff1f1; }
+    .ip-trigger .caret { color: #525252; font-size: 10px; margin-left: 2px; flex-shrink: 0; }
+    .ip-trigger .ip-label {
+      color: #161616; font-style: normal;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      max-width: 420px;
+    }
+    .ip-trigger .ip-sub {
+      color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+      flex-shrink: 0;
+    }
+    .ip-trigger .clear-btn {
+      background: none; border: none; cursor: pointer; color: #6f6f6f;
+      padding: 0 2px 0 4px; font-size: 14px; line-height: 1;
+    }
+    .ip-trigger .clear-btn:hover { color: #a2191f; }
+    .ip-kind {
+      padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .ip-kind.result { background: #d0e2ff; color: #0043ce; }
+    .ip-kind.param  { background: #f6f2ff; color: #6929c4; }
+    .ip-kind.panel  { background: #e8daff; color: #491d8b; }
+    .ip-pop {
+      position: absolute; top: calc(100% + 4px); left: 0;
+      min-width: 380px; max-width: 520px;
+      background: #fff; border: 1px solid #8d8d8d; border-radius: 4px;
+      z-index: 100; box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      overflow: hidden;
+    }
+    .ip-pop-search {
+      width: 100%; padding: 10px 12px; border: none; border-bottom: 1px solid #e0e0e0;
+      font-size: 13px; box-sizing: border-box; outline: none; background: #fff;
+    }
+    .ip-pop-search:focus { background: #f4f9ff; }
+    .ip-pop-scope {
+      display: flex; gap: 1rem; padding: 6px 10px; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0; font-size: 12px;
+    }
+    .ip-pop-scope label { cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+    .ip-pop-scope .warn-pill {
+      background: #fff8e1; color: #b28600; font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 3px; margin-left: 4px;
+    }
+    .ip-pop-warn {
+      background: #fff8e1; color: #6b4a00; padding: 6px 10px;
+      font-size: 11px; border-bottom: 1px solid #f1c21b;
+    }
+    .ip-pop-list { max-height: 280px; overflow-y: auto; }
+    .ip-section {
+      padding: 6px 10px; background: #fafafa;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+      color: #525252; font-weight: 600;
+    }
+    .ip-item {
+      display: flex; align-items: center; gap: 10px;
+      width: 100%; padding: 8px 12px; background: none; border: none;
+      border-top: 1px solid #f4f4f4; cursor: pointer; text-align: left;
+      font-family: inherit; font-size: 13px;
+    }
+    .ip-item:hover, .ip-item:focus { background: #edf5ff; outline: none; }
+    .ip-item-body { flex: 1; min-width: 0; }
+    .ip-item-name { color: #161616; line-height: 1.3; }
+    .ip-item-meta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+      margin-top: 2px; line-height: 1.3;
+    }
+    .ip-item .sample-chip {
+      background: #f4f4f4; color: #525252; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; flex-shrink: 0;
+    }
+    .ip-pop-empty { padding: 16px; color: #6f6f6f; font-size: 12px; font-style: italic; text-align: center; }
+    .ip-pop-more { padding: 8px 12px; font-size: 11px; color: #6f6f6f; font-style: italic; border-top: 1px solid #f4f4f4; }
+
+    /* === Empty state === */
+    .empty-state {
+      padding: 3rem 2rem; text-align: center; background: #fafafa;
+      border: 2px dashed #c6c6c6; border-radius: 4px;
+    }
+    .empty-state .icon {
+      font-size: 32px; color: #8d8d8d; margin-bottom: 0.5rem;
+    }
+    .empty-state .title {
+      font-size: 16px; font-weight: 600; color: #161616; margin-bottom: 4px;
+    }
+    .empty-state .desc {
+      font-size: 13px; color: #525252; margin-bottom: 1rem;
+    }
+
+    /* === Inline validation error === */
+    .field-error {
+      color: #a2191f; font-size: 11px; margin-top: 4px;
+      display: flex; align-items: center; gap: 4px;
+    }
+    .save-error {
+      background: #fff1f1; border-left: 3px solid #da1e28;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px;
+    }
+    .save-error .title { color: #6f0000; font-weight: 600; margin-bottom: 4px; }
+    .save-error ul { margin: 0; padding-left: 1.2rem; color: #a2191f; font-size: 12px; }
+
+    /* === Confirmation modal === */
+    .modal-overlay {
+      position: fixed; inset: 0; background: rgba(22, 22, 22, 0.5); z-index: 200;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .modal-panel {
+      background: #fff; min-width: 480px; max-width: 560px;
+      box-shadow: 0 16px 24px rgba(0,0,0,0.18);
+    }
+    .modal-head { padding: 1rem 1.25rem; border-bottom: 1px solid #e0e0e0; }
+    .modal-title { font-size: 18px; font-weight: 400; }
+    .modal-body { padding: 1rem 1.25rem; font-size: 13px; color: #161616; }
+    .modal-foot {
+      padding: 1rem 1.25rem; border-top: 1px solid #e0e0e0;
+      display: flex; gap: 0.5rem; justify-content: flex-end;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      color: #161616; display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+    .panel h4 .pill.amber { background: #fff8e1; color: #b28600; }
+    .panel h4 .pill.gray { background: #f4f4f4; color: #525252; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* WHEN block — formula bar */
+    .formula-bar-wrap {
+      position: relative; background: #fff; border: 1px solid #8d8d8d;
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      padding: 10px 12px;
+    }
+    .formula-bar-wrap:focus-within { border-color: #0f62fe; outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .formula-overlay {
+      position: absolute; top: 10px; left: 12px; right: 12px;
+      pointer-events: none; white-space: pre-wrap; word-wrap: break-word;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+    }
+    .formula-input {
+      position: relative; width: 100%; min-height: 1.4em; resize: vertical;
+      border: none; outline: none; background: transparent;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: transparent; caret-color: #161616;
+    }
+    .formula-prompt {
+      font-size: 11px; color: #525252; margin-top: 4px; display: flex; gap: 0.5rem;
+    }
+    .formula-prompt .err { color: #a2191f; }
+    .formula-prompt .ok { color: #0e6027; }
+
+    /* WHEN/THEN labels */
+    .block-label {
+      display: inline-block;
+      font-size: 10px; padding: 3px 10px; border-radius: 999px;
+      font-weight: 700; letter-spacing: 0.5px; margin-bottom: 6px;
+    }
+    .block-label.when { background: #fff8e1; color: #b28600; }
+    .block-label.then { background: #defbe6; color: #0e6027; }
+
+    /* Action list */
+    .action-row {
+      display: grid; grid-template-columns: 140px 1fr 36px;
+      gap: 0.5rem; align-items: center; padding: 6px 0;
+      border-bottom: 1px dashed #e0e0e0;
+    }
+    .action-row select, .action-row input {
+      width: 100%; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .action-row .a-fields { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .action-row .a-fields > * { flex: 1; min-width: 140px; }
+    .action-row .delete-btn {
+      background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px;
+    }
+    .action-tag {
+      display: inline-block; padding: 2px 8px; border-radius: 4px;
+      font-size: 11px; font-weight: 600;
+    }
+    .action-tag.order { background: #d0e2ff; color: #0043ce; }
+    .action-tag.note { background: #fff1f1; color: #a2191f; }
+    .action-tag.alert { background: #ffd6e8; color: #9f1853; }
+    .action-tag.priority { background: #fff8e1; color: #b28600; }
+    .action-tag.panel { background: #e8daff; color: #491d8b; }
+
+    /* Decision table mode */
+    .decision-table {
+      width: 100%; border-collapse: collapse; font-size: 13px;
+      background: #fff;
+    }
+    .decision-table th, .decision-table td {
+      padding: 8px 12px; border: 1px solid #e0e0e0; text-align: left;
+      vertical-align: top;
+    }
+    .decision-table thead th {
+      background: #f4f4f4; font-size: 11px; text-transform: uppercase;
+      letter-spacing: 0.5px; color: #525252;
+    }
+    .decision-table .col-header-when { background: #fff8e1; color: #b28600; }
+    .decision-table .col-header-then { background: #defbe6; color: #0e6027; }
+    .decision-table tbody tr:hover { background: #fafafa; }
+    .decision-table .dt-cell {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+    .mode-toggle {
+      display: inline-flex; border: 1px solid #c6c6c6; border-radius: 4px; overflow: hidden;
+      margin-left: 0.5rem;
+    }
+    .mode-toggle button {
+      background: #fff; border: none; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    }
+    .mode-toggle button.active { background: #0f62fe; color: #fff; }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 160px; font-size: 13px; color: #161616; }
+    .sim-row input, .sim-row select {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-result {
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+      border-left: 3px solid;
+    }
+    .sim-result.fires { background: #defbe6; border-color: #198038; }
+    .sim-result.idle { background: #f4f4f4; border-color: #c6c6c6; }
+    .sim-result .head {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600;
+    }
+    .sim-result.fires .head { color: #0e6027; }
+    .sim-result.idle .head { color: #525252; }
+    .sim-result .body {
+      font-size: 14px; margin-top: 4px;
+    }
+    .sim-result .action-line {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+      padding: 4px 0;
+    }
+
+    /* Cascade view */
+    .cascade {
+      display: flex; align-items: center; gap: 0.5rem; padding: 0.75rem;
+      background: #fafafa; border: 1px solid #e0e0e0;
+      overflow-x: auto;
+    }
+    .cascade .node {
+      flex: 0 0 auto; padding: 6px 10px; font-size: 12px;
+      border-radius: 4px; font-family: 'IBM Plex Mono', monospace;
+      white-space: nowrap;
+    }
+    .cascade .node.trigger { background: #fff8e1; color: #b28600; border: 1px solid #f1c21b; }
+    .cascade .node.action { background: #defbe6; color: #0e6027; border: 1px solid #24a148; }
+    .cascade .node.chain { background: #d0e2ff; color: #0043ce; border: 1px solid #4589ff; }
+    .cascade .arr { color: #525252; font-size: 14px; }
+
+    /* Conflict notification */
+    .conflict {
+      background: #fff1f1; border-left: 3px solid #da1e28;
+      padding: 0.5rem 0.75rem; font-size: 12px; color: #6f0000;
+      margin-top: 0.5rem;
+    }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Reflex Test Rules &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Reflex rule editor</strong>
+    &nbsp;<span style="color: #6f6f6f;">— this is what expands inline when you click a Reflex rule row in the list view, shown at full width.</span>
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">
+    Loading…
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    window.addEventListener('error', function (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Error:</strong> ' + (e.message || 'unknown') +
+          (e.filename ? ' &nbsp;<em>' + e.filename.split('/').pop() + ':' + e.lineno + '</em>' : '');
+      }
+    });
+    window.addEventListener('load', function () {
+      var missing = [];
+      if (typeof React === 'undefined')    missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined')    missing.push('Babel');
+      var s = document.getElementById('boot-status');
+      if (missing.length && s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Missing dependencies:</strong> ' + missing.join(', ') +
+          '. Network may be blocking cdnjs.cloudflare.com / unpkg.com.';
+      }
+    });
+  </script>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // DOMAIN DATA
+    // ========================================================================
+    const TESTS = [
+      { id: 'TSH',       name: 'TSH',                        loinc: '3016-3',  type: 'numeric',   units: 'µIU/mL', sample: 'Serum',
+        refRange: [0.4, 4.5],     criticalRange: [0.1, 10],    deltaPct: 50 },
+      { id: 'FT4',       name: 'Free T4',                    loinc: '3024-7',  type: 'numeric',   units: 'ng/dL',  sample: 'Serum',
+        refRange: [0.8, 1.8],     criticalRange: [0.4, 4.0],   deltaPct: 30 },
+      { id: 'HIV_Screen',name: 'HIV-1/2 Ab Screen (Rapid)',  loinc: '49560-6', type: 'coded',     values: ['Reactive','Weak Reactive','Non-Reactive'], sample: 'Whole Blood' },
+      { id: 'HIV1_Conf', name: 'HIV-1 Confirmatory (WB)',    loinc: '7917-8',  type: 'coded',     values: ['Positive','Negative','Indeterminate'], sample: 'Serum' },
+      { id: 'WBC',       name: 'WBC Count',                  loinc: '6690-2',  type: 'numeric',   units: '10⁹/L',  sample: 'EDTA Tube',
+        refRange: [4.0, 11.0],    criticalRange: [2.0, 30.0],  deltaPct: 25 },
+      { id: 'HGB',       name: 'Hemoglobin',                 loinc: '718-7',   type: 'numeric',   units: 'g/dL',   sample: 'EDTA Tube',
+        refRange: [12.0, 17.5],   criticalRange: [7.0, 20.0],  deltaPct: 20 },
+      { id: 'PLT',       name: 'Platelets',                  loinc: '777-3',   type: 'numeric',   units: '10⁹/L',  sample: 'EDTA Tube',
+        refRange: [150, 400],     criticalRange: [50, 1000],   deltaPct: 30 },
+      { id: 'GLU',       name: 'Glucose',                    loinc: '2345-7',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum',
+        refRange: [70, 110],      criticalRange: [40, 500],    deltaPct: 30 },
+      { id: 'CR',        name: 'Creatinine',                 loinc: '2160-0',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum',
+        refRange: [0.7, 1.3],     criticalRange: [0.3, 10.0],  deltaPct: 30 },
+      { id: 'Nitrites',  name: 'Urine Nitrites',             loinc: '5802-4',  type: 'coded',     values: ['Negative','Positive'], sample: 'Urines' },
+      { id: 'Leuk',      name: 'Urine Leukocytes',           loinc: '5799-2',  type: 'coded',     values: ['Negative','Trace','+','++','+++'], sample: 'Urines' },
+      { id: 'UC',        name: 'Urine Culture',              loinc: '630-4',   type: 'reflex',    sample: 'Urines' },
+      { id: 'StrepA',    name: 'Strep A RADT',               loinc: '17656-0', type: 'coded',     values: ['Positive','Negative'], sample: 'Respiratory Swab' },
+      { id: 'ThroatCx',  name: 'Throat Culture',             loinc: '587-3',   type: 'reflex',    sample: 'Respiratory Swab' },
+      { id: 'Diff',      name: 'Manual WBC Differential',    loinc: '764-1',   type: 'reflex',    sample: 'EDTA Tube' },
+      { id: 'Retic',     name: 'Reticulocyte Count',         loinc: '4679-7',  type: 'numeric',   units: '%',      sample: 'EDTA Tube' },
+      { id: 'IronPanel', name: 'Iron Panel',                 loinc: 'panel',   type: 'reflex',    sample: 'Serum' },
+      { id: 'Lactate',   name: 'Lactate',                    loinc: '32693-4', type: 'numeric',   units: 'mmol/L', sample: 'Serum',
+        refRange: [0.5, 2.0],     criticalRange: [0.2, 4.0],   deltaPct: 30 },
+      { id: 'TPOAb',     name: 'Thyroid Peroxidase Ab',       loinc: '8099-1',  type: 'numeric',   units: 'IU/mL',  sample: 'Serum', refRange: [0, 34] },
+      { id: 'TgAb',      name: 'Thyroglobulin Ab',            loinc: '8095-9',  type: 'numeric',   units: 'IU/mL',  sample: 'Serum', refRange: [0, 115] },
+      // Additional tests to make the picker search meaningful
+      { id: 'T3',        name: 'Total T3',                    loinc: '3053-6',  type: 'numeric',   units: 'ng/dL',  sample: 'Serum', refRange: [80, 200] },
+      { id: 'T4',        name: 'Total T4',                    loinc: '3026-2',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [4.5, 12.0] },
+      { id: 'BUN',       name: 'Blood Urea Nitrogen',         loinc: '3094-0',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [7, 25] },
+      { id: 'eGFR',      name: 'eGFR',                        loinc: '62238-1', type: 'numeric',   units: 'mL/min', sample: 'Serum', refRange: [60, 120] },
+      { id: 'CO2',       name: 'CO₂ / Bicarbonate (CMP)',     loinc: '2028-9',  type: 'numeric',   units: 'mmol/L', sample: 'Serum', refRange: [22, 30] },
+      { id: 'Phos',      name: 'Phosphorus',                  loinc: '2777-1',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [2.5, 4.5] },
+      { id: 'Mg',        name: 'Magnesium',                   loinc: '2601-3',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [1.7, 2.2] },
+      { id: 'TP',        name: 'Total Protein',               loinc: '2885-2',  type: 'numeric',   units: 'g/dL',   sample: 'Serum', refRange: [6.0, 8.3] },
+      { id: 'ALP',       name: 'Alkaline Phosphatase',        loinc: '6768-6',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [44, 147] },
+      { id: 'GGT',       name: 'GGT',                         loinc: '2324-2',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [9, 48] },
+      { id: 'BiliD',     name: 'Bilirubin, Direct',           loinc: '1968-7',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [0, 0.3] },
+      { id: 'BiliT',     name: 'Bilirubin, Total',            loinc: '1975-2',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [0.1, 1.2] },
+      { id: 'Amylase',   name: 'Amylase',                     loinc: '1798-8',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [25, 125] },
+      { id: 'Lipase',    name: 'Lipase',                      loinc: '3040-3',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [0, 160] },
+      { id: 'CK',        name: 'Creatine Kinase',             loinc: '2157-6',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [22, 198] },
+      { id: 'LDH',       name: 'LDH',                         loinc: '2532-0',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [125, 220] },
+      { id: 'Trop',      name: 'Troponin I (High-sens)',      loinc: '67151-1', type: 'numeric',   units: 'ng/L',   sample: 'Serum', refRange: [0, 14], criticalRange: [0, 100] },
+      { id: 'BNP',       name: 'BNP',                         loinc: '30934-4', type: 'numeric',   units: 'pg/mL',  sample: 'Serum', refRange: [0, 100] },
+      { id: 'HbA1c',     name: 'Hemoglobin A1c',              loinc: '4548-4',  type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [4.0, 5.6] },
+      { id: 'Fe',        name: 'Iron, Serum',                 loinc: '2498-4',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [60, 170] },
+      { id: 'TIBC',      name: 'Total Iron-Binding Capacity', loinc: '2500-7',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [240, 450] },
+      { id: 'Ferritin',  name: 'Ferritin',                    loinc: '2276-4',  type: 'numeric',   units: 'ng/mL',  sample: 'Serum', refRange: [12, 300] },
+      { id: 'PT',        name: 'Prothrombin Time',            loinc: '5902-2',  type: 'numeric',   units: 'sec',    sample: 'Plasma', refRange: [10, 13] },
+      { id: 'PTT',       name: 'Partial Thromboplastin Time', loinc: '14979-9', type: 'numeric',   units: 'sec',    sample: 'Plasma', refRange: [25, 35] },
+      { id: 'DDimer',    name: 'D-Dimer',                     loinc: '48065-7', type: 'numeric',   units: 'µg/mL',  sample: 'Plasma', refRange: [0, 0.5] },
+      { id: 'Procalc',   name: 'Procalcitonin',               loinc: '33959-8', type: 'numeric',   units: 'ng/mL',  sample: 'Serum', refRange: [0, 0.1] },
+      { id: 'BloodCx',   name: 'Blood Culture',               loinc: '600-7',   type: 'reflex',    sample: 'Whole Blood' },
+      { id: 'RBC',       name: 'Red Blood Cell Count',        loinc: '789-8',   type: 'numeric',   units: '10¹²/L', sample: 'EDTA Tube', refRange: [4.2, 5.9] },
+      { id: 'HCT',       name: 'Hematocrit',                  loinc: '4544-3',  type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [36, 50] },
+      { id: 'MCV',       name: 'MCV',                         loinc: '787-2',   type: 'numeric',   units: 'fL',     sample: 'EDTA Tube', refRange: [80, 100] },
+      { id: 'RDW',       name: 'RDW',                         loinc: '788-0',   type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [11.5, 14.5] },
+    ];
+
+    // Panels — composed of multiple tests, run on one sample
+    const PANELS = [
+      { id: 'PANEL_BMP',    name: 'Basic Metabolic Panel (BMP)',       sample: 'Serum',     tests: ['NA','K','CL','CO2','BUN','CR','GLU','CA'] },
+      { id: 'PANEL_CMP',    name: 'Comprehensive Metabolic Panel (CMP)',sample: 'Serum',    tests: ['NA','K','CL','CO2','BUN','CR','GLU','CA','ALB','TP','AST','ALT','ALP','BiliT'] },
+      { id: 'PANEL_LIPID',  name: 'Lipid Panel',                       sample: 'Serum',     tests: ['TC','HDL','TRIG','LDL'] },
+      { id: 'PANEL_HEPATIC',name: 'Hepatic Function Panel (LFTs)',     sample: 'Serum',     tests: ['AST','ALT','ALP','GGT','BiliT','BiliD','ALB','TP'] },
+      { id: 'PANEL_THYROID',name: 'Thyroid Panel',                     sample: 'Serum',     tests: ['TSH','FT4','T3','T4'] },
+      { id: 'PANEL_THYRAB', name: 'Thyroid Antibody Panel',            sample: 'Serum',     tests: ['TPOAb','TgAb'] },
+      { id: 'PANEL_IRON',   name: 'Iron Studies',                      sample: 'Serum',     tests: ['Fe','TIBC','Ferritin'] },
+      { id: 'PANEL_CARDIAC',name: 'Cardiac Panel',                     sample: 'Serum',     tests: ['Trop','CK','BNP','LDH'] },
+      { id: 'PANEL_SEPSIS', name: 'Sepsis Panel',                      sample: 'Serum',     tests: ['Lactate','Procalc'] },
+      { id: 'PANEL_COAG',   name: 'Coagulation Panel',                 sample: 'Plasma',    tests: ['PT','PTT','INR','DDimer'] },
+      { id: 'PANEL_ANEMIA', name: 'Anemia Workup',                     sample: 'EDTA Tube', tests: ['HGB','RBC','MCV','RDW','Retic'] },
+      { id: 'PANEL_CBC',    name: 'CBC with Differential',             sample: 'EDTA Tube', tests: ['WBC','RBC','HGB','HCT','PLT','MCV','RDW','Diff'] },
+    ];
+    const PANEL_BY_ID = Object.fromEntries(PANELS.map(p => [p.id, p]));
+    const ATTRS = [
+      { id: 'Age',    name: 'Age',    units: 'years' },
+      { id: 'Sex',    name: 'Sex',    units: '(M/F)' },
+      { id: 'Sample', name: 'Sample', units: '(type)' },
+    ];
+    const KEYWORDS = ['AND', 'OR', 'NOT', 'IN'];
+
+    // Semantic predicates — compile to numeric expressions at save time
+    // using the test catalog's reference/critical ranges. Available per-test
+    // based on what metadata the test has.
+    const PREDICATES = [
+      // Catalog-based (no value input)
+      { id: 'isNormal',             group: 'catalog',  requires: 'refRange',      label: 'is within the normal range',         short: 'is normal',                 desugar: (id, t)    => `${id} >= ${t.refRange[0]} AND ${id} <= ${t.refRange[1]}` },
+      { id: 'isOutsideNormal',      group: 'catalog',  requires: 'refRange',      label: 'is outside the normal range',        short: 'is outside normal',         desugar: (id, t)    => `${id} < ${t.refRange[0]} OR ${id} > ${t.refRange[1]}` },
+      { id: 'isAboveNormal',        group: 'catalog',  requires: 'refRange',      label: 'is above the normal range',          short: 'is above normal',           desugar: (id, t)    => `${id} > ${t.refRange[1]}` },
+      { id: 'isBelowNormal',        group: 'catalog',  requires: 'refRange',      label: 'is below the normal range',          short: 'is below normal',           desugar: (id, t)    => `${id} < ${t.refRange[0]}` },
+      { id: 'isCritical',           group: 'catalog',  requires: 'criticalRange', label: 'is at a critical value (either direction)', short: 'is critical',        desugar: (id, t)    => `${id} <= ${t.criticalRange[0]} OR ${id} >= ${t.criticalRange[1]}` },
+      { id: 'isCriticallyHigh',     group: 'catalog',  requires: 'criticalRange', label: 'is critically high',                 short: 'is critically high',        desugar: (id, t)    => `${id} >= ${t.criticalRange[1]}` },
+      { id: 'isCriticallyLow',      group: 'catalog',  requires: 'criticalRange', label: 'is critically low',                  short: 'is critically low',         desugar: (id, t)    => `${id} <= ${t.criticalRange[0]}` },
+      { id: 'isFlagged',            group: 'catalog',  requires: 'refRange',      label: 'has an abnormal flag',               short: 'is flagged',                desugar: (id, t)    => `flag(${id}) != "N"` },
+      { id: 'changedSignificantly', group: 'catalog',  requires: 'deltaPct',      label: 'has changed significantly from the prior result', short: 'changed significantly', desugar: (id, t) => `abs(${id} - prior(${id})) / prior(${id}) * 100 >= ${t.deltaPct}` },
+
+      // Specific-value comparison (numeric tests; takes a number input)
+      { id: 'gt',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is greater than (>)',    short: 'is greater than',     desugar: (id, t, v) => `${id} > ${v}` },
+      { id: 'gte',         group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at least (≥)',         short: 'is at least',         desugar: (id, t, v) => `${id} >= ${v}` },
+      { id: 'lt',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is less than (<)',        short: 'is less than',        desugar: (id, t, v) => `${id} < ${v}` },
+      { id: 'lte',         group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at most (≤)',          short: 'is at most',          desugar: (id, t, v) => `${id} <= ${v}` },
+      { id: 'eq',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is exactly (=)',          short: 'equals',              desugar: (id, t, v) => `${id} == ${v}` },
+      { id: 'between',     group: 'value', requires: 'numeric', valueInput: 'range',  label: 'is between (inclusive)',  short: 'is between',          desugar: (id, t, v) => v ? `${id} >= ${v[0]} AND ${id} <= ${v[1]}` : `${id} between ?` },
+
+      // Coded values — just "is" and "is not", each takes one or more values
+      { id: 'is',    group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is…',     short: 'is',
+        desugar: (id, t, vs) => {
+          const list = Array.isArray(vs) ? vs : [];
+          if (list.length === 0) return `${id} is ?`;
+          if (list.length === 1) return `${id} == "${list[0]}"`;
+          return `${id} IN (${list.map(v => '"' + v + '"').join(', ')})`;
+        } },
+      { id: 'isNot', group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is not…', short: 'is not',
+        desugar: (id, t, vs) => {
+          const list = Array.isArray(vs) ? vs : [];
+          if (list.length === 0) return `${id} is not ?`;
+          if (list.length === 1) return `${id} != "${list[0]}"`;
+          return `${id} NOT IN (${list.map(v => '"' + v + '"').join(', ')})`;
+        } },
+    ];
+
+    // Build natural-language phrase including any value input
+    function predicatePhrase(testIdOrInput, predId, value, mode = 'full') {
+      // Accept either a string testId (legacy) or an input object { testId, paramId? }
+      let testId, paramId, meta;
+      if (typeof testIdOrInput === 'string') {
+        testId = testIdOrInput; paramId = null; meta = TEST_BY_ID[testId];
+      } else if (testIdOrInput) {
+        testId = testIdOrInput.testId; paramId = testIdOrInput.paramId;
+        const t = TEST_BY_ID[testId];
+        meta = paramId ? (t?.analyzerParameters || []).find(p => p.id === paramId) : t;
+      }
+      const p = PREDICATES.find(p => p.id === predId);
+      if (!meta || !p) return '';
+      const labelText = (mode === 'short' ? p.short : p.label).replace(/…$/, '').replace(/\s*\(.*?\)\s*$/, '').trim();
+      const displayName = paramId ? `${testId} ${meta.name}` : (TEST_BY_ID[testId]?.name || testId);
+      const base = `${displayName} ${labelText}`;
+      if (!p.valueInput)               return base;
+      if (p.valueInput === 'range')    return value && value[0] != null && value[1] != null ? `${base} ${value[0]} and ${value[1]}` : `${base} …`;
+      if (p.valueInput === 'codedMulti') {
+        const list = Array.isArray(value) ? value : [];
+        if (list.length === 0) return `${base} …`;
+        if (list.length === 1) return `${base} ${list[0]}`;
+        if (list.length === 2) return `${base} ${list[0]} or ${list[1]}`;
+        return `${base} ${list.slice(0, -1).join(', ')}, or ${list[list.length-1]}`;
+      }
+      const unit = meta.units ? ' ' + meta.units : '';
+      return value != null && value !== '' ? `${base} ${value}${unit}` : `${base} …`;
+    }
+    const PRED_IDS = PREDICATES.map(p => p.id);
+
+    function predicatesFor(test) {
+      return PREDICATES.filter(p => predicateAvailable(p, test));
+    }
+
+    function predicateAvailable(p, test) {
+      if (!test) return false;
+      if (p.requires === 'refRange')      return Array.isArray(test.refRange);
+      if (p.requires === 'criticalRange') return Array.isArray(test.criticalRange);
+      if (p.requires === 'deltaPct')      return typeof test.deltaPct === 'number';
+      if (p.requires === 'values')        return Array.isArray(test.values);
+      if (p.requires === 'numeric')       return test.type === 'numeric';
+      return false;
+    }
+
+    const REQUIREMENT_REASONS = {
+      refRange:      'a reference range in the catalog',
+      criticalRange: 'critical thresholds in the catalog',
+      deltaPct:      'a delta threshold in the catalog',
+      values:        'coded values in the catalog',
+      numeric:       'a numeric test type',
+    };
+
+    const PREDICATE_GROUPS = [
+      { id: 'catalog', label: 'Catalog-based (uses test\'s reference / critical ranges)' },
+      { id: 'value',   label: 'Specific value (enter your own threshold)' },
+      { id: 'coded',   label: 'Coded value (pick from test\'s possible values)' },
+    ];
+
+    const TEST_BY_ID = Object.fromEntries(TESTS.map(t => [t.id, t]));
+    const ATTR_BY_ID = Object.fromEntries(ATTRS.map(a => [a.id, a]));
+
+    // ========================================================================
+    // TOKENIZER for boolean condition expressions
+    // ========================================================================
+    function tokenize(text) {
+      const re = /("[^"]*"|'[^']*')|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=)|([(),])|(\s+)|(.)/g;
+      const out = [];
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({ kind: 'str', text: m[1] });
+        else if (m[2]) out.push({ kind: 'num', text: m[2] });
+        else if (m[3]) {
+          const id = m[3];
+          if (KEYWORDS.includes(id.toUpperCase())) out.push({ kind: 'bool', text: id });
+          else if (PRED_IDS.includes(id))     out.push({ kind: 'pred', text: id });
+          else if (TEST_BY_ID[id])  out.push({ kind: 'var', text: id });
+          else if (ATTR_BY_ID[id]) out.push({ kind: 'attr', text: id });
+          else out.push({ kind: 'unknown', text: id });
+        }
+        else if (m[4]) out.push({ kind: 'op', text: m[4] });
+        else if (m[5]) out.push({ kind: 'paren', text: m[5] });
+        else if (m[6]) out.push({ kind: 'ws', text: m[6] });
+        else out.push({ kind: 'other', text: m[7] });
+      }
+      return out;
+    }
+    function lint(tokens) {
+      const issues = [];
+      const unknowns = tokens.filter(t => t.kind === 'unknown');
+      if (unknowns.length) {
+        issues.push({ kind: 'err', msg: `Unknown identifier${unknowns.length > 1 ? 's' : ''}: ${unknowns.map(u => u.text).join(', ')}` });
+      }
+      let depth = 0;
+      for (const t of tokens) {
+        if (t.kind === 'paren' && t.text === '(') depth++;
+        else if (t.kind === 'paren' && t.text === ')') depth--;
+        if (depth < 0) { issues.push({ kind: 'err', msg: 'Unmatched closing paren' }); break; }
+      }
+      if (depth > 0) issues.push({ kind: 'err', msg: `${depth} unclosed paren${depth > 1 ? 's' : ''}` });
+      // Single =  warning
+      if (tokens.some(t => t.kind === 'op' && t.text === '=')) {
+        issues.push({ kind: 'warn', msg: 'Use == for equality (single = is assignment)' });
+      }
+      return issues;
+    }
+
+    // ========================================================================
+    // TEST CATALOG REFERENCE — compact metadata card per test in the rule
+    // (No predicate chips — predicates live in the Compose picker with
+    // disabled+reason for unsupported ones.)
+    // ========================================================================
+    function TestCatalogRef({ testIds }) {
+      return (
+        <div className="pred-index">
+          {testIds.map(tid => {
+            const t = TEST_BY_ID[tid];
+            if (!t) return null;
+            return (
+              <div key={tid} className="pred-test">
+                <div className="head">
+                  <span><strong>{t.name}</strong> <span style={{ fontWeight: 400, color: '#6f6f6f', fontSize: 11 }}>({tid})</span></span>
+                  <span style={{ fontSize: 10, color: '#6f6f6f' }}>{t.values ? 'coded result' : (t.units ? t.units : t.type)}</span>
+                </div>
+                <div className="meta" style={{ lineHeight: 1.6 }}>
+                  {t.refRange      ? <div>Reference range: <strong>{t.refRange[0]}–{t.refRange[1]} {t.units}</strong></div>      : <div style={{ color: '#a8a8a8' }}>No reference range set</div>}
+                  {t.criticalRange ? <div>Critical thresholds: <strong>≤{t.criticalRange[0]} or ≥{t.criticalRange[1]}</strong></div> : <div style={{ color: '#a8a8a8' }}>No critical thresholds set</div>}
+                  {t.deltaPct      ? <div>Delta threshold: <strong>{t.deltaPct}%</strong></div> : <div style={{ color: '#a8a8a8' }}>No delta threshold set</div>}
+                  {t.values        && <div>Coded values: <strong>{t.values.join(', ')}</strong></div>}
+                </div>
+                <div style={{ marginTop: 6, fontSize: 11, color: '#0f62fe' }}>
+                  → <a href="#" style={{ color: '#0f62fe' }}>Edit in Test Catalog</a>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // CONDITION FORMULA BAR
+    // ========================================================================
+    function ConditionBar({ value, onChange }) {
+      const tokens = tokenize(value);
+      const issues = lint(tokens);
+      const varCount = tokens.filter(t => t.kind === 'var').length;
+      const attrCount = tokens.filter(t => t.kind === 'attr').length;
+      return (
+        <div>
+          <div className="formula-bar-wrap">
+            <div className="formula-overlay">
+              {tokens.map((t, i) => (
+                <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+              ))}
+              {value === '' && <span style={{ color: '#a8a8a8' }}>Type a condition… e.g. TSH &gt; 4.5 OR TSH &lt; 0.4</span>}
+            </div>
+            <textarea
+              className="formula-input"
+              value={value}
+              onChange={e => onChange(e.target.value)}
+              spellCheck={false}
+              rows={Math.max(1, value.split('\n').length)}
+            />
+          </div>
+          <div className="formula-prompt">
+            {issues.filter(i => i.kind === 'err').length === 0 && issues.filter(i => i.kind === 'warn').length === 0
+              ? <span className="ok">✓ Valid · references {varCount} test{varCount !== 1 ? 's' : ''}{attrCount ? `, ${attrCount} patient attr${attrCount !== 1 ? 's' : ''}` : ''}</span>
+              : issues.map((i, idx) => <span key={idx} className={i.kind === 'err' ? 'err' : 'warn'} style={{ color: i.kind === 'warn' ? '#b28600' : '#a2191f' }}>{i.kind === 'err' ? '⚠' : '!'} {i.msg}</span>)}
+            <span style={{ marginLeft: 'auto', color: '#0f62fe' }}>
+              Insert: test names, AND/OR/NOT, "coded values"
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // ACTION LIST
+    // ========================================================================
+    const ACTION_TYPES = [
+      { id: 'order',    label: 'Order Test or Panel', tag: 'order' },
+      { id: 'note_int', label: 'Internal Note',       tag: 'note' },
+      { id: 'note_ext', label: 'External Note',       tag: 'note' },
+      { id: 'alert',    label: 'Send Alert',          tag: 'alert' },
+      // 'Set Priority' removed — was redundant with Order Test's priority field. Phase 2 may add "escalate trigger priority" if a clear use case surfaces.
+    ];
+
+    // ========================================================================
+    // SEARCHABLE TEST + PANEL PICKER
+    // ========================================================================
+    function TestOrPanelPicker({ value, onChange, triggerSample }) {
+      // value: { kind: 'test'|'panel', id }
+      const [q, setQ] = useState('');
+      const [open, setOpen] = useState(false);
+      const [scope, setScope] = useState('same'); // 'same' or 'any'
+
+      const selected = value
+        ? (value.kind === 'panel'
+            ? PANELS.find(p => p.id === value.id)
+            : TEST_BY_ID[value.id])
+        : null;
+
+      const sampleFilter = (scope === 'same' && triggerSample) ? triggerSample : null;
+      const ql = q.toLowerCase();
+      const tests = TESTS.filter(t => {
+        if (sampleFilter && t.sample !== sampleFilter) return false;
+        if (t.type === 'reflex') return q ? (t.name + t.id).toLowerCase().includes(ql) : true; // include orderable reflex tests too
+        return q === '' || (t.name + ' ' + t.id + ' ' + (t.loinc || '')).toLowerCase().includes(ql);
+      });
+      const panels = PANELS.filter(p => {
+        if (sampleFilter && p.sample !== sampleFilter) return false;
+        return q === '' || (p.name + ' ' + p.tests.join(' ')).toLowerCase().includes(ql);
+      });
+      const totalMatches = tests.length + panels.length;
+
+      const pick = (kind, id) => {
+        onChange({ kind, id });
+        setQ('');
+        setOpen(false);
+      };
+
+      return (
+        <div className="tp-picker">
+          <div className="tp-input-wrap" onClick={() => setOpen(true)}>
+            {selected ? (
+              <span className="tp-selected">
+                <span className="kind">{value.kind === 'panel' ? 'panel' : 'test'}</span>
+                {selected.name} <span style={{ opacity: 0.6, fontWeight: 400 }}>({selected.id})</span>
+                <span className="clear" onClick={(e) => { e.stopPropagation(); onChange(null); setOpen(true); }}>✕</span>
+              </span>
+            ) : null}
+            <input className="tp-input"
+                   placeholder={selected ? 'Change…' : `Search tests and panels (${TESTS.length + PANELS.length} available)…`}
+                   value={q}
+                   onChange={e => { setQ(e.target.value); setOpen(true); }}
+                   onFocus={() => setOpen(true)}
+                   onBlur={() => setTimeout(() => setOpen(false), 200)} />
+          </div>
+          {open && (
+            <div className="tp-pop">
+              <div className="tp-scope">
+                <label>
+                  <input type="radio" checked={scope === 'same'} onChange={() => setScope('same')} />
+                  Same sample type{triggerSample ? ` (${triggerSample})` : ''} only
+                </label>
+                <label>
+                  <input type="radio" checked={scope === 'any'} onChange={() => setScope('any')} />
+                  All sample types
+                  <span className="warn-pill">requires new collection</span>
+                </label>
+              </div>
+              {scope === 'any' && (
+                <div className="tp-warn">
+                  ⚠ Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. The lab will need to collect a new specimen.
+                </div>
+              )}
+              {totalMatches === 0 && (
+                <div className="tp-empty">
+                  No matches. {scope === 'same' && triggerSample
+                    ? `Try "All sample types" — only ${triggerSample} tests/panels shown.`
+                    : 'Try a different search term.'}
+                </div>
+              )}
+              {tests.length > 0 && (
+                <>
+                  <div className="tp-section">Tests · {tests.length} matching</div>
+                  {tests.slice(0, 12).map(t => (
+                    <div key={t.id} className="tp-item" onMouseDown={() => pick('test', t.id)}>
+                      <span className="kind-chip">Test</span>
+                      <span className="label">
+                        <div className="name">{t.name}</div>
+                        <div className="meta">{t.id} · {t.loinc ? `LOINC ${t.loinc}` : t.type} {t.units ? '· ' + t.units : ''}</div>
+                      </span>
+                      <span className="sample-chip">{t.sample}</span>
+                    </div>
+                  ))}
+                  {tests.length > 12 && (
+                    <div className="tp-empty" style={{ padding: '6px', fontSize: 11 }}>
+                      …and {tests.length - 12} more. Refine your search.
+                    </div>
+                  )}
+                </>
+              )}
+              {panels.length > 0 && (
+                <>
+                  <div className="tp-section">Panels · {panels.length} matching</div>
+                  {panels.slice(0, 8).map(p => (
+                    <div key={p.id} className="tp-item" onMouseDown={() => pick('panel', p.id)}>
+                      <span className="kind-chip panel">Panel</span>
+                      <span className="label">
+                        <div className="name">{p.name}</div>
+                        <div className="meta">{p.tests.length} tests: {p.tests.join(', ')}</div>
+                      </span>
+                      <span className="sample-chip">{p.sample}</span>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function ActionRow({ action, onChange, onDelete, triggerSample }) {
+      const type = ACTION_TYPES.find(a => a.id === action.type) || ACTION_TYPES[0];
+      return (
+        <div className="action-row">
+          <select value={action.type} onChange={e => onChange({ ...action, type: e.target.value })}>
+            {ACTION_TYPES.map(a => <option key={a.id} value={a.id}>{a.label}</option>)}
+          </select>
+          <div className="a-fields">
+            {action.type === 'order' && (
+              <>
+                <UnifiedInputPicker
+                  mode="target"
+                  value={action.target}
+                  onChange={v => onChange({ ...action, target: v })}
+                  triggerSample={triggerSample} />
+                <select value={action.priority || 'routine'} onChange={e => onChange({ ...action, priority: e.target.value })}
+                        style={{ flex: '0 0 110px' }}>
+                  <option value="routine">Routine</option>
+                  <option value="stat">STAT</option>
+                  <option value="urgent">Urgent</option>
+                </select>
+                <input type="text" placeholder="Reason (visible on order)" value={action.reason || ''}
+                       onChange={e => onChange({ ...action, reason: e.target.value })}
+                       style={{ flex: '1 1 200px' }} />
+              </>
+            )}
+            {(action.type === 'note_int' || action.type === 'note_ext') && (
+              <input type="text" placeholder={action.type === 'note_int' ? 'Internal note (visible to lab staff)' : 'External note (visible to clinician)'}
+                     value={action.note || ''} onChange={e => onChange({ ...action, note: e.target.value })} />
+            )}
+            {action.type === 'alert' && (
+              <>
+                <select>
+                  <option>Critical Value Alert</option>
+                  <option>Reportable Disease (notify MOH)</option>
+                  <option>Provider Notification</option>
+                </select>
+                <input type="text" placeholder="Alert message" />
+              </>
+            )}
+          </div>
+          <button className="delete-btn" onClick={onDelete} title="Remove action">×</button>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // SAMPLE RULE DATA (with structured WHEN/THEN)
+    // ========================================================================
+    const RULES = [
+      {
+        id: 1, name: 'Thyroid panel reflex — TSH abnormal + FT4 < 0.7', status: 'active',
+        when: 'isOutsideNormal(TSH) AND lt(FT4, 0.7)',
+        whenSummary: [
+          { t:'pred', v:'isOutsideNormal' }, { t:'paren', v:'(' }, { t:'var', v:'TSH' }, { t:'paren', v:')' },
+          { t:'bool', v:'AND' },
+          { t:'pred', v:'lt' }, { t:'paren', v:'(' }, { t:'var', v:'FT4' }, { t:'paren', v:',' }, { t:'num', v:'0.7' }, { t:'paren', v:')' }
+        ],
+        actions: [
+          { type: 'order', target: { kind: 'panel', id: 'PANEL_THYRAB' }, priority: 'routine', reason: 'Thyroid antibody workup' },
+          { type: 'note_ext', note: 'Auto reflex per lab policy' },
+        ],
+        thenSummary: 'Order Thyroid Antibody Panel + external note',
+        edited: '2026-04-22 by m.kone',
+      },
+      {
+        id: 2, name: 'HIV Screen Reactive → confirmatory', status: 'active', cascadeGroup: 'HIV',
+        when: 'HIV_Screen == "Reactive"',
+        whenSummary: [
+          { t:'var', v:'HIV_Screen' }, { t:'op', v:'==' }, { t:'str', v:'"Reactive"' }
+        ],
+        actions: [
+          { type: 'order', test: 'HIV1_Conf', priority: 'routine', reason: 'Reactive screen — confirm by Western Blot' },
+          { type: 'note_ext', note: 'Screening result reactive. Confirmatory test ordered automatically per national algorithm.' }
+        ],
+        thenSummary: 'Order HIV-1 Confirmatory + external note',
+        edited: '2026-04-15 by p.diallo',
+      },
+      {
+        id: 3, name: 'HIV Screen Weak Reactive → repeat', status: 'active', cascadeGroup: 'HIV',
+        when: 'HIV_Screen == "Weak Reactive"',
+        whenSummary: [
+          { t:'var', v:'HIV_Screen' }, { t:'op', v:'==' }, { t:'str', v:'"Weak Reactive"' }
+        ],
+        actions: [
+          { type: 'order', test: 'HIV_Screen', priority: 'routine', reason: 'Equivocal — repeat in 2 weeks per national algorithm' },
+        ],
+        thenSummary: 'Repeat HIV Screen',
+        edited: '2026-04-15 by p.diallo',
+      },
+      {
+        id: 4, name: 'WBC critically high → manual differential', status: 'active',
+        when: 'isCriticallyHigh(WBC)',
+        whenSummary: [{ t:'pred', v:'isCriticallyHigh' }, { t:'paren', v:'(' }, { t:'var', v:'WBC' }, { t:'paren', v:')' }],
+        actions: [{ type: 'order', test: 'Diff', priority: 'routine', reason: 'WBC above critical high — manual review' }],
+        thenSummary: 'Order Manual WBC Differential',
+        edited: '2026-03-12 by m.kone',
+      },
+      {
+        id: 5, name: 'Urine dipstick positive → culture', status: 'active',
+        when: '(Nitrites == "Positive" OR Leuk IN ("++","+++"))',
+        whenSummary: [
+          { t:'paren', v:'(' }, { t:'var', v:'Nitrites' }, { t:'op', v:'==' }, { t:'str', v:'"Positive"' },
+          { t:'bool', v:'OR' }, { t:'var', v:'Leuk' }, { t:'bool', v:'IN' }, { t:'str', v:'("++","+++")' }, { t:'paren', v:')' }
+        ],
+        actions: [{ type: 'order', test: 'UC', reason: 'Dipstick suggests UTI — culture & sensitivity' }],
+        thenSummary: 'Order Urine Culture',
+        edited: '2026-02-28 by m.kone',
+      },
+      {
+        id: 6, name: 'Strep A positive → throat culture', status: 'disabled',
+        when: 'StrepA == "Positive" AND Age < 18',
+        whenSummary: [
+          { t:'var', v:'StrepA' }, { t:'op', v:'==' }, { t:'str', v:'"Positive"' },
+          { t:'bool', v:'AND' }, { t:'attr', v:'Age' }, { t:'op', v:'<' }, { t:'num', v:'18' }
+        ],
+        actions: [{ type: 'order', test: 'ThroatCx', reason: 'Pediatric — confirm with culture' }],
+        thenSummary: 'Order Throat Culture',
+        edited: '2025-12-10 by p.diallo',
+      },
+      {
+        id: 7, name: 'Critical glucose → alert + lactate', status: 'active',
+        when: 'isCritical(GLU)',
+        whenSummary: [{ t:'pred', v:'isCritical' }, { t:'paren', v:'(' }, { t:'var', v:'GLU' }, { t:'paren', v:')' }],
+        actions: [
+          { type: 'alert', alert: 'Critical Value Alert' },
+          { type: 'order', test: 'Lactate', priority: 'stat' }
+        ],
+        thenSummary: 'Critical alert + order STAT Lactate',
+        edited: '2026-04-05 by m.kone',
+      },
+      {
+        id: 8, name: 'Severe anemia → workup', status: 'active',
+        when: 'HGB < 7 AND Age > 18',
+        whenSummary: [{ t:'var', v:'HGB' }, { t:'op', v:'<' }, { t:'num', v:'7' }, { t:'bool', v:'AND' }, { t:'attr', v:'Age' }, { t:'op', v:'>' }, { t:'num', v:'18' }],
+        actions: [
+          { type: 'order', test: 'Retic' },
+          { type: 'panel', panel: 'Iron studies (Fe, TIBC, Ferritin, Transferrin)' }
+        ],
+        thenSummary: 'Order Reticulocyte + Iron panel',
+        edited: '2026-04-30 by m.kone',
+      },
+    ];
+
+    // Try to match a predicate call starting at index i.
+    // Returns { predId, testId, value, endIndex } or null.
+    function matchPredCall(tokens, i) {
+      let j = i;
+      if (tokens[j]?.kind !== 'pred') return null;
+      const predId = tokens[j].text; j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      if (!(tokens[j]?.kind === 'paren' && tokens[j].text === '(')) return null;
+      j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      if (tokens[j]?.kind !== 'var') return null;
+      const testId = tokens[j].text; j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      let value = null;
+      if (tokens[j]?.kind === 'paren' && tokens[j].text === ',') {
+        j++;
+        while (tokens[j]?.kind === 'ws') j++;
+        if (tokens[j]?.kind === 'num' || tokens[j]?.kind === 'str') {
+          value = tokens[j].text.replace(/^"|"$/g, '');
+          if (tokens[j].kind === 'num') value = +value;
+          j++;
+          while (tokens[j]?.kind === 'ws') j++;
+        }
+      }
+      if (!(tokens[j]?.kind === 'paren' && tokens[j].text === ')')) return null;
+      return { predId, testId, value, endIndex: j + 1 };
+    }
+
+    function FormulaSummary({ text }) {
+      const tokens = tokenize(text);
+      const out = [];
+      let i = 0;
+      while (i < tokens.length) {
+        const m = matchPredCall(tokens, i);
+        if (m) {
+          const p = PREDICATES.find(p => p.id === m.predId);
+          const t = TEST_BY_ID[m.testId];
+          if (p) {
+            const suffix = p.valueInput
+              ? (m.value != null ? ` ${m.value}${t?.units ? ' ' + t.units : ''}` : ' …')
+              : '';
+            out.push(
+              <span key={i} className="phrase">
+                <strong>{m.testId}</strong> <em>{p.short}{suffix}</em>
+              </span>
+            );
+            i = m.endIndex;
+            continue;
+          }
+        }
+        const tok = tokens[i];
+        out.push(<span key={i} className={tok.kind === 'ws' ? '' : `tok-${tok.kind}`}>{tok.text}</span>);
+        i++;
+      }
+      return <span className="rule-summary">{out}</span>;
+    }
+
+    function RuleSummary({ when, thenSummary }) {
+      return (
+        <div className="rule-when-then">
+          <span className="label w">WHEN</span>
+          <FormulaSummary text={when} />
+          <span className="arrow">→</span>
+          <span className="label t">THEN</span>
+          <span className="then" style={{ color: '#0e6027' }}>{thenSummary}</span>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // SIMULATOR — see if rule fires given sample inputs
+    // ========================================================================
+    function TSHSimulator() {
+      const [tsh, setTsh] = useState(8.4);
+      const [ft4, setFt4] = useState(0.5);
+      const tshRange = TEST_BY_ID.TSH.refRange;
+      const ft4Threshold = 0.7;  // matches the specific-value cutoff in the default rule
+      const tshOutside = tsh < tshRange[0] || tsh > tshRange[1];
+      const ft4Low = ft4 < ft4Threshold;
+      const fires = tshOutside && ft4Low;
+      return (
+        <div>
+          <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+            Enter results for both tests. The rule mixes a catalog-based condition (TSH outside normal) with a specific-value condition (FT4 &lt; {ft4Threshold}).
+          </span>
+          <div className="sim-row">
+            <label>TSH</label>
+            <input type="number" step="0.1" value={tsh} onChange={e => setTsh(+e.target.value || 0)} />
+            <span style={{ flex: '0 0 60px', fontSize: 12, color: '#6f6f6f' }}>µIU/mL</span>
+          </div>
+          <div style={{ fontSize: 11, color: tshOutside ? '#a2191f' : '#0e6027', marginLeft: 160, marginTop: -4, marginBottom: 6 }}>
+            {tshOutside ? `↳ outside normal (catalog range ${tshRange[0]}–${tshRange[1]})` : `↳ normal (catalog range ${tshRange[0]}–${tshRange[1]})`}
+          </div>
+          <div className="sim-row">
+            <label>Free T4 (FT4)</label>
+            <input type="number" step="0.1" value={ft4} onChange={e => setFt4(+e.target.value || 0)} />
+            <span style={{ flex: '0 0 60px', fontSize: 12, color: '#6f6f6f' }}>ng/dL</span>
+          </div>
+          <div style={{ fontSize: 11, color: ft4Low ? '#a2191f' : '#0e6027', marginLeft: 160, marginTop: -4, marginBottom: 6 }}>
+            {ft4Low ? `↳ less than ${ft4Threshold} (specific-value condition)` : `↳ at or above ${ft4Threshold} (specific-value condition)`}
+          </div>
+          <div className={'sim-result ' + (fires ? 'fires' : 'idle')}>
+            <div className="head">{fires ? '✓ Rule fires' : '◯ Rule does not fire'}</div>
+            <div className="body">
+              {fires
+                ? <>
+                    Both conditions are true — <strong>TSH is outside the normal range</strong> AND <strong>Free T4 is less than {ft4Threshold}</strong>.
+                    <div className="action-line" style={{ marginTop: 6 }}>
+                      → <span className="action-tag order">Order Test</span> Thyroid antibody panel
+                    </div>
+                  </>
+                : <>
+                    <div style={{ marginBottom: 4 }}>TSH is outside normal: <strong>{tshOutside ? 'Yes' : 'No'}</strong></div>
+                    <div style={{ marginBottom: 4 }}>Free T4 is less than {ft4Threshold}: <strong>{ft4Low ? 'Yes' : 'No'}</strong></div>
+                    <div style={{ color: '#6f6f6f' }}>The rule needs both to be Yes to fire.</div>
+                  </>
+              }
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function HIVSimulator() {
+      const [result, setResult] = useState('Reactive');
+      const fires1 = result === 'Reactive';
+      const fires2 = result === 'Weak Reactive';
+      return (
+        <div>
+          <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+            Pick a screen result. The simulator runs <strong>all</strong> rules in the HIV cascade to show which fires.
+          </span>
+          <div className="sim-row">
+            <label>HIV Screen result</label>
+            <select value={result} onChange={e => setResult(e.target.value)}>
+              <option>Reactive</option>
+              <option>Weak Reactive</option>
+              <option>Non-Reactive</option>
+            </select>
+            <span style={{ flex: '0 0 60px' }}></span>
+          </div>
+          <div className={'sim-result ' + (fires1 ? 'fires' : 'idle')}>
+            <div className="head">Rule #2 · Reactive → Confirmatory</div>
+            <div className="body">
+              {fires1
+                ? <>
+                    <div className="action-line">→ <span className="action-tag order">Order Test</span> HIV-1 Confirmatory (WB)</div>
+                    <div className="action-line">→ <span className="action-tag note">External Note</span> "Screening result reactive…"</div>
+                  </>
+                : '— not fired'}
+            </div>
+          </div>
+          <div className={'sim-result ' + (fires2 ? 'fires' : 'idle')}>
+            <div className="head">Rule #3 · Weak Reactive → Repeat Screen</div>
+            <div className="body">
+              {fires2
+                ? <div className="action-line">→ <span className="action-tag order">Order Test</span> HIV Screen (repeat)</div>
+                : '— not fired'}
+            </div>
+          </div>
+          {result === 'Non-Reactive' && (
+            <div className="sim-result idle">
+              <div className="head">No rules fire</div>
+              <div className="body">Non-reactive — no further testing. This is the expected terminal state for this cascade.</div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // ANALYZER PARAMETERS — attach to a few tests for the demo
+    // ========================================================================
+    // Inject analyzer parameters onto existing test catalog entries.
+    // In a real implementation these come from the Test Catalog editor sourced
+    // via the existing QC table linkage.
+    TESTS.find(t => t.id === 'WBC').analyzerParameters = [
+      { id: 'blasts',     name: 'Blasts suspected',           type: 'coded',   values: ['Yes','No'] },
+      { id: 'atyplymph',  name: 'Atypical lymphs suspected',  type: 'coded',   values: ['Yes','No'] },
+      { id: 'nRBC',       name: 'Nucleated RBC count',        type: 'numeric', units: '/100 WBC', refRange: [0, 0] },
+    ];
+    TESTS.find(t => t.id === 'GLU').analyzerParameters = [
+      { id: 'sampleHemolyzed', name: 'Sample hemolyzed flag', type: 'coded', values: ['Yes','No'] },
+      { id: 'sampleIcteric',   name: 'Sample icteric flag',   type: 'coded', values: ['Yes','No'] },
+    ];
+    // Rebuild TEST_BY_ID index in case anyone needs analyzer params from it
+    Object.assign(TEST_BY_ID, Object.fromEntries(TESTS.map(t => [t.id, t])));
+
+    function inputMeta(testId, paramId) {
+      const t = TEST_BY_ID[testId]; if (!t) return null;
+      if (paramId) return (t.analyzerParameters || []).find(p => p.id === paramId);
+      return t;
+    }
+
+    // ========================================================================
+    // UNIFIED INPUT PICKER — used for both condition inputs and action targets
+    // Modes:
+    //   'input'  — search test results + analyzer parameters (for conditions)
+    //   'target' — search test results + panels (for Order actions); sample filter
+    // ========================================================================
+    function UnifiedInputPicker({ value, onChange, mode, triggerSample, error }) {
+      const [open, setOpen] = useState(false);
+      const [q, setQ] = useState('');
+      const [scope, setScope] = useState('same'); // 'same' | 'any', only used in target mode
+      const triggerRef = React.useRef(null);
+
+      // Close on Escape; restore focus to trigger
+      React.useEffect(() => {
+        if (!open) return;
+        const onKey = (e) => {
+          if (e.key === 'Escape') {
+            setOpen(false);
+            triggerRef.current?.focus();
+          }
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+      }, [open]);
+
+      // Sync default scope to trigger sample on first open
+      React.useEffect(() => {
+        if (open && mode === 'target') setScope('same');
+      }, [open, mode]);
+
+      // Build candidates
+      const candidates = [];
+      if (mode === 'input') {
+        TESTS.forEach(t => {
+          if (t.type === 'reflex') return; // reflex-only tests (orderable, not result-producing) excluded from conditions
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded · ' + t.values.length + ' values' : (t.units || 'numeric')}${t.sample ? ' · sample: ' + t.sample : ''}`,
+            sample: t.sample,
+          });
+          (t.analyzerParameters || []).forEach(p => {
+            candidates.push({
+              kind: 'param', testId: t.id, paramId: p.id,
+              humanName: p.name,
+              parentName: t.name,
+              techId: `${t.id}.${p.id}`,
+              meta: `${p.type === 'coded' ? 'coded · ' + p.values.join(' / ') : (p.units || 'numeric')}${p.refRange ? ' · range ' + p.refRange[0] + '–' + p.refRange[1] : ''}`,
+              sample: t.sample,
+            });
+          });
+        });
+      } else {
+        // target mode — tests (incl. orderable reflex) + panels
+        TESTS.forEach(t => {
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded' : (t.units || t.type)}`,
+            sample: t.sample,
+          });
+        });
+        PANELS.forEach(p => {
+          candidates.push({
+            kind: 'panel', panelId: p.id,
+            humanName: p.name,
+            techId: p.id,
+            meta: `${p.tests.length} tests: ${p.tests.slice(0, 5).join(', ')}${p.tests.length > 5 ? ', …' : ''}`,
+            sample: p.sample,
+          });
+        });
+      }
+
+      const filterSample = (mode === 'target' && scope === 'same' && triggerSample) ? triggerSample : null;
+      const filtered = candidates.filter(c => {
+        if (filterSample && c.sample !== filterSample) return false;
+        return q === '' ||
+          (c.humanName + ' ' + (c.parentName || '') + ' ' + c.techId + ' ' + c.meta).toLowerCase().includes(q.toLowerCase());
+      });
+
+      const selected = value
+        ? (value.kind === 'panel'
+            ? PANELS.find(p => p.id === value.id)
+            : (value.paramId ? inputMeta(value.testId, value.paramId) : TEST_BY_ID[value.testId]))
+        : null;
+      const selectedKind = value?.kind || (value?.paramId ? 'param' : 'result');
+      const selectedTechId = value
+        ? (value.kind === 'panel' ? value.id
+           : value.paramId ? `${value.testId}.${value.paramId}` : value.testId)
+        : null;
+
+      const pick = (c) => {
+        if (c.kind === 'panel') onChange({ kind: 'panel', id: c.panelId });
+        else if (c.kind === 'param') onChange({ kind: 'result', testId: c.testId, paramId: c.paramId });
+        else onChange({ kind: 'result', testId: c.testId });
+        setQ(''); setOpen(false);
+        setTimeout(() => triggerRef.current?.focus(), 0);
+      };
+
+      // Split filtered by kind for sectioning
+      const tests   = filtered.filter(c => c.kind === 'result');
+      const params  = filtered.filter(c => c.kind === 'param');
+      const panels  = filtered.filter(c => c.kind === 'panel');
+
+      const tests_results_sectionTitle = mode === 'input' ? 'Test results' : 'Tests';
+
+      return (
+        <div className="ip-wrap">
+          <button ref={triggerRef} type="button"
+                  className={'ip-trigger' + (value ? '' : ' empty') + (error ? ' error' : '')}
+                  aria-haspopup="listbox" aria-expanded={open}
+                  onClick={() => setOpen(o => !o)}
+                  title={value ? `${selected?.name || selectedTechId} (${selectedTechId})` : 'Pick…'}>
+            {value && (
+              <span className={'ip-kind ' + selectedKind}>{selectedKind === 'param' ? 'param' : selectedKind === 'panel' ? 'panel' : 'result'}</span>
+            )}
+            <span className="ip-label">{selected?.name || (mode === 'input' ? 'Pick test or parameter…' : 'Pick test or panel…')}</span>
+            {value && <span className="ip-sub">{selectedTechId}</span>}
+            {value && (
+              <span className="clear-btn" role="button" aria-label="Clear selection"
+                    onClick={(e) => { e.stopPropagation(); onChange(null); }}>×</span>
+            )}
+            <span className="caret">{open ? '▴' : '▾'}</span>
+          </button>
+          {open && (
+            <>
+              <div style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+                   onClick={() => setOpen(false)} aria-hidden="true" />
+              <div className="ip-pop" role="listbox">
+                <input type="text" className="ip-pop-search" autoFocus
+                       placeholder={mode === 'input'
+                         ? 'Search test name, parameter, LOINC, units…'
+                         : 'Search tests and panels…'}
+                       value={q} onChange={e => setQ(e.target.value)} />
+                {mode === 'target' && (
+                  <div className="ip-pop-scope">
+                    <label><input type="radio" checked={scope === 'same'} onChange={() => setScope('same')} />
+                      Same sample type{triggerSample ? ` (${triggerSample})` : ''} only</label>
+                    <label><input type="radio" checked={scope === 'any'} onChange={() => setScope('any')} />
+                      All sample types <span className="warn-pill">requires new collection</span></label>
+                  </div>
+                )}
+                {mode === 'target' && scope === 'any' && (
+                  <div className="ip-pop-warn">
+                    ⚠ Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. Lab will need to collect a new specimen.
+                  </div>
+                )}
+                <div className="ip-pop-list">
+                  {filtered.length === 0 && <div className="ip-pop-empty">No matches.</div>}
+                  {tests.length > 0 && (
+                    <>
+                      <div className="ip-section">{tests_results_sectionTitle} · {tests.length} matching</div>
+                      {tests.slice(0, 10).map((c, i) => (
+                        <button key={'r' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind result">{mode === 'input' ? 'result' : 'test'}</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name"><strong>{c.humanName}</strong></div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {params.length > 0 && (
+                    <>
+                      <div className="ip-section">Analyzer parameters · {params.length} matching</div>
+                      {params.slice(0, 10).map((c, i) => (
+                        <button key={'p' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind param">param</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name">
+                              <span style={{ color: '#6f6f6f' }}>{c.parentName} →</span> <strong>{c.humanName}</strong>
+                            </div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {panels.length > 0 && (
+                    <>
+                      <div className="ip-section">Panels · {panels.length} matching</div>
+                      {panels.slice(0, 8).map((c, i) => (
+                        <button key={'pa' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind panel">panel</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name"><strong>{c.humanName}</strong></div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {tests.length > 10 && (
+                    <div className="ip-pop-more">…and {tests.length - 10} more tests. Refine your search.</div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // COMPOSE MODE — row-list view of a compound WHEN clause
+    // ========================================================================
+    function ComposeRowValueInput({ test, predDef, value, onChange }) {
+      if (!predDef || !predDef.valueInput) return null;
+      const inputStyle = { padding: '4px 8px', fontSize: 13, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', minWidth: 80 };
+      if (predDef.valueInput === 'number') {
+        return (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <input type="number" step="any" placeholder="value"
+                   value={value ?? ''} onChange={e => onChange(e.target.value === '' ? null : +e.target.value)}
+                   style={inputStyle} />
+            {test.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{test.units}</span>}
+          </span>
+        );
+      }
+      if (predDef.valueInput === 'range') {
+        const v = value || [null, null];
+        return (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <input type="number" step="any" placeholder="low" value={v[0] ?? ''}
+                   onChange={e => onChange([e.target.value === '' ? null : +e.target.value, v[1]])}
+                   style={{ ...inputStyle, width: 70, minWidth: 70 }} />
+            <span style={{ fontSize: 11, color: '#525252' }}>and</span>
+            <input type="number" step="any" placeholder="high" value={v[1] ?? ''}
+                   onChange={e => onChange([v[0], e.target.value === '' ? null : +e.target.value])}
+                   style={{ ...inputStyle, width: 70, minWidth: 70 }} />
+            {test.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{test.units}</span>}
+          </span>
+        );
+      }
+      if (predDef.valueInput === 'coded') {
+        return (
+          <select value={value ?? ''} onChange={e => onChange(e.target.value || null)} style={inputStyle}>
+            <option value="">— pick value —</option>
+            {test.values.map(v => <option key={v} value={v}>{v}</option>)}
+          </select>
+        );
+      }
+      if (predDef.valueInput === 'codedMulti') {
+        const selected = value || [];
+        return (
+          <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 4, alignItems: 'center' }}>
+            {test.values.map(v => (
+              <label key={v} style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 3, cursor: 'pointer' }}>
+                <input type="checkbox"
+                       checked={selected.includes(v)}
+                       onChange={e => {
+                         const next = e.target.checked
+                           ? [...selected, v]
+                           : selected.filter(x => x !== v);
+                         onChange(next);
+                       }} />
+                {v}
+              </label>
+            ))}
+          </span>
+        );
+      }
+      return null;
+    }
+
+    function ComposeBuilder({ rows, joiners, onChange }) {
+      // rows: [{ input: { kind:'result', testId, paramId? } | null, pred, value }, ...]
+      const setRow = (i, patch) => onChange(rows.map((r, idx) => idx === i ? { ...r, ...patch } : r), joiners);
+      const setJoiner = (i, val) => onChange(rows, joiners.map((j, idx) => idx === i ? val : j));
+      const addRow = () => onChange([...rows, { input: null, pred: '', value: null }], [...joiners, 'AND']);
+      const removeRow = (i) => onChange(rows.filter((_, idx) => idx !== i), joiners.filter((_, idx) => idx !== i));
+      return (
+        <div className="compose-block">
+          {rows.map((r, i) => {
+            const meta = r.input ? inputMeta(r.input.testId, r.input.paramId) : null;
+            const predDef = r.pred ? PREDICATES.find(p => p.id === r.pred) : null;
+            return (
+              <div key={i} className="compose-row">
+                {i === 0
+                  ? <span className="joiner first">WHEN</span>
+                  : <select className="joiner" aria-label="Join with previous condition"
+                            value={joiners[i] || 'AND'} onChange={e => setJoiner(i, e.target.value)}>
+                      <option>AND</option><option>OR</option>
+                    </select>}
+                <UnifiedInputPicker
+                  mode="input"
+                  value={r.input}
+                  onChange={v => setRow(i, { input: v, pred: '', value: null })}
+                />
+                <div className="pred-pick">
+                  {meta ? (
+                    <>
+                      <select value={r.pred}
+                              aria-label="Question to ask about the input"
+                              onChange={e => setRow(i, { pred: e.target.value, value: null })}>
+                        <option value="">— pick a question —</option>
+                        {PREDICATE_GROUPS.map(g => {
+                          const groupPreds = PREDICATES.filter(p => p.group === g.id);
+                          return (
+                            <optgroup key={g.id} label={g.label}>
+                              {groupPreds.map(p => {
+                                const available = predicateAvailable(p, meta);
+                                const reason = REQUIREMENT_REASONS[p.requires] || 'compatible input';
+                                return (
+                                  <option key={p.id} value={p.id} disabled={!available}>
+                                    {p.label}{!available ? ` — needs ${reason}` : ''}
+                                  </option>
+                                );
+                              })}
+                            </optgroup>
+                          );
+                        })}
+                      </select>
+                      <ComposeRowValueInput test={meta} predDef={predDef} value={r.value}
+                                            onChange={v => setRow(i, { value: v })} />
+                    </>
+                  ) : (
+                    <span style={{ fontSize: 11, color: '#a8a8a8', fontStyle: 'italic' }}>
+                      Pick an input first to see questions you can ask
+                    </span>
+                  )}
+                </div>
+                <button className="delete" onClick={() => removeRow(i)} aria-label="Remove this condition">×</button>
+              </div>
+            );
+          })}
+          <button className="cds--btn cds--btn--ghost add-cta" onClick={addRow}
+                  aria-label="Add another condition">
+            <span className="plus">+</span>
+            <span>Add another condition</span>
+            <span className="hint">join with AND or OR</span>
+          </button>
+        </div>
+      );
+    }
+
+    // Compile compose-row state to a formula string
+    function rowsToFormula(rows, joiners) {
+      const parts = [];
+      rows.forEach((r, i) => {
+        if (i > 0) parts.push(joiners[i] || 'AND');
+        if (!(r.input && r.pred)) { parts.push('_'); return; }
+        const tid = r.input.paramId ? `${r.input.testId}.${r.input.paramId}` : r.input.testId;
+        const p = PREDICATES.find(p => p.id === r.pred);
+        if (p && p.valueInput) {
+          let v;
+          if (p.valueInput === 'range') v = `[${(r.value || [])[0] ?? '?'},${(r.value || [])[1] ?? '?'}]`;
+          else if (p.valueInput === 'codedMulti') v = `[${(r.value || []).map(x => '"' + x + '"').join(',')}]`;
+          else if (p.valueInput === 'coded') v = `"${r.value ?? ''}"`;
+          else v = r.value ?? '?';
+          parts.push(`${r.pred}(${tid}, ${v})`);
+        } else {
+          parts.push(`${r.pred}(${tid})`);
+        }
+      });
+      return parts.join(' ');
+    }
+
+    // ========================================================================
+    // TSH/FT4 COMPOUND EDITOR — demonstrates compound predicates
+    // ========================================================================
+    function TSHEditor() {
+      const [mode, setMode] = useState('compose');
+      const [showTechnical, setShowTechnical] = useState(false);
+      const [rows, setRows] = useState([
+        { input: { kind: 'result', testId: 'TSH' }, pred: 'isOutsideNormal',  value: null },
+        { input: { kind: 'result', testId: 'FT4' }, pred: 'lt',               value: 0.7 },
+      ]);
+      const [joiners, setJoiners] = useState([null, 'AND']);
+      const when = rowsToFormula(rows, joiners);
+      const setComposeState = (newRows, newJoiners) => {
+        setRows(newRows); setJoiners(newJoiners);
+      };
+      const setWhen = (v) => { /* formula-bar typed input — would parse back to rows in a real impl */ };
+      // Collect distinct tests referenced for the Predicate Index
+      const referencedTests = [...new Set(rows.map(r => r.input?.testId).filter(Boolean))];
+
+      const [triggerSample, setTriggerSample] = useState('Serum');
+      const [catalogOpen, setCatalogOpen] = useState(false);
+      const [simulatorOpen, setSimulatorOpen] = useState(true);
+      // Save states — for demo: idle | saving | error
+      const [saveState, setSaveState] = useState('idle');
+      const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+      const [actions, setActions] = useState([
+        { type: 'order', target: { kind: 'panel', id: 'PANEL_THYRAB' }, priority: 'routine', reason: 'TSH + FT4 both abnormal — reflex thyroid antibody workup' },
+        { type: 'note_ext', note: 'TSH and Free T4 are both outside the normal range. Thyroid antibody panel ordered automatically per lab reflex policy.' },
+      ]);
+      const updateAction = (i, a) => setActions(arr => arr.map((x, idx) => idx === i ? a : x));
+      const deleteAction = (i) => setActions(arr => arr.filter((_, idx) => idx !== i));
+      const addAction = () => setActions(arr => [...arr, { type: 'order', test: '' }]);
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Triggers on: TSH or FT4 (Serum)</span>
+                <span className="cds--tag cds--tag--teal">2 conditions (AND)</span>
+                <span className="cds--tag cds--tag--purple">{actions.length} action{actions.length !== 1 ? 's' : ''}</span>
+              </div>
+
+              <div className="editor-stack">
+
+                {/* TOP — Test catalog data (collapsible, default closed) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (catalogOpen ? '' : ' collapsed')}
+                          aria-expanded={catalogOpen}
+                          onClick={() => setCatalogOpen(o => !o)}>
+                    <span className="caret">{catalogOpen ? '▾' : '▸'}</span>
+                    <span className="col-title">Test catalog data</span>
+                    <span className="col-summary">
+                      {referencedTests.length > 0
+                        ? `${referencedTests.map(id => TEST_BY_ID[id]?.name || id).join(', ')} · ranges and thresholds defined in the catalog`
+                        : 'Pick a test in the rule to see its catalog metadata'}
+                    </span>
+                    <span className="pill gray">Reference</span>
+                  </button>
+                  {catalogOpen && (
+                    <div className="collapsible-body">
+                      <div className="compact-hint" style={{ marginBottom: 8 }}>
+                        What's defined in the Test Catalog for each test in this rule. Questions in
+                        the Compose picker are enabled based on this metadata — set ranges or
+                        thresholds here to unlock more questions.
+                      </div>
+                      <TestCatalogRef
+                        testIds={referencedTests.length > 0 ? referencedTests : ['TSH']} />
+                    </div>
+                  )}
+                </div>
+
+                {/* MIDDLE — Rule definition (full width) */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">WHEN / THEN</span> <span className="pill" style={{ background: '#cfeaff', color: '#0072c3' }}>Compound</span></h4>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      <div style={{ flex: 2 }}>
+                        <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                        <input type="text" defaultValue="Thyroid panel reflex — TSH + FT4 both abnormal"
+                               style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                      </div>
+                      <div style={{ flex: 1 }}>
+                        <label style={{ fontSize: 12, color: '#525252' }}>Trigger sample</label>
+                        <select value={triggerSample} onChange={e => setTriggerSample(e.target.value)}
+                                style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }}>
+                          <option>Serum</option><option>Plasma</option><option>Whole Blood</option>
+                          <option>EDTA Tube</option><option>Urines</option>
+                          <option>Any sample type</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 6 }}>
+                      <div className="block-label when" style={{ marginBottom: 0 }}>WHEN</div>
+                      <div className="mode-tabs">
+                        <button className={mode === 'compose' ? 'active' : ''} onClick={() => setMode('compose')}>Build it</button>
+                        <button className={mode === 'formula' ? 'active' : ''} onClick={() => setMode('formula')}>Type it</button>
+                      </div>
+                      <span style={{ marginLeft: 'auto', fontSize: 11, color: '#6f6f6f' }}>
+                        Same rule. Both views save the same way.
+                      </span>
+                    </div>
+
+                    {/* Plain-English rule preview, always visible */}
+                    <div style={{
+                      background: '#f4f9ff', borderLeft: '3px solid #0f62fe',
+                      padding: '0.5rem 0.75rem', marginBottom: 8, fontSize: 14, color: '#161616'
+                    }}>
+                      <span style={{ fontSize: 10, color: '#0043ce', fontWeight: 700, letterSpacing: 0.5 }}>RULE READS AS</span>
+                      <div style={{ marginTop: 4 }}>
+                        Reflex the thyroid antibody panel when{' '}
+                        {rows.map((r, i) => (
+                          <React.Fragment key={i}>
+                            {i > 0 && <strong style={{ color: '#0043ce' }}> {joiners[i] || 'AND'} </strong>}
+                            <strong>{predicatePhrase(r.input, r.pred, r.value) || '…'}</strong>
+                          </React.Fragment>
+                        ))}.
+                      </div>
+                    </div>
+
+                    {mode === 'compose'
+                      ? <ComposeBuilder rows={rows} joiners={joiners} onChange={setComposeState} />
+                      : <ConditionBar value={when} onChange={setWhen} />}
+
+                    {/* Technical form — hidden by default */}
+                    <div style={{ marginTop: 6 }}>
+                      <button onClick={() => setShowTechnical(s => !s)}
+                              style={{ background: 'none', border: 'none', color: '#0f62fe', cursor: 'pointer', fontSize: 11, padding: 0 }}>
+                        {showTechnical ? '▾ Hide technical form' : '▸ Show technical form (for developers / DMN export)'}
+                      </button>
+                      {showTechnical && (
+                        <div style={{ marginTop: 6, background: '#f4f4f4', padding: '0.5rem 0.75rem', fontSize: 12 }}>
+                          <div style={{ fontSize: 10, color: '#525252', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>
+                            Stored AST (semantic form)
+                          </div>
+                          <code style={{ fontSize: 12 }}><FormulaSummary text={when} /></code>
+                          <div style={{ fontSize: 10, color: '#525252', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 8, marginBottom: 4 }}>
+                            Compiled (semantic predicates expand to numeric expressions; specific-value predicates stay as-is)
+                          </div>
+                          <code style={{ fontSize: 12, color: '#525252' }}>
+                            {(() => {
+                              const parts = rows.map(r => {
+                                const p = PREDICATES.find(p => p.id === r.pred);
+                                if (!p) return '_';
+                                const inp = r.input || {};
+                                const tid = inp.paramId ? `${inp.testId}.${inp.paramId}` : (inp.testId || '_');
+                                const meta = inp.testId ? (inp.paramId ? (TEST_BY_ID[inp.testId]?.analyzerParameters || []).find(x => x.id === inp.paramId) || {} : TEST_BY_ID[inp.testId] || {}) : {};
+                                if (p.valueInput) return p.desugar(tid, meta, r.value);
+                                return p.desugar(tid, meta);
+                              });
+                              const out = [];
+                              parts.forEach((p, i) => {
+                                if (i > 0) out.push(` ${joiners[i] || 'AND'} `);
+                                out.push(`(${p})`);
+                              });
+                              return out.join('');
+                            })()}
+                          </code>
+                          <div style={{ fontSize: 11, color: '#6f6f6f', marginTop: 6, fontStyle: 'italic' }}>
+                            The semantic form (top) is what's stored — when reference ranges change in the Test Catalog, the compiled form (bottom) updates automatically.
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 6 }}>
+                      <div className="block-label then" style={{ marginBottom: 0 }}>THEN do all of the following</div>
+                      <span style={{ marginLeft: 'auto', fontSize: 11, color: '#6f6f6f' }}>
+                        {actions.length} action{actions.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                    {actions.map((a, i) => (
+                      <ActionRow key={i} action={a} triggerSample={triggerSample}
+                                 onChange={(na) => updateAction(i, na)} onDelete={() => deleteAction(i)} />
+                    ))}
+                    <button className="add-cta" onClick={addAction}>
+                      <span className="plus">+</span>
+                      <span>Add another action</span>
+                      <span className="hint">Order test · Order panel · Note · Set priority · Send alert</span>
+                    </button>
+                  </div>
+                </div>
+
+                {/* BOTTOM — Simulator (collapsible, default open) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (simulatorOpen ? '' : ' collapsed')}
+                          aria-expanded={simulatorOpen}
+                          onClick={() => setSimulatorOpen(o => !o)}>
+                    <span className="caret">{simulatorOpen ? '▾' : '▸'}</span>
+                    <span className="col-title">Simulator</span>
+                    <span className="col-summary">
+                      Test the rule against hypothetical TSH and Free T4 inputs.
+                    </span>
+                    <span className="pill green">Sandbox</span>
+                  </button>
+                  {simulatorOpen && (
+                    <div className="collapsible-body">
+                      <TSHSimulator />
+                    </div>
+                  )}
+                </div>
+
+              </div>
+
+              {/* Save state visualizations — toggle via the demo buttons below */}
+              {saveState === 'error' && (
+                <div className="save-error" role="alert">
+                  <div className="title">⚠ Couldn't save this rule — please fix the issues below:</div>
+                  <ul>
+                    <li>Condition 2: predicate is incomplete (FT4 is less than … needs a numeric value)</li>
+                    <li>Cross-sample reflex requires an audit reason (action 1 orders a Whole Blood test from a Serum trigger).</li>
+                  </ul>
+                </div>
+              )}
+
+              <div className="footer-actions">
+                {/* Demo controls — let reviewers see all states */}
+                <span style={{ fontSize: 11, color: '#6f6f6f', alignSelf: 'center', marginRight: 'auto' }}>
+                  Demo:
+                  <button onClick={() => setSaveState('idle')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'idle' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>idle</button> ·
+                  <button onClick={() => setSaveState('saving')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'saving' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>saving</button> ·
+                  <button onClick={() => setSaveState('error')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'error' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>save-failed</button>
+                </span>
+                <button className="cds--btn cds--btn--ghost" onClick={() => setShowDisableConfirm(true)}>Disable rule</button>
+                <button className="cds--btn cds--btn--ghost" disabled={saveState === 'saving'}>Cancel</button>
+                <button className="cds--btn cds--btn--primary" disabled={saveState === 'saving'}
+                        aria-busy={saveState === 'saving'}>
+                  {saveState === 'saving' ? 'Saving…' : 'Save changes'}
+                </button>
+              </div>
+            </div>
+
+            {showDisableConfirm && (
+              <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="confirm-title"
+                   onClick={(e) => { if (e.target === e.currentTarget) setShowDisableConfirm(false); }}>
+                <div className="modal-panel">
+                  <div className="modal-head">
+                    <div className="modal-title" id="confirm-title">Disable this rule?</div>
+                  </div>
+                  <div className="modal-body">
+                    <p style={{ margin: 0 }}>
+                      <strong>Thyroid panel reflex — TSH abnormal + FT4 &lt; 0.7</strong> will stop firing immediately on save.
+                      Existing reflex orders already created by this rule are not affected.
+                    </p>
+                    <p style={{ marginTop: 12, fontSize: 12, color: '#525252' }}>
+                      The rule remains visible in the list as <em>Disabled</em>. You can re-enable it from the row's overflow menu at any time.
+                    </p>
+                  </div>
+                  <div className="modal-foot">
+                    <button className="cds--btn cds--btn--secondary" onClick={() => setShowDisableConfirm(false)}>Cancel</button>
+                    <button className="cds--btn cds--btn--danger" onClick={() => setShowDisableConfirm(false)}>Disable rule</button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // HIV CASCADE EDITOR — decision table mode
+    // ========================================================================
+    function HIVCascadeEditor() {
+      const [mode, setMode] = useState('table');
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Trigger: HIV Screen (Whole Blood)</span>
+                <span className="cds--tag cds--tag--purple">Cascade · 2 rules</span>
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem' }}>
+                <span style={{ fontSize: 13, color: '#525252' }}>
+                  Two rules share <strong>HIV_Screen</strong> as their trigger. View as:
+                </span>
+                <div className="mode-toggle">
+                  <button className={mode === 'individual' ? 'active' : ''} onClick={() => setMode('individual')}>Individual rules</button>
+                  <button className={mode === 'table' ? 'active' : ''} onClick={() => setMode('table')}>Decision table</button>
+                </div>
+              </div>
+
+              {mode === 'table' && (
+                <div className="panel" style={{ padding: '1rem' }}>
+                  <h4>HIV Screen decision table <span className="pill">Compact view</span></h4>
+                  <p className="compact-hint" style={{ marginBottom: '0.75rem' }}>
+                    Each row is a rule. Authoring multiple rules with the same trigger as a table makes the cascade easier to read than three separate forms.
+                  </p>
+                  <table className="decision-table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: 40 }}>#</th>
+                        <th className="col-header-when">When HIV_Screen equals…</th>
+                        <th className="col-header-then">Order test</th>
+                        <th className="col-header-then">Priority</th>
+                        <th className="col-header-then">External note</th>
+                        <th style={{ width: 40 }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>1</td>
+                        <td className="dt-cell"><span className="tok-str">"Reactive"</span></td>
+                        <td className="dt-cell"><span className="tok-var">HIV1_Conf</span> <span style={{ color: '#6f6f6f' }}>(Confirmatory WB)</span></td>
+                        <td className="dt-cell">Routine</td>
+                        <td className="dt-cell" style={{ fontFamily: 'inherit', fontSize: 12 }}>
+                          "Reactive — confirm with WB per national algorithm"
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      <tr>
+                        <td>2</td>
+                        <td className="dt-cell"><span className="tok-str">"Weak Reactive"</span></td>
+                        <td className="dt-cell"><span className="tok-var">HIV_Screen</span> <span style={{ color: '#6f6f6f' }}>(repeat)</span></td>
+                        <td className="dt-cell">Routine</td>
+                        <td className="dt-cell" style={{ fontFamily: 'inherit', fontSize: 12 }}>
+                          "Equivocal — repeat in 2 weeks"
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      <tr style={{ background: '#fafafa' }}>
+                        <td>3</td>
+                        <td className="dt-cell"><span className="tok-str">"Non-Reactive"</span></td>
+                        <td colSpan={3} className="dt-cell" style={{ fontFamily: 'inherit', color: '#525252', fontStyle: 'italic' }}>
+                          (no actions — terminal state)
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <button className="cds--btn cds--btn--ghost" style={{ marginTop: 8, fontSize: 12 }}>+ Add row</button>
+                </div>
+              )}
+
+              {mode === 'individual' && (
+                <div className="panel">
+                  <p className="compact-hint">Each rule renders in its own WHEN/THEN editor (like the TSH editor above). Switch back to <strong>Decision table</strong> for the compact view.</p>
+                </div>
+              )}
+
+              <div className="editor-grid" style={{ marginTop: '1rem' }}>
+                <div className="panel">
+                  <h4>Simulator <span className="pill green">Sandbox</span></h4>
+                  <HIVSimulator />
+                </div>
+                <div className="panel">
+                  <h4>Cascade preview <span className="pill gray">Read-only</span></h4>
+                  <div className="cascade" style={{ flexWrap: 'wrap' }}>
+                    <div className="node trigger">HIV Screen</div>
+                    <span className="arr">→</span>
+                    <div className="node action">HIV-1 Confirmatory (WB)</div>
+                    <span className="arr">↘</span>
+                  </div>
+                  <div className="cascade" style={{ marginTop: 4 }}>
+                    <div className="node trigger">HIV Screen</div>
+                    <span className="arr">→</span>
+                    <div className="node chain">HIV Screen (repeat)</div>
+                    <span style={{ fontSize: 11, color: '#6f6f6f', marginLeft: 8 }}>self-loop · capped at 1 retry</span>
+                  </div>
+
+                  <h4 style={{ fontSize: 13, margin: '1rem 0 0.5rem' }}>Conflicts</h4>
+                  <div className="conflict">
+                    ⚠ Rule #2 (Reactive) and Rule #3 (Weak Reactive) cannot both fire on the same result —
+                    HIV_Screen has a single coded value. No conflict.
+                  </div>
+                  <div style={{ marginTop: 6, fontSize: 11, color: '#0e6027' }}>
+                    ✓ Coverage check: all three coded values (Reactive, Weak Reactive, Non-Reactive) are handled.
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run all simulations</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA LIBRARY (templates)
+    // ========================================================================
+    const LIBRARY = [
+      { name: 'HIV cascade (national algorithm)', shape: 'Screen → Confirmatory / Repeat / End', src: 'WHO 2019' },
+      { name: 'TB cascade (GeneXpert → DST)',     shape: 'GeneXpert+ → Drug Susceptibility',    src: 'WHO 2021' },
+      { name: 'Syphilis reverse algorithm',       shape: 'Treponemal+ → RPR + TPPA',            src: 'CDC 2015' },
+      { name: 'Hepatitis B reflex',               shape: 'HBsAg+ → HBeAg + HBV DNA',            src: 'AASLD' },
+      { name: 'Urine dipstick → culture',         shape: 'Nitrites/Leuk+ → C&S',                 src: 'standard' },
+      { name: 'Strep RADT → throat culture',      shape: 'RADT- and pediatric → culture',       src: 'IDSA' },
+      { name: 'CBC manual differential trigger',  shape: 'WBC>30k or atypical → manual diff',   src: 'CLSI H20-A2' },
+      { name: 'TSH reflex Free T4',               shape: 'TSH abnormal → FT4',                   src: 'ATA 2014' },
+      { name: 'Coombs+ → eluate + panel',         shape: 'DAT+ → eluate, ABO/Rh confirm',       src: 'AABB' },
+      { name: 'Severe anemia workup',             shape: 'Hgb<7 → Retic + Iron + B12/Folate',   src: 'standard' },
+      { name: 'Critical glucose alert',           shape: '<40 or >500 → alert + lactate',       src: 'CLSI C24-A3' },
+      { name: 'Newborn TSH reflex',               shape: 'NB TSH>20 → Day-7 repeat',            src: 'AAP 2006' },
+    ];
+
+    function LibraryDrawer({ onClose }) {
+      const [q, setQ] = useState('');
+      const filtered = LIBRARY.filter(t =>
+        (t.name + t.shape + t.src).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="library-drawer">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <h4>Reflex algorithm library &nbsp;<span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f' }}>{LIBRARY.length} entries · search by name, citation, or shape</span></h4>
+            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#525252', fontSize: 16 }}>✕</button>
+          </div>
+          <input
+            className="library-search"
+            placeholder="Search algorithms (e.g. 'HIV', 'TSH', 'urine')…"
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="library-grid">
+            {filtered.map(tpl => (
+              <div key={tpl.name} className="library-card">
+                <div className="name">{tpl.name}</div>
+                <div className="shape">{tpl.shape}</div>
+                <div className="src">{tpl.src}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 11, color: '#6f6f6f' }}>
+            Picking an algorithm prefills the WHEN/THEN block(s) and adds the cascade as a single decision-table entry.
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      // TSH (1) + HIV cascade (2 — anchors the HIV group) both pre-expanded
+      const [expandedIds, setExpandedIds] = useState(new Set([1, 2]));
+      const toggleExpanded = (id) => setExpandedIds(s => {
+        const ns = new Set(s);
+        if (ns.has(id)) ns.delete(id); else ns.add(id);
+        return ns;
+      });
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [libraryOpen, setLibraryOpen] = useState(false);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Reflex Test Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Reflex Test Rules
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> Reflex rules read as plain English clinical
+              questions: <em>"when TSH is outside the normal range AND Free T4 is less than
+              0.7, reflex the thyroid antibody panel."</em> Authors pick a test, then a
+              question about it. Three kinds of questions are available:
+              <strong>catalog-based</strong> (uses the test's reference / critical ranges —
+              "is outside normal", "is critically high"); <strong>specific-value</strong>
+              (you enter a number — "is at least 6.5", "is between 50 and 80"); and
+              <strong>coded value</strong> (pick from the test's possible values — "is
+              reactive", "is any of: ++, +++"). Conditions compose with AND / OR / NOT.
+              Multiple actions per rule. The technical form is hidden by default and
+              available behind a toggle for developers / DMN export.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search rules by name, trigger test, or action…" />
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Trigger sample: All ▾</span>
+              <span className="filter-pill">Cascade group: All ▾</span>
+            </div>
+            <div>
+              <button className={'browse-btn' + (libraryOpen ? ' open' : '')}
+                      onClick={() => setLibraryOpen(o => !o)}
+                      style={{ marginRight: 8 }}>
+                Browse algorithm library
+              </button>
+              <button className="cds--btn cds--btn--primary">+ New rule</button>
+            </div>
+          </div>
+
+          {libraryOpen && <LibraryDrawer onClose={() => setLibraryOpen(false)} />}
+
+          {/* Rule list */}
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 90 }}>Status</th>
+                  <th>Rule</th>
+                  <th style={{ width: 140 }}>Cascade</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                  <th style={{ width: 60 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {RULES.map(rule => {
+                  const isExpanded = expandedIds.has(rule.id);
+                  return (
+                  <React.Fragment key={rule.id}>
+                    <tr style={{ background: isExpanded ? '#edf5ff' : 'transparent' }}>
+                      <td>
+                        <button
+                          onClick={() => toggleExpanded(rule.id)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                          {isExpanded ? '▾' : '▸'}
+                        </button>
+                      </td>
+                      <td>
+                        {rule.status === 'active'
+                          ? <span className="cds--tag cds--tag--green">Active</span>
+                          : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                      </td>
+                      <td>
+                        <div className="rule-name">{rule.name}</div>
+                        <RuleSummary when={rule.when} thenSummary={rule.thenSummary} />
+                      </td>
+                      <td style={{ fontSize: 12 }}>
+                        {rule.cascadeGroup
+                          ? <span className="cds--tag cds--tag--purple">{rule.cascadeGroup}</span>
+                          : <span style={{ color: '#a8a8a8' }}>—</span>}
+                      </td>
+                      <td style={{ fontSize: 12, color: '#6f6f6f' }}>{rule.edited}</td>
+                      <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                    </tr>
+                    {isExpanded && rule.id === 1 && <TSHEditor />}
+                    {isExpanded && rule.id === 2 && <HIVCascadeEditor />}
+                    {isExpanded && rule.id === 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#fafafa', fontSize: 13, color: '#525252' }}>
+                          This rule shares the HIV cascade. Open <strong>rule #2</strong> above to edit the cascade as a decision table.
+                        </td>
+                      </tr>
+                    )}
+                    {isExpanded && rule.id !== 1 && rule.id !== 2 && rule.id !== 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#f4f4f4', fontSize: 13, color: '#525252' }}>
+                          (Editor for <strong>{rule.name}</strong> would render in the same WHEN/THEN layout. Cascade groups would offer decision-table mode.)
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What changed vs. today:</strong> WHEN/THEN structure replaces "Add Reflex Rule
+            Conditions / Perform the following actions" (clearer mental model, matches Drools,
+            Salesforce Flow, Zapier). Boolean formula bar replaces row-of-conditions + ANY/ALL dropdown —
+            supports coded results (HIV "Reactive"), numeric comparisons, patient attributes, and
+            properly nested AND/OR with parens. Structured action list replaces "free-form text with sample-type dropdown" —
+            picks from Order Test, Order Panel, Note (internal/external), Set Priority, Send Alert.
+            Decision-table mode added for cascades (HIV, TB, syphilis) so the cascade reads as a single
+            artifact instead of three separate forms. Simulator added on the right pane — paste a sample
+            result, see what fires. Cascade overlay shows downstream chains and self-loops. Conflict
+            detection runs on save. Algorithm library replaces "no templates" with WHO/CDC/IDSA-cited cascades.
+            Same Carbon shell as Calculated Values v2 — list view, inline expansion, two-pane editor.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message +
+          '<pre style="font-size:11px;">' + (e.stack || '').split('\n').slice(0,6).join('\n') + '</pre>';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/designs/admin-config/test-rules-list-view-preview.html
+++ b/designs/admin-config/test-rules-list-view-preview.html
@@ -1,0 +1,938 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Rules — Unified List View — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+    .phrase {
+      display: inline-flex; align-items: baseline; gap: 4px;
+      background: #f4f9ff; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Sans', sans-serif; font-size: 12px;
+      color: #161616; margin: 0 2px;
+    }
+    .phrase strong { font-weight: 600; color: #161616; }
+    .phrase em { color: #0072c3; font-style: normal; font-weight: 500; }
+
+    .summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+
+    /* Type chips */
+    .type-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 4px;
+      text-transform: uppercase; letter-spacing: 0.4px;
+    }
+    .type-chip.rule  { background: #d0e2ff; color: #0043ce; }
+    .type-chip.algo  { background: #e8daff; color: #491d8b; }
+    .type-chip.calc  { background: #defbe6; color: #0e6027; }
+    .type-chip.mcalc { background: #fff8e1; color: #b28600; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 260px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .filter-pill.active { background: #d0e2ff; color: #0043ce; border-color: #4589ff; }
+
+    /* New button + menu */
+    .new-btn-wrap { position: relative; display: inline-block; }
+    .new-menu {
+      position: absolute; top: 100%; right: 0; margin-top: 4px;
+      background: #fff; border: 1px solid #c6c6c6;
+      min-width: 280px; z-index: 5;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    }
+    .new-menu .item {
+      padding: 10px 14px; cursor: pointer; display: flex; flex-direction: column; gap: 2px;
+      border-bottom: 1px solid #f4f4f4;
+    }
+    .new-menu .item:hover { background: #edf5ff; }
+    .new-menu .item:last-child { border-bottom: none; }
+    .new-menu .item-name { font-size: 13px; font-weight: 600; color: #161616; }
+    .new-menu .item-desc { font-size: 11px; color: #6f6f6f; }
+
+    /* Data table */
+    table.cds--data-table { width: 100%; background: #fff; border: 1px solid #e0e0e0; border-top: none; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    .when-then {
+      display: flex; align-items: center; gap: 0.5rem; margin-top: 4px;
+      flex-wrap: wrap;
+    }
+    .when-then .label {
+      font-size: 10px; padding: 2px 6px; border-radius: 999px; font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    .when-then .label.w { background: #fff8e1; color: #b28600; }
+    .when-then .label.t { background: #defbe6; color: #0e6027; }
+    .when-then .arrow { color: #525252; }
+    .summary-text {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+
+    /* Tests involved column */
+    .test-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+    .test-chip {
+      background: #f4f4f4; color: #161616;
+      padding: 2px 8px; border-radius: 4px; font-size: 11px;
+      font-family: 'IBM Plex Mono', monospace;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .test-chip.input  { border-color: #a2191f; color: #a2191f; }
+    .test-chip.output { border-color: #198038; color: #0e6027; }
+    .test-chip.both   { border-color: #0043ce; color: #0043ce; }
+    .test-chip:hover { background: #edf5ff; border-color: #0f62fe; color: #0f62fe; }
+
+    /* Open-in-editor link for algos / multi-step */
+    .open-editor-row {
+      background: #f4f4f4; padding: 1rem 1.5rem; border-top: 2px solid #491d8b;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .open-editor-row.calc { border-color: #b28600; }
+    .open-editor-row .left { display: flex; flex-direction: column; gap: 4px; }
+    .open-editor-row .title { font-size: 14px; font-weight: 600; }
+    .open-editor-row .desc { font-size: 12px; color: #525252; }
+    .open-editor-row .right { display: flex; gap: 0.5rem; align-items: center; }
+
+    /* Inline rule editor (when simple rule is expanded) */
+    .inline-rule-editor {
+      background: #f4f4f4; padding: 1.25rem; border-top: 2px solid #0f62fe;
+    }
+    .inline-rule-editor .editor-grid {
+      display: grid; grid-template-columns: 1.2fr 1fr; gap: 1rem;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #d0e2ff; color: #0043ce; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .field-row { display: flex; gap: 0.75rem; margin-bottom: 0.5rem; align-items: end; }
+    .field-row label { font-size: 12px; color: #525252; display: block; margin-bottom: 4px; }
+    .field-row input, .field-row select {
+      padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 13px; width: 100%;
+    }
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.75rem;
+    }
+
+    /* Side panel — test catalog cross-reference */
+    .layout-grid {
+      display: grid; grid-template-columns: 1fr 320px; gap: 1rem;
+    }
+    .side-panel {
+      background: #fff; border: 1px solid #e0e0e0; padding: 1rem;
+      align-self: start; position: sticky; top: 1rem;
+    }
+    .side-panel h4 {
+      margin: 0 0 0.5rem; font-size: 13px; font-weight: 600;
+    }
+    .side-panel .test-card {
+      padding: 8px 10px; border: 1px solid #e0e0e0; margin-bottom: 6px;
+      font-size: 12px;
+    }
+    .side-panel .test-card .tname { font-weight: 600; color: #161616; }
+    .side-panel .test-card .tmeta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+    }
+    .side-panel .test-card .role {
+      font-size: 10px; padding: 1px 6px; border-radius: 3px;
+      margin-right: 4px;
+    }
+    .side-panel .test-card .role.input  { background: #fff1f1; color: #a2191f; }
+    .side-panel .test-card .role.output { background: #defbe6; color: #0e6027; }
+    .side-panel .test-card .role.intermediate { background: #d0e2ff; color: #0043ce; }
+    .catalog-link {
+      display: block; margin-top: 0.75rem; padding: 0.5rem; background: #edf5ff;
+      font-size: 12px; color: #0043ce; text-decoration: none; text-align: center;
+      border: 1px solid #4589ff;
+    }
+    .catalog-link:hover { background: #d0e2ff; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; font-style: italic; }
+
+    /* Empty state */
+    .empty-state {
+      padding: 3rem 2rem; text-align: center;
+      background: #fff; border: 1px solid #e0e0e0; border-top: none;
+    }
+    .empty-state .icon { font-size: 32px; color: #8d8d8d; margin-bottom: 0.5rem; }
+    .empty-state .title { font-size: 16px; font-weight: 600; color: #161616; margin-bottom: 4px; }
+    .empty-state .desc { font-size: 13px; color: #525252; margin-bottom: 1rem; }
+
+    /* Batch action bar — shows when items are selected */
+    .batch-bar {
+      display: flex; align-items: center; gap: 0.5rem; justify-content: space-between;
+      background: #0043ce; color: #fff; padding: 0.5rem 1rem;
+      border: 1px solid #0043ce; border-bottom: none;
+    }
+    .batch-bar .count { font-size: 13px; font-weight: 600; }
+    .batch-bar .actions { display: flex; gap: 0.5rem; }
+    .batch-bar button {
+      background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.3); color: #fff;
+      padding: 4px 10px; font-size: 12px; cursor: pointer;
+    }
+    .batch-bar button:hover { background: rgba(255,255,255,0.25); }
+    .batch-bar button.danger { border-color: #fa4d56; }
+    .batch-bar .clear { background: none; border: none; color: #fff; cursor: pointer; padding: 4px; }
+
+    /* Counts row */
+    .count-row {
+      display: flex; gap: 1.5rem; margin-bottom: 0.75rem; font-size: 13px; color: #525252;
+    }
+    .count-row .c { display: flex; align-items: center; gap: 6px; }
+    .count-row .num {
+      font-weight: 600; font-size: 16px; color: #161616;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Test Rules unified list view &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">
+    Loading… <span id="boot-detail">if this message persists, check the browser console for errors.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    // Visible boot diagnostics so the page never silently dies on a CDN miss.
+    window.addEventListener('error', function (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1';
+        s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Error:</strong> ' + (e.message || 'unknown') +
+          (e.filename ? ' &nbsp; <em>' + e.filename + ':' + e.lineno + '</em>' : '');
+      }
+    });
+    function _checkDeps() {
+      var missing = [];
+      if (typeof React === 'undefined') missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined') missing.push('Babel');
+      var s = document.getElementById('boot-detail');
+      if (missing.length) {
+        s.textContent = 'Missing dependencies: ' + missing.join(', ') + '. Check the network tab for blocked CDNs (cdnjs.cloudflare.com, unpkg.com).';
+        s.style.color = '#a2191f';
+      } else {
+        s.textContent = 'Dependencies loaded. Mounting…';
+      }
+    }
+    window.addEventListener('load', _checkDeps);
+  </script>
+
+  <script type="text/babel">
+    const { useState } = React;
+
+    const KNOWN_TESTS = ['TSH','FT4','HIV_Screen','HIV_Conf','HIV_Tie','HIV_Status','TC','HDL','TRIG','LDL','SCr','Bili','INR','Na','MELD_Na','WBC','Diff','HGB','Retic','GLU','Lactate','Nitrites','Leuk','UC','StrepA','ThroatCx','CA','ALB','CorrCa','WT','HT','BMI','Trep','RPR','TPPA','Syph_Final','Sputum','GeneXpert','DST','TB_Final'];
+    const KEYWORDS = ['AND','OR','NOT','IN'];
+    const PREDICATES = ['isNormal','isOutsideNormal','isAboveNormal','isBelowNormal','isCritical','isCriticallyHigh','isCriticallyLow','isFlagged','changedSignificantly','isReactive','isPositive','isAnyOf'];
+    function tokenize(text) {
+      const re = /("[^"]*")|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=|\+|-|\*|\/)|([(),])|(\s+)|(.)/g;
+      const out = []; let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({k:'str', t:m[1]});
+        else if (m[2]) out.push({k:'num', t:m[2]});
+        else if (m[3]) {
+          if (KEYWORDS.includes(m[3].toUpperCase())) out.push({k:'bool', t:m[3]});
+          else if (PREDICATES.includes(m[3])) out.push({k:'pred', t:m[3]});
+          else if (['min','max','log','ln','round','if','eq','pow'].includes(m[3])) out.push({k:'fn', t:m[3]});
+          else if (['Age','Sex','Sample'].includes(m[3])) out.push({k:'attr', t:m[3]});
+          else if (KNOWN_TESTS.includes(m[3])) out.push({k:'var', t:m[3]});
+          else out.push({k:'var', t:m[3]});
+        }
+        else if (m[4]) out.push({k:'op', t:m[4]});
+        else if (m[5]) out.push({k:'paren', t:m[5]});
+        else if (m[6]) out.push({k:'ws', t:m[6]});
+        else out.push({k:'other', t:m[7]});
+      }
+      return out;
+    }
+    const PREDICATE_SHORT = {
+      isNormal: 'is within normal',
+      isOutsideNormal: 'is outside normal',
+      isAboveNormal: 'is above normal',
+      isBelowNormal: 'is below normal',
+      isCritical: 'is critical',
+      isCriticallyHigh: 'is critically high',
+      isCriticallyLow: 'is critically low',
+      isFlagged: 'is flagged',
+      changedSignificantly: 'changed significantly',
+      isReactive: 'is reactive',
+      isPositive: 'is positive',
+      isAnyOf: 'is one of…',
+    };
+
+    function Tokenized({ text }) {
+      const tokens = tokenize(text);
+      const out = [];
+      let i = 0;
+      while (i < tokens.length) {
+        const t = tokens[i];
+        if (t.k === 'pred' &&
+            tokens[i+1] && tokens[i+1].k === 'paren' && tokens[i+1].t === '(' &&
+            tokens[i+2] && tokens[i+2].k === 'var' &&
+            tokens[i+3] && tokens[i+3].k === 'paren' && tokens[i+3].t === ')') {
+          const phrase = PREDICATE_SHORT[t.t];
+          const testId = tokens[i+2].t;
+          if (phrase) {
+            out.push(
+              <span key={i} className="phrase">
+                <strong>{testId}</strong> <em>{phrase}</em>
+              </span>
+            );
+            i += 4;
+            continue;
+          }
+        }
+        out.push(<span key={i} className={t.k === 'ws' ? '' : 'tok-' + t.k}>{t.t}</span>);
+        i++;
+      }
+      return <span className="summary-text">{out}</span>;
+    }
+
+    // ========================================================================
+    // UNIFIED RULES DATA — mix of types
+    // ========================================================================
+    const ITEMS = [
+      {
+        id: 1, type: 'rule', name: 'TSH abnormal → reflex Free T4',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isOutsideNormal(TSH)', then: 'Order Free T4' },
+        tests: [{ id: 'TSH', role: 'input' }, { id: 'FT4', role: 'output' }],
+        trigger: 'On TSH result',
+        edited: '2026-04-22 by m.kone',
+      },
+      {
+        id: 2, type: 'algo', name: 'HIV 3-test national algorithm',
+        status: 'active',
+        summary: { kind: 'algo', nodes: 3, ends: 4, paths: 'Screen → Confirm → Tiebreaker' },
+        tests: [
+          { id: 'HIV_Screen', role: 'input' }, { id: 'HIV_Conf', role: 'intermediate' },
+          { id: 'HIV_Tie', role: 'intermediate' }, { id: 'HIV_Status', role: 'output' }
+        ],
+        trigger: 'On HIV_Status order',
+        edited: '2026-04-30 by p.diallo',
+      },
+      {
+        id: 3, type: 'calc', name: 'LDL Cholesterol (Friedewald)',
+        status: 'active',
+        summary: { kind: 'formula', text: 'LDL = TC - HDL - TRIG / 5' },
+        tests: [{ id: 'TC', role: 'input' }, { id: 'HDL', role: 'input' }, { id: 'TRIG', role: 'input' }, { id: 'LDL', role: 'output' }],
+        trigger: 'On all inputs resulted',
+        edited: '2026-04-28 by p.diallo',
+      },
+      {
+        id: 12, type: 'calc', name: 'TB GenoType Resistance Interpretation', outputKind: 'coded',
+        status: 'active',
+        summary: { kind: 'formula', text: 'Decision table: 4 rules + Otherwise · maps band pattern + melting points to 6 categories' },
+        tests: [
+          { id: 'TB_GT', role: 'input' },
+          { id: 'TB_INTERP', role: 'output' }
+        ],
+        trigger: 'On TB_GT result',
+        edited: '2026-05-08 by m.kone',
+      },
+      {
+        id: 4, type: 'mcalc', name: 'MELD-Na (Liver allocation)',
+        status: 'active',
+        summary: { kind: 'mcalc', steps: 6, finalText: 'MELD_Na (capped 6–40)' },
+        tests: [
+          { id: 'SCr', role: 'input' }, { id: 'Bili', role: 'input' },
+          { id: 'INR', role: 'input' }, { id: 'Na', role: 'input' },
+          { id: 'MELD_Na', role: 'output' }
+        ],
+        trigger: 'On all inputs resulted',
+        edited: '2026-03-22 by p.diallo',
+      },
+      {
+        id: 5, type: 'rule', name: 'WBC critically high → manual differential',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isCriticallyHigh(WBC)', then: 'Order Manual Diff' },
+        tests: [{ id: 'WBC', role: 'input' }, { id: 'Diff', role: 'output' }],
+        trigger: 'On WBC result',
+        edited: '2026-03-12 by m.kone',
+      },
+      {
+        id: 6, type: 'calc', name: 'BMI', status: 'active',
+        summary: { kind: 'formula', text: 'BMI = WT / pow(HT, 2)' },
+        tests: [{ id: 'WT', role: 'input' }, { id: 'HT', role: 'input' }, { id: 'BMI', role: 'output' }],
+        trigger: 'On WT + HT resulted',
+        edited: '2026-04-12 by m.kone',
+      },
+      {
+        id: 7, type: 'rule', name: 'Urine dipstick positive → culture',
+        status: 'active',
+        summary: { kind: 'whenThen', when: '(Nitrites == "Positive" OR Leuk IN ("++","+++"))', then: 'Order Urine Culture' },
+        tests: [{ id: 'Nitrites', role: 'input' }, { id: 'Leuk', role: 'input' }, { id: 'UC', role: 'output' }],
+        trigger: 'On dipstick result',
+        edited: '2026-02-28 by m.kone',
+      },
+      {
+        id: 8, type: 'algo', name: 'TB cascade (GeneXpert → DST)',
+        status: 'disabled',
+        summary: { kind: 'algo', nodes: 4, ends: 6, paths: 'Sputum → GX → DST → 2nd-line' },
+        tests: [
+          { id: 'Sputum', role: 'input' }, { id: 'GeneXpert', role: 'intermediate' },
+          { id: 'DST', role: 'intermediate' }, { id: 'TB_Final', role: 'output' }
+        ],
+        trigger: 'On TB_Final order',
+        edited: '2026-01-04 by p.diallo',
+      },
+      {
+        id: 9, type: 'calc', name: 'Corrected Calcium', status: 'active',
+        summary: { kind: 'formula', text: 'CorrCa = CA + 0.8 * (4 - ALB)' },
+        tests: [{ id: 'CA', role: 'input' }, { id: 'ALB', role: 'input' }, { id: 'CorrCa', role: 'output' }],
+        trigger: 'On Ca + Alb resulted',
+        edited: '2026-04-21 by m.kone',
+      },
+      {
+        id: 10, type: 'rule', name: 'Critical glucose → alert + lactate',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isCritical(GLU)', then: 'Critical Alert + STAT Lactate' },
+        tests: [{ id: 'GLU', role: 'input' }, { id: 'Lactate', role: 'output' }],
+        trigger: 'On GLU result',
+        edited: '2026-04-05 by m.kone',
+      },
+      {
+        id: 11, type: 'algo', name: 'Syphilis reverse algorithm',
+        status: 'active',
+        summary: { kind: 'algo', nodes: 3, ends: 4, paths: 'Treponemal → RPR → TPPA' },
+        tests: [
+          { id: 'Trep', role: 'input' }, { id: 'RPR', role: 'intermediate' },
+          { id: 'TPPA', role: 'intermediate' }, { id: 'Syph_Final', role: 'output' }
+        ],
+        trigger: 'On Syph_Final order',
+        edited: '2025-11-29 by p.diallo',
+      },
+    ];
+
+    // Counts
+    const COUNTS = ITEMS.reduce((acc, x) => {
+      acc[x.type] = (acc[x.type] || 0) + 1;
+      acc.total++;
+      if (x.status === 'active') acc.active++;
+      return acc;
+    }, { total: 0, active: 0 });
+
+    function TestChips({ tests }) {
+      return (
+        <div className="test-chips">
+          {tests.map(t => (
+            <span key={t.id} className={'test-chip ' + t.role} title={
+              t.role === 'input' ? 'Read by this rule' :
+              t.role === 'output' ? 'Written by this rule (test in catalog)' :
+              'Decision step in the algorithm'
+            }>
+              {t.id}
+            </span>
+          ))}
+        </div>
+      );
+    }
+
+    function ItemSummary({ item }) {
+      const s = item.summary;
+      if (s.kind === 'whenThen') {
+        return (
+          <div className="when-then">
+            <span className="label w">WHEN</span>
+            <Tokenized text={s.when} />
+            <span className="arrow">→</span>
+            <span className="label t">THEN</span>
+            <span style={{ color: '#0e6027', fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>{s.then}</span>
+          </div>
+        );
+      }
+      if (s.kind === 'formula') {
+        return <div className="summary"><Tokenized text={s.text} /></div>;
+      }
+      if (s.kind === 'algo') {
+        return (
+          <div className="summary" style={{ display: 'flex', gap: 12, alignItems: 'center', color: '#525252' }}>
+            <span><strong>{s.nodes}</strong> decision steps · <strong>{s.ends}</strong> end states</span>
+            <span style={{ color: '#491d8b', fontFamily: 'monospace' }}>{s.paths}</span>
+          </div>
+        );
+      }
+      if (s.kind === 'mcalc') {
+        return (
+          <div className="summary" style={{ color: '#525252' }}>
+            <strong>{s.steps}</strong> named intermediates → <span style={{ color: '#0e6027', fontFamily: 'monospace' }}>{s.finalText}</span>
+          </div>
+        );
+      }
+      return null;
+    }
+
+    function TypeChip({ type }) {
+      const labels = { rule: 'Rule', algo: 'Algorithm', calc: 'Calc', mcalc: 'Multi-step Calc' };
+      return <span className={'type-chip ' + type}>{labels[type]}</span>;
+    }
+
+    // ========================================================================
+    // INLINE RULE EDITOR (only for type='rule' — simple WHEN/THEN)
+    // ========================================================================
+    function InlineRuleEditor({ item }) {
+      const [when, setWhen] = useState(item.summary.when);
+      // Which dedicated preview corresponds to this item?
+      const dedicatedPreview = item.type === 'rule' ? 'reflex-tests-redesign-preview.html'
+        : (item.type === 'calc' && item.outputKind === 'coded') ? 'calc-decision-table-preview.html'
+        : 'calculated-values-redesign-v2-preview.html';
+      const editorName = item.type === 'rule' ? 'Reflex rule editor'
+        : (item.type === 'calc' && item.outputKind === 'coded') ? 'Coded Calculation editor (Decision Table)'
+        : 'Numeric Calculation editor (Formula bar)';
+      return (
+        <tr>
+          <td colSpan={7} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="inline-rule-editor">
+              {/* Cross-preview navigation banner */}
+              <div style={{
+                background: '#edf5ff', border: '1px solid #4589ff', borderLeft: '3px solid #0f62fe',
+                padding: '0.5rem 0.75rem', marginBottom: 12, fontSize: 12, color: '#0043ce',
+                display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap'
+              }}>
+                <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 700 }}>
+                  Editor preview
+                </span>
+                <span style={{ color: '#525252' }}>
+                  This is the inline editor for a <strong>{item.type === 'rule' ? 'Reflex rule' : 'Calculation'}</strong>.
+                  See the full-width version with all states + interactivity:
+                </span>
+                <a href={dedicatedPreview}
+                   style={{ marginLeft: 'auto', background: '#0f62fe', color: '#fff', padding: '4px 12px',
+                            textDecoration: 'none', fontSize: 12, fontWeight: 600, borderRadius: 3 }}>
+                  Open {editorName} →
+                </a>
+              </div>
+              <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+                <span className="cds--tag cds--tag--blue">Editing inline</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Single decision point</span>
+              </div>
+
+              <div className="editor-grid">
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">WHEN / THEN</span></h4>
+                  <div className="field-row">
+                    <div style={{ flex: 1 }}>
+                      <label>Name</label>
+                      <input type="text" defaultValue={item.name} />
+                    </div>
+                  </div>
+                  <div style={{ marginTop: 12 }}>
+                    <div style={{ fontSize: 10, fontWeight: 700, color: '#b28600', background: '#fff8e1', display: 'inline-block', padding: '3px 10px', borderRadius: 999, marginBottom: 6 }}>WHEN</div>
+                    <div style={{ background: '#fff', border: '1px solid #8d8d8d', padding: '8px 12px', fontFamily: 'IBM Plex Mono', fontSize: 14 }}>
+                      <Tokenized text={when} />
+                    </div>
+                    <div className="compact-hint" style={{ marginTop: 4 }}>
+                      Inline formula bar — same syntax as the algorithm decision tables.
+                    </div>
+                  </div>
+                  <div style={{ marginTop: 12 }}>
+                    <div style={{ fontSize: 10, fontWeight: 700, color: '#0e6027', background: '#defbe6', display: 'inline-block', padding: '3px 10px', borderRadius: 999, marginBottom: 6 }}>THEN</div>
+                    <div style={{ background: '#fff', border: '1px solid #e0e0e0', padding: '8px 12px', fontSize: 13 }}>
+                      <span style={{ background: '#d0e2ff', color: '#0043ce', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600, marginRight: 6 }}>Order Test</span>
+                      {item.summary.then}
+                    </div>
+                  </div>
+                </div>
+                <div className="panel">
+                  <h4>Test catalog references <span className="pill" style={{ background: '#e8daff', color: '#491d8b' }}>FYI</span></h4>
+                  <div className="compact-hint" style={{ marginBottom: 8 }}>
+                    Every test this rule touches is a real entry in the Test Catalog. Click any chip to jump to its catalog page.
+                  </div>
+                  {item.tests.map(t => (
+                    <div key={t.id} style={{ padding: 6, borderBottom: '1px solid #f4f4f4', display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+                      <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{t.id}</span>
+                      <span style={{ color: '#6f6f6f' }}>
+                        {t.role === 'input' ? 'Reads result' : t.role === 'output' ? 'Writes result' : 'Decision step'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // OPEN-IN-EDITOR ROW (for algo / mcalc — full-page editors)
+    // ========================================================================
+    function OpenEditorRow({ item }) {
+      const isCalc = item.type === 'mcalc';
+      return (
+        <tr>
+          <td colSpan={7} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className={'open-editor-row' + (isCalc ? ' calc' : '')}>
+              <div className="left">
+                <div className="title">
+                  This is a {item.type === 'algo' ? 'multi-step algorithm' : 'multi-step calculation'} —
+                  it doesn't edit inline.
+                </div>
+                <div className="desc">
+                  {item.type === 'algo'
+                    ? `${item.summary.nodes} decision steps wired together with ${item.summary.ends} end states. The workflow editor takes over a full screen so the graph has room to breathe.`
+                    : `${item.summary.steps} named intermediate values feeding a final output. The multi-step editor shows the dependency graph plus each step's formula bar.`}
+                </div>
+                <div className="desc" style={{ marginTop: 4 }}>
+                  Tests touched: <TestChips tests={item.tests} />
+                </div>
+              </div>
+              <div className="right">
+                <span style={{ background: '#f1c21b', color: '#6b4a00', padding: '2px 8px', borderRadius: 3, fontSize: 10, fontWeight: 700, alignSelf: 'center', marginRight: 8 }}>PHASE 2</span>
+                <a href="algorithm-as-graph-preview.html"
+                   style={{ background: '#0f62fe', color: '#fff', padding: '6px 14px', textDecoration: 'none',
+                            fontSize: 12, fontWeight: 600, borderRadius: 3 }}>
+                  Open in {item.type === 'algo' ? 'Algorithm Editor' : 'Multi-step Editor'} →
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // SIDE PANEL — Test Catalog cross-reference for a selected item
+    // ========================================================================
+    function CatalogPanel({ item }) {
+      if (!item) {
+        return (
+          <div className="side-panel">
+            <h4>Test catalog references</h4>
+            <div className="compact-hint">
+              Click any rule, algorithm, or multi-step calc to see which tests it touches and how.
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="side-panel">
+          <h4>Tests touched by "{item.name}"</h4>
+          <div className="compact-hint" style={{ marginBottom: 8 }}>
+            Every test below is a real entry in the Test Catalog. The rule is glue between them — it doesn't create new test types.
+          </div>
+          {item.tests.map(t => (
+            <div key={t.id} className="test-card">
+              <div className="tname">
+                <span className={'role ' + t.role}>{t.role}</span>
+                {t.id}
+              </div>
+              <div className="tmeta">
+                {t.role === 'input' && 'Rule reads this test\'s result'}
+                {t.role === 'output' && 'Rule writes a result back to this test'}
+                {t.role === 'intermediate' && 'Algorithm orders this test at a decision step'}
+              </div>
+            </div>
+          ))}
+          <a href="#" className="catalog-link">→ Open Test Catalog</a>
+          <h4 style={{ marginTop: 16 }}>Trigger mode</h4>
+          <div style={{ fontSize: 12, color: '#525252' }}>
+            <strong>{item.trigger}</strong>
+          </div>
+          <div className="compact-hint" style={{ marginTop: 4 }}>
+            {item.trigger.includes('order')
+              ? 'Provider orders the output test; the rule cascade runs underneath. Provider doesn\'t see the cascade.'
+              : 'Rule reads the trigger result and decides what (if anything) to order next.'}
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState(1);
+      const [newMenuOpen, setNewMenuOpen] = useState(false);
+      const [typeFilter, setTypeFilter] = useState('all');
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [selectedIds, setSelectedIds] = useState(new Set());
+      const [demoEmpty, setDemoEmpty] = useState(false);  // For showcasing empty state
+
+      const selected = ITEMS.find(i => i.id === expandedId);
+      const filtered = demoEmpty ? [] : (typeFilter === 'all' ? ITEMS : ITEMS.filter(i => i.type === typeFilter));
+
+      const toggleSel = (id) => setSelectedIds(s => {
+        const ns = new Set(s); if (ns.has(id)) ns.delete(id); else ns.add(id); return ns;
+      });
+      const allSelected = filtered.length > 0 && filtered.every(i => selectedIds.has(i.id));
+      const toggleAll = () => {
+        if (allSelected) setSelectedIds(s => { const ns = new Set(s); filtered.forEach(i => ns.delete(i.id)); return ns; });
+        else setSelectedIds(s => { const ns = new Set(s); filtered.forEach(i => ns.add(i.id)); return ns; });
+      };
+      const clearSel = () => setSelectedIds(new Set());
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Test Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Test Rules <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>rules · algorithms · multi-step calculations</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> One page for everything that wires Test Catalog entries
+              together — simple rules (WHEN/THEN reflex or arithmetic calc), algorithms (multi-step
+              workflows like HIV 3-test), and multi-step calculations (MELD-Na). The list view shows
+              all three types with type-aware summaries. <strong>Predicates</strong> like{' '}
+              <span className="tok-pred">isOutsideNormal(TSH)</span>,{' '}
+              <span className="tok-pred">isCriticallyHigh(WBC)</span>, and{' '}
+              <span className="tok-pred">isCritical(GLU)</span> replace hardcoded numeric thresholds —
+              the actual range comes from the Test Catalog, so a range change updates every rule
+              automatically. Simple rules expand <em>inline</em>; algorithms and multi-step calcs
+              open in <em>dedicated full-screen editors</em>. Every rule type reads and writes
+              ordinary tests in the Test Catalog.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Counts */}
+          <div className="count-row">
+            <div className="c"><span className="num">{COUNTS.total}</span> total</div>
+            <div className="c"><span className="num">{COUNTS.active}</span> active</div>
+            <div className="c"><TypeChip type="rule" /> <span className="num">{COUNTS.rule || 0}</span></div>
+            <div className="c"><TypeChip type="algo" /> <span className="num">{COUNTS.algo || 0}</span></div>
+            <div className="c"><TypeChip type="calc" /> <span className="num">{COUNTS.calc || 0}</span></div>
+            <div className="c"><TypeChip type="mcalc" /> <span className="num">{COUNTS.mcalc || 0}</span></div>
+          </div>
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search by name, test, or formula text…" />
+              <span className={'filter-pill' + (typeFilter === 'all' ? ' active' : '')} onClick={() => setTypeFilter('all')}>All types</span>
+              <span className={'filter-pill' + (typeFilter === 'rule' ? ' active' : '')} onClick={() => setTypeFilter('rule')}>Rules</span>
+              <span className={'filter-pill' + (typeFilter === 'algo' ? ' active' : '')} onClick={() => setTypeFilter('algo')}>Algorithms</span>
+              <span className={'filter-pill' + (typeFilter === 'calc' ? ' active' : '')} onClick={() => setTypeFilter('calc')}>Calcs</span>
+              <span className={'filter-pill' + (typeFilter === 'mcalc' ? ' active' : '')} onClick={() => setTypeFilter('mcalc')}>Multi-step</span>
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Trigger test ▾</span>
+            </div>
+            <div className="new-btn-wrap">
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 13 }}
+                      onClick={() => setNewMenuOpen(o => !o)}>+ New ▾</button>
+              {newMenuOpen && (
+                <div className="new-menu">
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="rule" /> &nbsp;Simple rule</div>
+                    <div className="item-desc">One condition → one or more actions. Inline editor. Use for TSH reflex, critical alerts, single-condition reflexes.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="algo" /> &nbsp;Algorithm</div>
+                    <div className="item-desc">Multiple decision steps wired together. Workflow editor. Use for HIV cascade, TB cascade, syphilis reverse algorithm.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="calc" /> &nbsp;Simple calculation</div>
+                    <div className="item-desc">One formula bar. Inline editor. Use for BMI, A:G ratio, anion gap.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="mcalc" /> &nbsp;Multi-step calculation</div>
+                    <div className="item-desc">Named intermediates feeding a final output. Multi-step editor. Use for MELD-Na, eGFR with caps, full CKD-EPI.</div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Batch action bar appears when items are selected */}
+          {selectedIds.size > 0 && (
+            <div className="batch-bar" role="region" aria-label="Bulk actions">
+              <span className="count">{selectedIds.size} selected</span>
+              <div className="actions">
+                <button>Enable</button>
+                <button>Disable</button>
+                <button>Export CSV</button>
+                <button className="danger">Delete…</button>
+              </div>
+              <button className="clear" aria-label="Clear selection" onClick={clearSel}>✕</button>
+            </div>
+          )}
+
+          {/* Empty state when there are no rules to show */}
+          {filtered.length === 0 ? (
+            <div className="empty-state">
+              <div className="icon">📋</div>
+              <div className="title">No rules yet</div>
+              <div className="desc">
+                {demoEmpty
+                  ? 'This is the empty state — the page when a fresh deployment has no rules configured.'
+                  : 'No rules match your filters. Try clearing them or change the search.'}
+              </div>
+              <button className="cds--btn cds--btn--primary">+ Create your first rule</button>
+              <div style={{ marginTop: 8 }}>
+                <button className="cds--btn cds--btn--ghost"
+                        onClick={() => setDemoEmpty(d => !d)}
+                        style={{ fontSize: 11 }}>
+                  {demoEmpty ? '← Restore demo rules' : 'Show empty state'}
+                </button>
+              </div>
+            </div>
+          ) : (
+          <div className="layout-grid">
+            <div>
+              <div style={{ marginBottom: 8 }}>
+                <button className="cds--btn cds--btn--ghost"
+                        onClick={() => setDemoEmpty(d => !d)}
+                        style={{ fontSize: 11 }}>
+                  {demoEmpty ? '← Restore demo rules' : 'Show empty state'}
+                </button>
+              </div>
+              <table className="cds--data-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 36 }}>
+                      <input type="checkbox" checked={allSelected} onChange={toggleAll}
+                             aria-label="Select all rules" />
+                    </th>
+                    <th style={{ width: 40 }}></th>
+                    <th style={{ width: 130 }}>Type</th>
+                    <th style={{ width: 80 }}>Status</th>
+                    <th>Name / summary</th>
+                    <th>Tests touched</th>
+                    <th style={{ width: 150 }}>Trigger</th>
+                    <th style={{ width: 60 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(item => {
+                    const isExpanded = expandedId === item.id;
+                    const isSelected = selectedIds.has(item.id);
+                    return (
+                    <React.Fragment key={item.id}>
+                      <tr style={{ background: isSelected ? '#edf5ff' : (isExpanded ? '#edf5ff' : 'transparent') }}>
+                        <td onClick={e => e.stopPropagation()}>
+                          <input type="checkbox" checked={isSelected}
+                                 onChange={() => toggleSel(item.id)}
+                                 aria-label={`Select ${item.name}`} />
+                        </td>
+                        <td style={{ cursor: 'pointer' }} onClick={() => setExpandedId(isExpanded ? null : item.id)}>
+                          <button aria-expanded={isExpanded}
+                                  aria-label={isExpanded ? 'Collapse rule' : 'Expand rule'}
+                                  style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe', padding: '4px 8px' }}>
+                            {isExpanded ? '▾' : '▸'}
+                          </button>
+                        </td>
+                        <td><TypeChip type={item.type} /></td>
+                        <td>
+                          {item.status === 'active'
+                            ? <span className="cds--tag cds--tag--green">Active</span>
+                            : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                        </td>
+                        <td>
+                          <div className="rule-name">{item.name}</div>
+                          <ItemSummary item={item} />
+                        </td>
+                        <td><TestChips tests={item.tests} /></td>
+                        <td style={{ fontSize: 12, color: '#525252' }}>{item.trigger}</td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      {isExpanded && (item.type === 'rule' || item.type === 'calc') && <InlineRuleEditor item={item} />}
+                      {isExpanded && (item.type === 'algo' || item.type === 'mcalc') && <OpenEditorRow item={item} />}
+                    </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <p style={{ fontSize: 11, color: '#6f6f6f', marginTop: 6, fontStyle: 'italic' }}>
+                Select rows via the checkbox at left to reveal the batch action bar (Enable / Disable / Export / Delete).
+              </p>
+            </div>
+            <CatalogPanel item={selected} />
+          </div>
+          )}
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>Data-model recap:</strong> every test referenced by a rule — input, intermediate
+            decision step, or output — is a regular entry in the Test Catalog. A rule is glue between
+            existing catalog entries. <em>Algorithm</em> and <em>multi-step calculation</em> introduce
+            no new result types; they just write into ordinary tests. Reporting, validation, manual
+            override, and FHIR ServiceRequest / Observation interoperability all work without
+            modification. The Test Catalog itself gets a corresponding cross-reference:
+            each test card shows "Used by 2 rules, 1 algorithm" so you can navigate from either side.
+            <br/><br/>
+            <strong>Trigger modes:</strong> rules trigger on a result; algorithms can trigger either
+            on a result (legacy reflex pattern) or on an order of the final-output test (cascade is
+            invisible to the provider). The trigger mode is a top-level field on the algorithm — same
+            distinction that Beckman REMISOL and Roche cobas IT use for cascades.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1';
+        s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message + '<pre style="font-size:11px;">' + (e.stack || '').split('\n').slice(0,6).join('\n') + '</pre>';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/designs/admin-config/test-rules-mvp-frs.md
+++ b/designs/admin-config/test-rules-mvp-frs.md
@@ -1,0 +1,837 @@
+# Test Rules Authoring — MVP Functional Requirements Specification
+
+**Status:** Draft for review
+**Author:** Casey Iiams-Hauser (caseyi@uw.edu)
+**Last updated:** 2026-05-11
+**Module:** Admin → Test Rules (replaces *Reflex Tests Management* + *Calculated Value Tests Management*)
+**Target release:** MVP — first shippable rule-authoring redesign
+
+---
+
+## 1. Overview
+
+### 1.1 Problem
+
+OpenELIS Global today exposes two admin pages for rule authoring — *Reflex Tests Management* and *Calculated Value Tests Management* — both under *Admin → Reflex Tests Configuration*. Audit of the live testing instance (testing.openelis-global.org) surfaced consistent problems on both pages:
+
+- Existing rules appear as collapsed cards showing only a rule name and an enable toggle. The lab manager cannot see what a rule does without opening its editor.
+- The condition editor on Reflex uses a row-of-rows pattern with an "Over All Option" ANY/ALL dropdown that's jargon for OR/AND. Compound conditions with nesting are not expressible.
+- The Calculated Values editor uses four "Add" buttons (Test Result, Mathematical Function, Integer, Patient Attribute) alongside a redundant *Insert Operation* dropdown carrying the same four values, with no live preview of the resulting formula or its computed output.
+- Neither editor supports semantic predicates ("is outside normal," "is critically high"). Authors must hand-encode numeric thresholds against the test catalog's reference ranges, which means a range change in the catalog silently invalidates every rule that referenced the old value.
+- The test/panel picker is a flat dropdown that cannot scale to deployments with hundreds of tests.
+- There is no way to preview, simulate, or test a rule before saving.
+- There is no template library, so common rules (TSH reflex, urine culture from dipstick, HIV cascade) get hand-rebuilt at every site rollout.
+
+These pains have been confirmed across multiple production OpenELIS deployments and during the live audit captured 2026-05-11.
+
+### 1.2 Scope of MVP
+
+This spec covers the **MVP** scope of a rule-authoring redesign. MVP is defined as the smallest viable surface that replaces the current broken authoring experience and unlocks rule creation at the scale a real lab catalog requires (hundreds of tests, dozens of panels, multi-condition rules with multiple actions).
+
+The MVP covers:
+
+- A unified Test Rules admin page replacing both legacy pages.
+- A Compose-mode authoring UI for Reflex rules using plain-English semantic predicates with AND/OR composition and multi-action support.
+- A Calculated Value editor that adapts to the destination test: **formula bar** with live preview for numeric outputs, **decision table** for coded outputs.
+- **Analyzer parameters** (melting points, Ct values, band-present flags, internal-control validity) as first-class condition inputs alongside test results, sourced from the existing QC-table linkage and associated with results at import.
+- A searchable test/panel picker with sample-type filtering.
+- A Test Catalog reference panel surfacing the catalog metadata each rule depends on, including analyzer parameters per test.
+- A new rule data model based on a typed AST (semantic predicates + operator predicates) that supports future Phase 2 features (algorithm-as-graph, multi-step calc) without migration.
+
+**Phase 2 capabilities** (formula bar for Reflex, decision-table cascade mode, algorithm-as-graph, simulator, validation tests, templates library) are documented in §10 and intentionally out of scope for MVP.
+
+### 1.3 Success Criteria
+
+MVP is successful when:
+
+1. A lab manager can open the Test Rules page, scan the list, and identify what every rule does at a glance without opening an editor.
+2. A lab manager can author a new compound reflex rule (≥ 2 conditions, ≥ 2 actions) in under three minutes without consulting documentation.
+3. A reference-range change in the Test Catalog automatically updates every rule that uses a catalog-based predicate referencing that test — no rule re-edit required.
+4. Searching for a test or panel in the action picker returns results in under 200 ms with a catalog of 500 entries.
+5. Existing rules from the legacy editors are auto-migrated to the new AST without loss of semantics.
+6. ISO 15189 audit reviewers can read any rule's plain-English form without lab-software training.
+
+---
+
+## 2. User Stories
+
+| ID | Story |
+|----|-------|
+| US-1 | As a **lab manager**, I want to scan the Test Rules page and see what every rule does without opening it, so that I can audit lab automation in minutes rather than hours. |
+| US-2 | As a **lab manager**, I want to author a reflex like "when TSH is outside normal AND Free T4 is less than 0.7, order the thyroid antibody panel" using plain-English questions, so that I can set up clinical automation without learning rule-builder syntax. |
+| US-3 | As a **lab IT / deployment implementer**, I want to search hundreds of tests and panels by name, ID, or LOINC code with a same-sample-type default, so that I can wire up real lab catalogs at scale. |
+| US-4 | As a **clinical reviewer / lab director**, I want every rule to read as a plain English sentence with the underlying catalog ranges visible, so that I can sign off on lab automation against published clinical guidelines. |
+| US-5 | As a **biomedical scientist** maintaining catalog metadata, I want predicates that need ranges or thresholds to be visibly disabled in the picker with a reason ("needs critical thresholds in the catalog"), so that I know what catalog work I need to complete to unlock a question. |
+| US-6 | As a **microbiology / molecular technologist**, I want to author a rule that combines analyzer-level raw values (melting points, band-present flags, internal-control validity) with reported results to produce a coded interpretation (e.g., "Wild type" vs "Rifampicin resistance suspected" for TB GenoType MTBDRplus), so that interpretation logic lives in OpenELIS as auditable rules rather than in technologists' heads. |
+
+---
+
+## 3. Functional Requirements
+
+### 3.1 List View
+
+**MVP is one page.** This is important to clarify before reading the rest of the FRS or looking at the mockups: the entire MVP product surface is the single route `/MasterListsPage/testRules` (the list view). Editing happens via inline row expansion — there is no separate editor route in MVP. Algorithms and multi-step calculations show an "Open in editor" CTA on their expanded row but those linked editors are Phase 2 work.
+
+The dedicated preview files (`reflex-tests-redesign-preview.html`, `calculated-values-redesign-v2-preview.html`, `calc-decision-table-preview.html`) show the editors **at full width** so design reviewers can see them clearly, but those editors render *inside* an expanded list row in production. The list view preview (`test-rules-list-view-preview.html`) demonstrates the entry point and the navigation model; its placeholder inline editor is replaced by the real editor from the dedicated previews at implementation time.
+
+**FR-1 · Unified Test Rules list.** A single admin page at `/MasterListsPage/testRules` lists every rule in the system. The legacy `reflex` and `calculatedValue` routes redirect to this page with the appropriate type filter pre-applied.
+
+**FR-2 · Plain-language rule summary.** Each row renders the rule as `WHEN [predicate(s)] THEN [actions]` in colored phrase chips, not as code. Example: `WHEN TSH is outside normal AND FT4 is less than 0.7 THEN Order Thyroid Antibody Panel + add external note`.
+
+**FR-3 · Type, status, and trigger columns.** Each row shows: rule type (Rule / Calculation), status (Active / Disabled), trigger description ("On TSH result," "On all inputs resulted"), last edited (date + author), and an overflow action menu.
+
+**FR-4 · Filters.** Filter rules by type, status, trigger sample type, and trigger test. Filters are URL-encoded so links are shareable.
+
+**FR-5 · Search.** Free-text search across rule name, referenced test name, test ID, LOINC code, and rule summary text. Search results update live as the user types; debounce 150 ms.
+
+**FR-6 · Inline expansion.** Clicking a row's chevron expands it inline to reveal the editor. Only one row at a time may be expanded. Clicking the chevron again, or any other row, collapses the current and (optionally) expands the next.
+
+**FR-7 · + New menu.** A primary "+ New" button on the toolbar reveals two options for MVP: *Simple rule* (Reflex) and *Simple calculation* (Calculated Value). Each menu item carries a one-line description of when to use it. *Algorithm* and *Multi-step calculation* are visible but disabled with "Phase 2" labels.
+
+**FR-8 · Counts row.** A small counts strip above the toolbar shows total rules, active count, and per-type counts (Rules: N · Calcs: M). Each count is a clickable filter shortcut.
+
+### 3.2 Common Authoring Concepts
+
+**FR-9 · Rule name, status, trigger sample.** Every rule has a required name (≤ 120 chars), a status (Active / Disabled), and a trigger sample type (Serum / Plasma / Whole Blood / EDTA Tube / Urines / etc., or "Any sample type"). These appear in a single field-row at the top of every editor.
+
+**FR-10 · Sample-type scope on Calculated Values.** Each Calculated Value rule has an "Applies to" control: *All sample types* (rule fires whenever every input test has a numeric result regardless of sample type) or *Selected sample types* (rule fires only on the listed sample types). Multi-select chips list the selected sample types. Default for new rules: *Selected sample types* containing the trigger sample.
+
+**FR-11 · Multiple conditions with AND/OR.** Both Reflex and Calculated Values support compound conditions. Conditions are joined with AND or OR. Parens for grouping are supported in Formula bar (Calculated Values) but not in MVP Compose mode (defer nested groups to Phase 2 — flat AND/OR is sufficient for the rules a lab authors at MVP launch).
+
+**FR-12 · Multiple actions per rule.** Reflex rules carry an ordered list of actions. Calculated Value rules write exactly one final result (the destination test) per rule but may include note actions in MVP — currently this is captured as a single action of type `compute`. (Multi-step calcs writing multiple intermediates are Phase 2.)
+
+### 3.3 Reflex Authoring — Compose Mode
+
+**FR-13 · Compose mode is the default Reflex editor.** Conditions are authored as a row-list. The first row begins "WHEN"; subsequent rows pick AND or OR from a joiner dropdown. Each row has three picker controls: test, predicate (question), and (when the predicate takes a value) one or more value inputs.
+
+**FR-14 · Test picker.** Each condition row's test picker is a searchable combobox over all numeric and coded tests in the Test Catalog. Reflex-only tests (those orderable but not result-producing) are excluded from condition rows.
+
+**FR-15 · Predicate picker.** After picking a test, the predicate dropdown shows all available predicates grouped into three optgroups:
+
+- **Catalog-based** — uses the test's reference range, critical thresholds, or delta threshold. Includes: `is within the normal range`, `is outside the normal range`, `is above the normal range`, `is below the normal range`, `is critically high`, `is critically low`, `is at a critical value (either direction)`, `has an abnormal flag`. (The `has changed significantly from the prior result` predicate is included when the catalog defines a delta threshold for that test.)
+- **Specific value** — author enters a numeric threshold. Includes: `is greater than (>)`, `is at least (≥)`, `is less than (<)`, `is at most (≤)`, `is exactly (=)`, `is between (inclusive)`. Available on every numeric test regardless of catalog metadata.
+- **Coded value** — for tests with discrete coded results (HIV Reactive/Non-Reactive, Strep Positive/Negative). Two predicates only: `is…` and `is not…`. Both take a multi-select set of coded values; the rendered phrase reads "X is Reactive" (single) or "X is Reactive or Weak Reactive" (multi).
+
+**FR-16 · Predicate availability — disabled with reason.** Predicates the selected test cannot support are shown in the dropdown but disabled, with the unmet requirement appended to the label. Example for a coded test: `is critically high — needs critical thresholds in the catalog`. The five disabling reasons are: needs a reference range, needs critical thresholds, needs a delta threshold, needs coded values, needs a numeric test type.
+
+**FR-17 · Value input per predicate.** When a predicate with a `valueInput` field is selected, an input renders inline next to the predicate dropdown. Input types: `number` (single number with units label), `range` (two numbers joined by "and"), `coded` (single-select from the test's coded values), `codedMulti` (checkbox set over the coded values).
+
+**FR-18 · Rule reads as.** A persistent blue panel at the top of the editor renders the entire rule as a flowing plain-English sentence using the test names, predicate phrases (with substituted values where applicable), and the AND/OR joiners. Example: *"Reflex the thyroid antibody panel when **TSH** is outside the normal range **AND** **FT4** is less than 0.7 ng/dL."* This is the artifact reviewers sign off on.
+
+**FR-19 · Action list with prominent + Add affordance.** Below the conditions, a "THEN do all of the following" section lists actions. Each action row has: an action-type dropdown, type-specific fields, and a delete control. Below the rows, a full-width dashed blue `+ Add another action` button with hint text listing available action types.
+
+**FR-20 · Action types — MVP.** Three action types: `Order Test or Panel`, `Internal Note` (visible to lab staff only), `External Note` (visible to clinician). The `Order Test or Panel` action carries: target (test or panel), priority (Routine / STAT / Urgent), and an optional reason string. `Send Alert` is Phase 2 (needs alerts subsystem integration). `Set Priority` is intentionally NOT included — priority is already a field on `Order Test`; a standalone "set priority" action was confusing and is removed from the design.
+
+### 3.4 Calculated Values Authoring — Formula Bar
+
+**FR-21 · Formula bar is the default Calculated Values editor.** A monospace text input with syntax-highlighted overlay. Identifiers are colored by token type (test result → blue, function → purple, operator → pink, constant → green). Unknown identifiers are underlined with a red wavy line and surfaced in the inline lint summary.
+
+**FR-22 · Variable picker side panel.** A tabbed side panel lists insertable items grouped by Test Results, Patient Attributes (Age, Sex, Sample), and Functions (`min`, `max`, `mean`, `log`, `pow`, `round`, `if`, `eq`). Each entry is click-to-insert at the cursor.
+
+**FR-22a · Keyboard shortcut for variable picker.** Typing `@` in the formula bar opens an inline autocomplete picker at the cursor anchored to the current word, identical in shape to the side panel's match list. **Do not use `/`** — it conflicts with the division operator and would break arithmetic formulas like Friedewald LDL (`TC - HDL - TRIG/5`). Functions are surfaced via `Ctrl+Space`. `Escape` closes the inline picker. `Tab` or `Enter` accepts the highlighted suggestion. The `@` glyph is consumed when the user selects a suggestion (it's the trigger, not part of the inserted identifier). If no suggestion exists, the literal `@` is preserved and a lint warning marks it as an unknown character.
+
+**FR-23 · Math view (rendered formula).** Below the formula bar, a read-only "Rendered" panel displays the formula in proper math notation: variables shown as pills with their units, division rendered as a fraction bar, parens balanced. This is the artifact reviewers sign off on for calculated values.
+
+**FR-24 · Live preview with sample inputs.** A right pane shows one numeric input per variable referenced in the formula. As the author edits inputs or the formula itself, the computed output recomputes and renders in a green result tile with the output's units. If the computed value falls in a flagged reference range, the flag (e.g., "Optimal," "Borderline high") renders below the value.
+
+**FR-25 · Output destination.** Each Calculated Value rule writes to exactly one destination test in the Test Catalog. The destination test is selected via the same searchable test picker (FR-27).
+
+**FR-26 · Catalog-based and specific-value references in `if()`.** Calculated Values support semantic predicates inside `if()` (e.g., `if(isFemale(Sex), formula1, formula2)`). The flowchart panel rendering branching is Phase 2; MVP renders `if()` as text.
+
+### 3.4a Calculated Value Output Kind — Numeric vs Coded
+
+**FR-26a · Output kind is driven by the destination test.** Every Calculated Value rule writes to exactly one destination test in the Test Catalog. The rule's output kind is determined by the destination test's `type` field: a numeric destination yields a `numeric` output kind; a coded destination yields a `coded` output kind. Authors do not toggle output kind separately — choosing the destination chooses the editor.
+
+**FR-26b · Numeric output → formula bar.** When output kind is `numeric`, the editor uses the Formula bar pattern (FR-21 through FR-26): one formula expression, math view, live preview against sample inputs, units, decimals, optional `if()` branches.
+
+**FR-26c · Coded output → decision table.** When output kind is `coded`, the editor uses a Decision Table pattern. The author writes a list of rules; each rule is a Compose-style condition block (using the same predicate vocabulary as Reflex) plus a single result picker drawn from the destination test's coded value list. Evaluation is top-down, first match wins. The rule list is followed by a required **Otherwise** row whose result also picks from the destination's coded values; this guarantees every input produces a defined output. Each rule supports the move-up / move-down / delete controls in its header.
+
+**FR-26d · Coded output simulator.** The right pane of a coded-output editor shows one input control per referenced input (test result or analyzer parameter). As inputs change, the simulator evaluates all rules top-down and displays the computed result with the matched rule number (or "Otherwise — fell through" when no rule matches). Result rendering matches the destination test's display formatting.
+
+**FR-26e · Coded-output rule reads-as preview.** Each rule renders an inline plain-English sentence summarizing its condition chain. The decision table header shows the destination test name and possible-values chips at the top of the editor.
+
+### 3.4b Analyzer Parameters as Rule Inputs
+
+**FR-26f · Analyzer parameter as TestRef target.** A condition row's input is not limited to a test's reported result. When the catalog associates analyzer parameters with a test (FR-26h), each parameter becomes a selectable input in the input picker. The reference shape is `{ testId, paramId? }` — `paramId` absent means "the test result," `paramId` present means "this analyzer parameter for this test."
+
+**FR-26g · Picker distinguishes results from parameters.** The input picker shows analyzer parameters and reported results as siblings in the same searchable list. Each option carries a distinct chip — `RESULT` (blue) vs `PARAM` (purple) — and a metadata line showing the parameter ID, units, and (for coded params) possible values. Search matches against the parameter's name, its parent test's ID, and its parameter ID (e.g., `TB_GT.rpoB_mp`).
+
+**FR-26h · Analyzer parameter metadata in catalog.** The Test Catalog optionally stores a list of analyzer parameters per test. Each parameter has: a parameter ID (unique within the test), a human-readable name, a type (`numeric` or `coded`), units (for numeric), reference range (for numeric, optional), and possible values (for coded). The metadata is populated from the existing **QC table**: instrument-side fields already captured for QC purposes are linked to patient results at result-import time, then surfaced to the catalog and to the rule editor.
+
+**FR-26i · Predicate vocabulary applies uniformly.** All predicates from §3.3 (`isOutsideNormal`, `isCritical`, `gt`, `between`, `is`, `isNot`, etc.) work on analyzer parameters the same way they work on test results. Availability is governed by parameter metadata using the same rules in FR-16: a numeric parameter with a `refRange` supports catalog-based predicates; a coded parameter supports `is`/`is not`; all numeric parameters support specific-value comparison predicates.
+
+**FR-26j · Catalog reference card includes parameters.** The right-pane Test Catalog reference card (FR-30) lists the analyzer parameters for each referenced test, grouped under a section labeled "Analyzer parameters" with a source indicator ("via QC table linkage · N captured"). Each parameter row shows its ID, name, type, and the relevant catalog metadata (units, range, or values).
+
+### 3.5 Test / Panel Picker
+
+**FR-27 · Searchable picker.** The picker is a combobox with:
+- A text input that filters in real time across name, ID, and LOINC code.
+- A selected-item pill (with a clear ✕) showing the picked entity, its kind chip (Test or Panel), name, and ID.
+- A dropdown list of matches grouped by Tests and Panels with section headers and counts.
+- Each match row shows: kind chip, name, metadata line (ID, LOINC or type, units, panel members if applicable), and the sample-type chip.
+- Match list is capped at 12 tests + 8 panels visible at once with "…and N more — refine your search" overflow.
+
+**FR-28 · Sample-type filter.** At the top of the picker dropdown, two radio buttons:
+- **Same sample type only** (default) — filters to entities whose sample matches the rule's trigger sample.
+- **All sample types — requires new collection** — broadens the search. An amber warning bar appears in the dropdown: *"Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. The lab will need to collect a new specimen."*
+
+**FR-29 · Cross-sample audit reason.** When a rule's order target uses a different sample type than the trigger sample, the rule must carry an `auditReason` string field (≤ 240 chars) explaining the cross-sample justification. The reason is shown on the rule's row in the list view, on the order itself when the rule fires, and in the rule's revision history. Save fails with an inline error if the reason is missing for any cross-sample target.
+
+### 3.6 Test Catalog Reference
+
+**FR-30 · Catalog reference card.** The right pane of every Reflex rule editor includes a "Test catalog data" card listing each test referenced by the rule's conditions. Each card shows the test's reference range, critical thresholds, delta threshold, and coded values from the catalog. Missing fields render as grey-italic placeholders ("No critical thresholds set"). A "→ Edit in Test Catalog" link opens the test's catalog entry in a new tab.
+
+**FR-31 · Symbolic references in stored AST.** Catalog-based predicates store a symbolic reference to the test, not a snapshot of the range values. When a test's reference range or critical thresholds change in the catalog, every rule using a catalog-based predicate on that test reflects the change without requiring re-edit or re-save.
+
+**FR-32 · Catalog change audit log.** A reference-range or critical-threshold change in the Test Catalog generates an audit-log entry that includes: which catalog field changed, the old and new values, the user who made the change, the timestamp, and a list of every rule (by ID) whose evaluation behavior changed as a result. The list view exposes a filter "Rules affected by recent catalog change" that shows only rules whose evaluation may have shifted in the last 30 days.
+
+### 3.6a Unified Input Picker
+
+**FR-30a · One Input Picker component used everywhere.** A single React component (`UnifiedInputPicker`) handles every place the user is selecting something testable. The picker has two modes:
+
+- **`mode: 'input'`** — for condition rows. Search across test results AND analyzer parameters. No panels. No sample-type filter.
+- **`mode: 'target'`** — for action targets (Order Test or Panel). Search across tests AND panels. No analyzer parameters. Sample-type filter active (same-sample default; "All sample types — requires new collection" override).
+
+The picker renders as a chip-style trigger button showing the human-readable name and a small monospace technical ID. The dropdown panel includes a search field, optgroup-style section headers (Tests / Analyzer parameters / Panels), and per-row kind chips (`RESULT` / `PARAM` / `PANEL`).
+
+**FR-30b · Picker accessibility.** The trigger is a `<button>` with `aria-haspopup="listbox"` and `aria-expanded`. The dropdown panel is `role="listbox"`. Escape closes the dropdown and returns focus to the trigger. Clicking outside also closes. Items are buttons; keyboard arrow navigation through the dropdown is required.
+
+**FR-30c · Picker selected-value clear control.** The trigger chip carries an inline ✕ that clears the selection without opening the dropdown. The clear button is accessible (`role="button"`, `aria-label="Clear selection"`).
+
+### 3.7 Save, Validation, and Status
+
+**FR-33 · Save validates required fields.** Save fails if: rule name is blank or > 120 chars; no conditions are defined; any condition row is incomplete (test, predicate, or required value missing); no actions are defined; any action's target or required field is missing; cross-sample reflex audit reason is missing.
+
+**FR-34 · Status toggle with confirmation.** Each rule has a single `Active / Disabled` toggle. The legacy "Toggle Rule" switch and "Active: true" checkbox duplicate of the current UI is replaced with this one control. Disabled rules never fire but remain editable. Switching from Active to Disabled prompts a confirmation modal (Carbon `Modal` with `kind="danger"`) explaining the consequences ("this rule will stop firing immediately on save; existing reflex orders are not affected; you can re-enable any time from the row's overflow menu"). Re-enabling does not require confirmation.
+
+**FR-35 · Audit metadata.** Each rule stores `createdAt`, `createdBy`, `updatedAt`, `updatedBy`, and `revisionCount`. The list view exposes "last edited by" inline.
+
+### 3.8 UI States
+
+**FR-36 · Empty state — list view.** When the system has zero rules (fresh deployment) or current filters yield zero matches, the table is replaced with an empty-state block containing an icon, a title, an explanatory subtitle, and a primary "+ Create your first rule" button. The empty-state distinguishes "no rules exist" from "no matches" via the subtitle copy.
+
+**FR-37 · Empty state — editor.** A new rule opens with a single empty condition row and a single empty action row pre-laid-out. Placeholders read "Pick an input first to see questions you can ask." Save is disabled until the rule has at least one complete condition row and one complete action.
+
+**FR-38 · Saving state.** While a save mutation is in flight, the Save button label changes to "Saving…", the Save and Cancel buttons are `disabled`, and the Save button carries `aria-busy="true"`. The entire editor remains visible so the user understands what's being saved.
+
+**FR-39 · Save-failed state.** When save returns a validation error, an `InlineNotification` with `kind="error"` appears above the footer actions listing every problem (one per `<li>`). The first error condition or action row also receives an inline error indicator (red border on the picker or value input) and focus jumps to the first invalid field. The error block is `role="alert"` so screen readers announce it.
+
+**FR-40 · Confirmation modals for destructive actions.** A modal appears when the user: disables an Active rule (FR-34), deletes a rule, or deletes a rule via batch action (FR-41). Modal uses Carbon `Modal` with primary button `kind="danger"` and a clear consequence statement.
+
+### 3.9 List View Batch Operations
+
+**FR-41 · Multi-select on list view.** Each row has a leading checkbox. A select-all checkbox in the table header selects every row matching the current filter. Selected rows are visually highlighted.
+
+**FR-42 · Batch action bar.** When ≥ 1 row is selected, a sticky action bar appears at the top of the table with the selected count, action buttons (Enable, Disable, Export CSV, Delete…), and a Clear-selection ✕. The Delete action triggers FR-40's confirmation. Enable/Disable apply individually to each selected rule's status.
+
+**FR-43 · Batch operation safety.** Batch Delete shows the count of rules to be deleted in the confirmation modal and requires the user to type "DELETE" before the confirm button is enabled (Phase 2 — MVP uses a single-tap confirm with the count).
+
+---
+
+## 4. Data Model
+
+### 4.1 Rule entity
+
+```
+Rule {
+  id: UUID
+  name: String(120)
+  type: enum { reflex, calc }
+  status: enum { active, disabled }
+  triggerSample: SampleType | "any"
+
+  // Reflex-only
+  conditionTree: ConditionAST?      // present when type=reflex
+  actions: List<Action>?            // present when type=reflex
+
+  // Calc-only
+  destinationTest: TestRef?         // present when type=calc; drives outputKind
+  outputKind: enum { numeric, coded }? // derived from destinationTest's type
+  formula: FormulaAST?              // present when type=calc AND outputKind=numeric
+  decisionTable: DecisionTable?     // present when type=calc AND outputKind=coded
+  outputUnits: String?              // numeric calc only
+  outputDecimals: Integer?          // numeric calc only
+  appliesTo: SampleScope            // calc only — {mode: 'all'|'selected', samples: List<SampleType>}
+
+  // Shared
+  auditReason: String(240)?         // required if any reflex action or calc input crosses sample type
+  createdAt, updatedAt: Timestamp
+  createdBy, updatedBy: UserRef
+  revisionCount: Integer
+}
+```
+
+### 4.2 Condition AST
+
+```
+ConditionAST = ConditionGroup | Predicate
+
+ConditionGroup {
+  op: enum { AND, OR }
+  children: List<ConditionAST>     // MVP: flat list (depth = 1); Phase 2 allows nesting
+}
+
+Predicate {
+  predicateId: String              // e.g. "isOutsideNormal", "gt", "is", "isNot"
+  testRef: TestRef                 // symbolic reference into Test Catalog (see 4.3a)
+  value?: Number | [Number, Number] | String | List<String>
+                                   // shape depends on predicateId's valueInput
+}
+```
+
+### 4.2a TestRef — reported result OR analyzer parameter
+
+```
+TestRef {
+  testId: TestID
+  paramId?: AnalyzerParamID        // when present, the predicate references the named
+                                   // analyzer parameter on this test, not the reported result
+}
+```
+
+Examples:
+- `{ testId: "TSH" }` — TSH's reported numeric result.
+- `{ testId: "HIV_Screen" }` — HIV Screen's reported coded result.
+- `{ testId: "TB_GT", paramId: "rpoB_mp" }` — rpoB melting point captured by the TB GenoType analyzer.
+- `{ testId: "TB_GT", paramId: "IC" }` — TB GenoType internal-control validity flag.
+
+### 4.2b DecisionTable — coded-output Calculations
+
+```
+DecisionTable {
+  rules: List<DecisionRule>
+  otherwise: CodedValue            // required — picks from destinationTest's coded values
+}
+
+DecisionRule {
+  id: Integer                      // stable within the table; used for revision diffs
+  condition: ConditionAST          // same shape as Reflex conditions
+  result: CodedValue               // picks from destinationTest's coded values
+}
+```
+
+Evaluation: rules are evaluated top-down in order; the first whose `condition` evaluates to true determines the result. If no rule matches, the `otherwise` value is the result. Order is preserved across saves and is the author's responsibility (move-up / move-down controls in the editor).
+
+### 4.3 Predicate catalog (MVP set)
+
+| ID | Group | Requires (catalog metadata) | Value input | Compiles to |
+|----|-------|------------------------------|-------------|-------------|
+| `isNormal`             | catalog | refRange      | none      | `T >= refLow AND T <= refHigh` |
+| `isOutsideNormal`      | catalog | refRange      | none      | `T < refLow OR T > refHigh` |
+| `isAboveNormal`        | catalog | refRange      | none      | `T > refHigh` |
+| `isBelowNormal`        | catalog | refRange      | none      | `T < refLow` |
+| `isCritical`           | catalog | criticalRange | none      | `T <= criticalLow OR T >= criticalHigh` |
+| `isCriticallyHigh`     | catalog | criticalRange | none      | `T >= criticalHigh` |
+| `isCriticallyLow`      | catalog | criticalRange | none      | `T <= criticalLow` |
+| `isFlagged`            | catalog | refRange      | none      | `flag(T) != "N"` |
+| `changedSignificantly` | catalog | deltaPct      | none      | `abs(T - prior(T)) / prior(T) * 100 >= deltaPct` |
+| `gt`, `gte`, `lt`, `lte`, `eq` | value | numeric | number | `T <op> v` |
+| `between`              | value   | numeric       | range     | `T >= lo AND T <= hi` |
+| `is`                   | coded   | values        | codedMulti| `T == "v"` or `T IN (...)` |
+| `isNot`                | coded   | values        | codedMulti| `T != "v"` or `T NOT IN (...)` |
+
+### 4.4 Action
+
+```
+Action = OrderAction | NoteAction
+
+OrderAction {
+  kind: "order"
+  target: { kind: "test" | "panel", id: ID }
+  priority: enum { routine, stat, urgent }
+  reason: String(240)?
+}
+
+NoteAction {
+  kind: "note_internal" | "note_external"
+  text: String(2000)
+}
+```
+
+### 4.5 Formula AST (Calculated Values)
+
+```
+FormulaAST = Literal | TestRef | AttrRef | BinaryOp | FunctionCall | IfExpression
+
+Literal       { value: Number }
+TestRef       { testId: TestID }
+AttrRef       { attrId: "Age" | "Sex" | "Sample" }
+BinaryOp      { op: enum { +,-,*,/,>,<,>=,<=,==,!=,AND,OR }, left, right }
+FunctionCall  { fn: enum { min, max, mean, log, pow, round, if, eq, abs }, args: List<FormulaAST> }
+IfExpression  { condition: FormulaAST, then: FormulaAST, else: FormulaAST }
+```
+
+### 4.6 Test Catalog dependencies
+
+The redesign treats the Test Catalog as the source of truth for:
+- Test ID, name, LOINC code, type (numeric / coded / reflex)
+- Sample type
+- Units
+- Reference range (`refLow`, `refHigh`)
+- Critical thresholds (`criticalLow`, `criticalHigh`)
+- Delta threshold percentage
+- Coded values (for coded-result tests)
+- **Analyzer parameters** (list per test, see §4.6a)
+
+The MVP assumes all of the above are already capturable in the existing OpenELIS test catalog. Open Question OQ-3 in §11 calls out the items that may need schema work.
+
+### 4.6a Analyzer parameters
+
+Each Test in the catalog optionally carries a list of analyzer parameters that the analyzer reports alongside the reportable result:
+
+```
+AnalyzerParameter {
+  id: AnalyzerParamID              // unique within the parent test (e.g., "rpoB_mp", "IC")
+  name: String                     // human-readable label
+  type: enum { numeric, coded }
+  units?: String                   // when type=numeric
+  refRange?: [Number, Number]      // when type=numeric — informational, enables catalog-based predicates
+  values?: List<String>            // when type=coded
+}
+```
+
+**Source of parameter data:** Analyzer parameters are sourced from the existing QC table in OpenELIS, which already captures instrument-side fields for quality control purposes. The required change is:
+
+1. **At result import time**, when an analyzer reports a patient result, the same instrument-side fields already captured for QC are associated with the patient's `Result` record as `analyzerParameterValues` keyed by `paramId`.
+2. **The Test Catalog editor** is extended to allow per-test definition of which analyzer parameters are exposed for rule authoring. The mapping between catalog `paramId` and the QC-table field is the catalog's responsibility.
+
+This is the only new persistence work in MVP scope.
+
+### 4.7 Panel entity
+
+```
+Panel {
+  id: ID
+  name: String
+  sample: SampleType
+  testIds: List<TestID>          // ordered list of constituent tests
+}
+```
+
+Panels are first-class catalog entities for MVP. If they are not already first-class in OpenELIS (Open Question OQ-4), a panel-management UI in Test Catalog is a co-dependency of MVP.
+
+---
+
+## 5. UI / UX Specification
+
+### 5.1 Layout patterns
+
+- **List view → inline expansion** for rule editing (per Constitution: no modals for forms).
+- **Two-pane editor** inside the expansion: left = authoring (Compose or Formula bar), right = reference (Test Catalog data card for Reflex; Live Preview for Calculated Values).
+- **Full-width Add CTAs** for Add Condition / Add Action: dashed blue border, plus-circle badge, clear label and hint text.
+- **Persistent rule preview** ("Rule reads as") at the top of every editor.
+
+### 5.2 Primary Carbon components
+
+- `DataTable` — rule list with column headers, sortable.
+- `Tile` — editor panels (left pane, right pane).
+- `Tag` — status (green Active / gray Disabled), type chips, sample-type chips.
+- `ComboBox` — searchable test/panel picker; variable picker for Calculated Values.
+- `MultiSelect` — sample-type scope selection on calc rules.
+- `Select` — predicate dropdown (with native `optgroup` + `disabled` options for unavailable predicates).
+- `TextInput`, `NumberInput`, `TextArea` — name, reason, note, value inputs.
+- `Toggle` — Active/Disabled status.
+- `Accordion` — collapsible Test Catalog reference card, advanced settings.
+- `Button` (primary, secondary, ghost, danger) — Save, Cancel, action add, delete row.
+- `InlineNotification` — validation errors on save; cross-sample warning in picker.
+- `Modal` — only for destructive confirmation (delete rule).
+
+### 5.3 Token color conventions
+
+| Token kind | Color | Use |
+|------------|-------|-----|
+| Test variable      | `#0043ce` (blue 70) | Test ID references |
+| Patient attribute  | `#a2191f` (red 70) | Age, Sex, Sample |
+| Function           | `#491d8b` (purple 70) | min, max, log, if |
+| Predicate (rendered phrase) | `#0072c3` (cyan 60) | isOutsideNormal in text form |
+| Operator           | `#d12771` (magenta 60) | `+`, `-`, `*`, `/`, `>`, etc. |
+| Boolean keyword    | `#8a3ffc` (purple 50) | AND, OR, NOT, IN |
+| Number             | `#198038` (green 50) | Literals |
+| String / coded     | `#0e6027` (green 60) | "Reactive" |
+| Unknown identifier | `#a2191f` underline wavy | Lint error |
+
+### 5.4 Accessibility (WCAG 2.1 AA)
+
+- All form controls keyboard accessible.
+- The Compose row joiner dropdown receives focus order between rows.
+- The searchable picker is keyboard-navigable: Tab into the search input, arrow keys to move through matches, Enter to select, Escape to close.
+- Color contrast on token rendering meets 4.5:1 against the white panel background (verified for the chosen IBM Plex Sans body weight).
+- Disabled predicate options retain their disabled-reason text in the option label (not as a tooltip alone) so screen readers announce the reason.
+- The "Cross-sample reflex" warning bar uses both the amber color and a ⚠ icon plus explicit text — not color alone.
+
+---
+
+## 6. Localization
+
+Every visible UI string is wrapped in `t(key, fallback)` per Constitution Principle 1. Keys follow the `rules.[area].[identifier]` convention.
+
+| Key | English fallback | Context |
+|-----|------------------|---------|
+| `rules.list.page_title` | Test Rules | List page H1 |
+| `rules.list.search_placeholder` | Search rules by name, test, or destination… | Toolbar search |
+| `rules.list.new_button` | + New | Toolbar primary button |
+| `rules.list.new_rule` | Simple rule | + New menu item |
+| `rules.list.new_calc` | Simple calculation | + New menu item |
+| `rules.list.col_type` | Type | Table column |
+| `rules.list.col_status` | Status | Table column |
+| `rules.list.col_rule` | Rule | Table column |
+| `rules.list.col_trigger` | Trigger | Table column |
+| `rules.list.col_edited` | Last edited | Table column |
+| `rules.list.filter_status_all` | Status: All | Filter pill |
+| `rules.list.filter_sample_all` | Sample: All | Filter pill |
+| `rules.list.empty_message` | No rules match your filters. | Empty state |
+| `rules.status.active` | Active | Status tag |
+| `rules.status.disabled` | Disabled | Status tag |
+| `rules.type.rule` | Rule | Type chip |
+| `rules.type.calc` | Calculation | Type chip |
+| `rules.editor.name_label` | Rule name | Editor field label |
+| `rules.editor.trigger_sample_label` | Trigger sample | Editor field label |
+| `rules.editor.when_block` | WHEN | Block header |
+| `rules.editor.then_block` | THEN do all of the following | Block header |
+| `rules.editor.reads_as_label` | RULE READS AS | Preview header |
+| `rules.editor.add_condition` | Add another condition | Add CTA |
+| `rules.editor.add_condition_hint` | join with AND or OR | Add CTA hint |
+| `rules.editor.add_action` | Add another action | Add CTA |
+| `rules.editor.add_action_hint` | Order test · Order panel · Note | Add CTA hint |
+| `rules.editor.save` | Save changes | Footer button |
+| `rules.editor.cancel` | Cancel | Footer button |
+| `rules.compose.pick_test` | — select test — | Test picker placeholder |
+| `rules.compose.pick_question` | — pick a question — | Predicate picker placeholder |
+| `rules.compose.pick_test_first` | Pick a test first to see questions you can ask | Predicate picker disabled state |
+| `rules.compose.joiner_when` | WHEN | First-row joiner label |
+| `rules.compose.joiner_and` | AND | Joiner option |
+| `rules.compose.joiner_or` | OR | Joiner option |
+| `rules.action.order` | Order Test or Panel | Action type |
+| `rules.action.note_internal` | Internal Note | Action type |
+| `rules.action.note_external` | External Note | Action type |
+| `rules.action.priority_routine` | Routine | Priority option |
+| `rules.action.priority_stat` | STAT | Priority option |
+| `rules.action.priority_urgent` | Urgent | Priority option |
+| `rules.action.reason_placeholder` | Reason (visible on order) | Reason input placeholder |
+| `rules.action.note_internal_placeholder` | Internal note (visible to lab staff) | Note input placeholder |
+| `rules.action.note_external_placeholder` | External note (visible to clinician) | Note input placeholder |
+| `rules.picker.search_placeholder` | Search tests and panels… | Picker input placeholder |
+| `rules.picker.scope_same` | Same sample type only | Picker filter radio |
+| `rules.picker.scope_all` | All sample types | Picker filter radio |
+| `rules.picker.scope_warning` | requires new collection | Picker filter chip |
+| `rules.picker.cross_sample_warning` | Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. The lab will need to collect a new specimen. | Picker amber warning |
+| `rules.picker.no_matches` | No matches. | Empty results |
+| `rules.picker.tests_section` | Tests | Section header |
+| `rules.picker.panels_section` | Panels | Section header |
+| `rules.predicate.is_normal` | is within the normal range | Catalog predicate label |
+| `rules.predicate.is_outside_normal` | is outside the normal range | Catalog predicate label |
+| `rules.predicate.is_above_normal` | is above the normal range | Catalog predicate label |
+| `rules.predicate.is_below_normal` | is below the normal range | Catalog predicate label |
+| `rules.predicate.is_critical` | is at a critical value (either direction) | Catalog predicate label |
+| `rules.predicate.is_critically_high` | is critically high | Catalog predicate label |
+| `rules.predicate.is_critically_low` | is critically low | Catalog predicate label |
+| `rules.predicate.is_flagged` | has an abnormal flag | Catalog predicate label |
+| `rules.predicate.changed_significantly` | has changed significantly from the prior result | Catalog predicate label |
+| `rules.predicate.gt` | is greater than (>) | Value predicate label |
+| `rules.predicate.gte` | is at least (≥) | Value predicate label |
+| `rules.predicate.lt` | is less than (<) | Value predicate label |
+| `rules.predicate.lte` | is at most (≤) | Value predicate label |
+| `rules.predicate.eq` | is exactly (=) | Value predicate label |
+| `rules.predicate.between` | is between (inclusive) | Value predicate label |
+| `rules.predicate.is` | is… | Coded predicate label |
+| `rules.predicate.is_not` | is not… | Coded predicate label |
+| `rules.predicate.disabled_refrange` | needs a reference range in the catalog | Disabled-reason suffix |
+| `rules.predicate.disabled_critical` | needs critical thresholds in the catalog | Disabled-reason suffix |
+| `rules.predicate.disabled_delta` | needs a delta threshold in the catalog | Disabled-reason suffix |
+| `rules.predicate.disabled_values` | needs coded values in the catalog | Disabled-reason suffix |
+| `rules.predicate.disabled_numeric` | needs a numeric test type | Disabled-reason suffix |
+| `rules.catalog_ref.title` | Test catalog data | Right-pane title |
+| `rules.catalog_ref.subtitle` | What's defined in the catalog for each test in this rule. | Right-pane subtitle |
+| `rules.catalog_ref.no_refrange` | No reference range set | Missing-metadata placeholder |
+| `rules.catalog_ref.no_critical` | No critical thresholds set | Missing-metadata placeholder |
+| `rules.catalog_ref.no_delta` | No delta threshold set | Missing-metadata placeholder |
+| `rules.catalog_ref.edit_link` | Edit in Test Catalog | Catalog deep link |
+| `rules.calc.applies_to_label` | Applies to | Sample-scope header |
+| `rules.calc.applies_to_all` | All sample types | Sample-scope radio |
+| `rules.calc.applies_to_selected` | Selected sample types | Sample-scope radio |
+| `rules.calc.output_dest_label` | Destination test | Output picker label |
+| `rules.calc.output_units_label` | Units | Output units label |
+| `rules.calc.output_decimals_label` | Decimals | Output decimals label |
+| `rules.calc.preview_title` | Live preview | Preview pane title |
+| `rules.calc.preview_subtitle` | Edit the formula on the left or change inputs here. Output recomputes live. | Preview pane subtitle |
+| `rules.calc.computed_label` | Computed | Computed-value tile label |
+| `rules.calc.flag_label` | Flag | Flag inline label |
+| `rules.error.name_required` | Rule name is required. | Save validation error |
+| `rules.error.no_conditions` | Add at least one condition. | Save validation error |
+| `rules.error.no_actions` | Add at least one action. | Save validation error |
+| `rules.error.incomplete_condition` | One or more conditions are incomplete. | Save validation error |
+| `rules.error.cross_sample_reason_required` | Cross-sample reflex requires an audit reason. | Save validation error |
+| `rules.error.otherwise_required` | Pick an Otherwise result so every input produces a defined output. | Save validation error |
+| `rules.calc.output_kind_label` | Output type | Editor field label |
+| `rules.calc.output_kind_numeric` | Numeric | Output kind chip |
+| `rules.calc.output_kind_coded` | Coded | Output kind chip |
+| `rules.calc.output_destination_label` | Output goes to | Decision-table destination header |
+| `rules.calc.output_destination_hint` | Because the destination is a coded test, the editor uses a decision table instead of a formula bar. Each row maps a condition to one of the possible result values. First match wins. | Decision-table editor hint |
+| `rules.calc.decision_rule_n` | Rule {n} | Decision rule card title |
+| `rules.calc.then_result_is` | THEN result is | Decision rule THEN bar label |
+| `rules.calc.pick_result` | — pick a result — | Result picker placeholder |
+| `rules.calc.otherwise_title` | Otherwise (if no rule above matches) | Otherwise row title |
+| `rules.calc.otherwise_subtitle` | A catch-all so every input produces a defined output. Required. | Otherwise row subtitle |
+| `rules.calc.add_decision_rule` | Add another rule | + Add rule CTA |
+| `rules.calc.add_decision_rule_hint` | evaluated top-down; first match wins | + Add rule hint |
+| `rules.calc.move_up` | Move up | Rule card move-up button |
+| `rules.calc.move_down` | Move down | Rule card move-down button |
+| `rules.calc.delete_rule` | Delete rule | Rule card delete button |
+| `rules.calc.simulator_result_label` | Computed result | Simulator output label |
+| `rules.calc.simulator_matched` | Matched Rule {n} (top-down evaluation) | Simulator trace label |
+| `rules.calc.simulator_otherwise` | No rule matched — fell through to Otherwise. | Simulator trace label (else) |
+| `rules.picker.kind_result` | Result | Picker chip for test result |
+| `rules.picker.kind_param` | Param | Picker chip for analyzer parameter |
+| `rules.catalog_ref.params_section` | Analyzer parameters | Catalog card section header |
+| `rules.catalog_ref.params_source` | via QC table linkage · {n} captured | Catalog card source line |
+| `rules.list.empty_title` | No rules yet | List empty-state title |
+| `rules.list.empty_desc` | Reflex rules and calculations live here. Start by creating one. | List empty-state subtitle |
+| `rules.list.empty_filter_desc` | No rules match your filters. Try clearing them or change the search. | List empty-state subtitle (filtered) |
+| `rules.list.empty_create` | + Create your first rule | List empty-state CTA |
+| `rules.list.batch_count` | {n} selected | Batch action bar count |
+| `rules.list.batch_enable` | Enable | Batch action |
+| `rules.list.batch_disable` | Disable | Batch action |
+| `rules.list.batch_export` | Export CSV | Batch action |
+| `rules.list.batch_delete` | Delete… | Batch action |
+| `rules.list.batch_clear` | Clear selection | Batch clear button (sr-only label) |
+| `rules.editor.save_in_progress` | Saving… | Save button (in flight) |
+| `rules.editor.save_error_title` | Couldn't save this rule — please fix the issues below: | Save-error block title |
+| `rules.editor.disable_rule` | Disable rule | Editor disable button |
+| `rules.editor.disable_confirm_title` | Disable this rule? | Confirmation modal title |
+| `rules.editor.disable_confirm_body` | This rule will stop firing immediately on save. Existing reflex orders are not affected. You can re-enable from the row's overflow menu at any time. | Confirmation modal body |
+| `rules.editor.disable_confirm_action` | Disable rule | Confirmation modal danger button |
+| `rules.editor.cancel_action` | Cancel | Generic cancel button |
+| `rules.picker.kind_panel` | Panel | Picker chip for panel |
+| `rules.calc.formula_hint` | Press @ for variable picker · Ctrl+Space for functions | Formula bar hint text |
+
+Translators: French (`fr`) translations required at MVP launch. Spanish (`es`) and Portuguese (`pt`) by end of Phase 2.
+
+---
+
+## 7. Permissions & Security
+
+### 7.1 Permission keys
+
+| Permission | Behaviour |
+|------------|-----------|
+| `RULES_VIEW`     | Read access to the Test Rules list and editor (read-only mode hides Save, +Add buttons, delete controls). |
+| `RULES_EDIT`     | Create, edit, save, delete rules. Status toggle. |
+| `RULES_REVIEW`   | (Phase 2) Approve/sign-off on a rule before it goes Active. MVP treats Save by `RULES_EDIT` as immediately Active. |
+
+### 7.2 Enforcement
+
+- UI: every Save / Add / Delete / status toggle control is hidden or disabled when the user lacks `RULES_EDIT`.
+- API: every mutation endpoint validates `RULES_EDIT`. 403 on absence. The mutation `editJiraIssue`-style verbs (`/api/rules/:id`, `POST/PUT/DELETE`) carry server-side permission checks.
+- Audit log: every mutation records the acting user and a serialized diff.
+
+### 7.3 Open permission question
+
+Per the memory `OpenELIS admin permissions are binary`, the current OpenELIS admin permission is effectively all-or-nothing. MVP either:
+- **Option A:** Treats Rules as part of the existing admin permission (binary: any admin can edit). Simpler; matches today's behavior.
+- **Option B:** Introduces `RULES_EDIT` as a new granular permission. Requires permission system work co-scoped with this feature.
+
+Recommend Option A for MVP. Option B is Phase 2 along with `RULES_REVIEW`.
+
+---
+
+## 8. Non-Functional Requirements
+
+### 8.1 Performance
+
+- **NFR-1:** List page initial render ≤ 1.5 s for 500 rules.
+- **NFR-2:** Test/panel picker search returns results in ≤ 200 ms for a catalog of 500 tests + 50 panels.
+- **NFR-3:** Inline editor expansion ≤ 400 ms (open + content render).
+- **NFR-4:** Save mutation round-trip ≤ 1 s for a typical rule.
+- **NFR-5:** Live preview recompute (Calculated Values) ≤ 50 ms per input change.
+
+### 8.2 Browser support
+
+- Chrome / Edge / Firefox / Safari last 2 major versions.
+- The preview / production builds use no features beyond ES2020 baseline.
+
+### 8.3 Accessibility
+
+- **NFR-A1:** WCAG 2.1 AA across the entire flow.
+- **NFR-A2:** Keyboard navigation through the picker, the Compose rows, and the action list. Tab order is left-to-right, top-to-bottom. Shift+Tab reverses.
+- **NFR-A3:** Screen reader: all disabled-predicate reasons are part of the option's accessible label, not tooltip only.
+- **NFR-A4:** Collapsible cards are rendered as `<button>` elements with `aria-expanded` and `aria-controls` referencing the body region.
+- **NFR-A5:** Picker dropdown closes on Escape and returns focus to the trigger. Click-outside closes without changing selection. The dropdown panel is `role="listbox"` with arrow-key navigation through items.
+- **NFR-A6:** Modal dialogs trap focus inside the modal until dismissed. The first focusable element receives focus on open; the trigger element regains focus on close. `aria-modal="true"` is set.
+- **NFR-A7:** Inline validation errors are wired via `aria-describedby` to the offending input. The summary error block is `role="alert"` for screen-reader announcement on save failure.
+- **NFR-A8:** Color contrast: 4.5:1 for text, 3:1 for large text and UI elements. Status, kind chip, and predicate phrase tokens are verified against the Carbon white background.
+- **NFR-A9:** No information conveyed by color alone. Status uses both color and text ("Active" / "Disabled"). Cross-sample warning uses both amber color and the ⚠ icon plus explicit text.
+- **NFR-A10:** Minimum touch target size 32×32 px for action buttons, chevrons, and reorder controls per Carbon guidance.
+
+### 8.4 Auditability (ISO 15189 alignment)
+
+- Every save records a structured diff.
+- Every rule shows its revision history (Phase 2 UI; MVP stores the data).
+- Every catalog change that affects rules surfaces in the list view filter.
+- Every cross-sample reflex carries a stored audit reason.
+
+### 8.5 Internationalization
+
+- All strings via `t()`.
+- Number formatting follows the user's locale for reference-range and computed-value display.
+
+---
+
+## 9. Acceptance Criteria
+
+### 9.1 Author flows
+
+**AC-1 — List view scan:** A user opens `/admin/testRules`, the page renders 25 rules within 1.5 s. Each rule shows its name, type, status, and a plain-English WHEN/THEN summary. (Maps to FR-1, FR-2, FR-3, US-1.)
+
+**AC-2 — Author simple Reflex rule:** A user clicks `+ New → Simple rule`. The inline editor opens. The user types a rule name, selects trigger sample (Serum), picks `TSH` as the first condition's test, picks `is outside the normal range` as the predicate. No value input appears (catalog-based predicate). The user clicks `+ Add another action`, picks `Order Test or Panel`, searches "free t4", selects FT4 from the picker, clicks Save. The rule is persisted and reappears on the list with its plain-English summary. Round trip ≤ 5 s. (Maps to FR-13, FR-14, FR-15, FR-19, FR-27, US-2.)
+
+**AC-3 — Compound rule with AND:** A user adds a second condition row, picks `Free T4` and the predicate `is less than (<)`. A number input appears next to the predicate. The user types `0.7`. The "Rule reads as" preview updates to *"…when **TSH** is outside the normal range AND **FT4** is less than 0.7 ng/dL."* Save succeeds. (Maps to FR-11, FR-17, FR-18.)
+
+**AC-4 — Coded predicate:** A user picks `HIV Screen` as the test, picks `is…`. A checkbox set appears showing Reactive, Weak Reactive, Non-Reactive. User checks "Reactive". Preview reads *"…when **HIV Screen** is Reactive…"*. (Maps to FR-15 coded, FR-17 codedMulti.)
+
+**AC-5 — Disabled predicate with reason:** A user picks a coded test (HIV Screen) as the condition test. The dropdown shows `is critically high — needs critical thresholds in the catalog` greyed out. (Maps to FR-16.)
+
+**AC-6 — Picker same-sample filter:** Trigger sample = Serum. User opens the action's order picker, searches "lipid". The Lipid Panel and four lipid tests appear. User toggles to "All sample types". No new entries appear (lipids are all Serum) but the warning bar shows. (Maps to FR-27, FR-28.)
+
+**AC-7 — Cross-sample warning + reason required:** Trigger sample = Serum. User toggles picker to "All sample types", searches "blood culture". Blood Culture (Whole Blood) appears with a sample-chip "Whole Blood". User selects it. Save fails with an inline error pointing to a required `auditReason` field. User enters "Per sepsis SOP — escalation on critical glucose". Save succeeds. (Maps to FR-28, FR-29, FR-33.)
+
+**AC-8 — Calculated Value live preview:** A user creates a calc rule `LDL = TC - HDL - TRIG/5`. As they type the formula, the math view below renders `Total Cholesterol [mg/dL] − HDL [mg/dL] − Triglycerides [mg/dL] / 5` with proper fraction bar. The right pane shows three input fields (TC, HDL, TRIG). Entering TC=200, HDL=50, TRIG=150 displays computed LDL=120 with units mg/dL. Sample-type scope is set to Selected: [Serum, Plasma]. (Maps to FR-21, FR-23, FR-24, FR-10.)
+
+**AC-9 — Catalog range change propagation:** A rule references `isOutsideNormal(TSH)`. Lab IT updates TSH's reference range in the Test Catalog from `0.4–4.5` to `0.5–4.0`. The Test Rules list view shows the rule in the "Rules affected by recent catalog change" filter. The rule's compiled expression now uses the new range. (Maps to FR-31, FR-32.)
+
+**AC-10 — Plain-English preview accuracy:** Every rule rendered by FR-18 (Rule reads as) matches the user's stated intent verbatim. Reviewer / lab director can validate a rule against published guidelines without consulting the technical form. (Maps to US-4.)
+
+### 9.2 Validation flows
+
+**AC-11 — Save blocks on missing fields:** Save fails with localized inline errors for: missing name, no conditions, no actions, incomplete condition row, missing cross-sample reason. The first error receives focus.
+
+**AC-12 — Disabling a rule:** A user opens an Active rule, toggles status to Disabled, saves. The rule stops firing immediately. The list view updates the status chip. The rule remains visible (Disabled rules are not deleted).
+
+### 9.3 Catalog integration
+
+**AC-13 — Picker scales to large catalog:** A test catalog of 500 tests + 50 panels is loaded. The picker remains responsive (search latency ≤ 200 ms) and the dropdown caps visible results with refine-search hints.
+
+**AC-14 — Symbolic catalog references in stored AST:** Inspecting a saved rule's persisted form shows the predicate stores a symbolic reference to the test (e.g., `predicateId: "isOutsideNormal", testRef: { testId: "TSH" }`), not a snapshot of the range values.
+
+**AC-15 — Coded-output Calculation (TB GenoType):** A user creates a new Calculation, picks `TB GenoType Resistance Interpretation` as the destination. The editor switches from formula bar to decision table because the destination is a coded test. The user creates four rules referencing the parent test's analyzer parameters (`TB_GT.IC`, `TB_GT.rpoB_pres`, `TB_GT.rpoB_mp`, `TB_GT.inhA_pres`, `TB_GT.katG_pres`) using a mix of coded `is` and numeric `between` predicates. The Otherwise row picks "Indeterminate." Save succeeds. The simulator with inputs IC=Yes, rpoB_pres=Yes, inhA_pres=No, katG_pres=No, rpoB_mp=84.2 reports "Matched Rule 2 → Wild type." Changing rpoB_mp to 79.0 reports "Matched Rule 3 → Rifampicin resistance suspected." (Maps to FR-26a/b/c/d/e, FR-26f/g/h/i, US-6.)
+
+**AC-16 — Analyzer parameter picker:** In the condition input picker, typing "rpoB" returns two matches: `TB_GT.rpoB_pres` (PARAM chip, coded, Yes/No) and `TB_GT.rpoB_mp` (PARAM chip, numeric, °C, range 82.5–86.5). Typing "TB" returns the parent test's reported result (RESULT chip, coded) plus all six analyzer parameters. The chip clearly distinguishes parameter from result. (Maps to FR-26g.)
+
+**AC-17 — Parameter-derived catalog metadata enables predicates:** For a numeric analyzer parameter with `refRange` defined in the catalog, the catalog-based predicates (`isOutsideNormal`, `isAboveNormal`, `isBelowNormal`) are enabled in the predicate dropdown. For a coded analyzer parameter, only `is` and `is not` are enabled; specific-value and catalog-based numeric predicates are greyed out with "needs a numeric test type." (Maps to FR-26i, FR-16.)
+
+**AC-18 — Rule ordering matters and is visible:** A user moves Rule 3 above Rule 2 using the up arrow in the rule header. The simulator's result changes accordingly when the inputs would have matched both rules. The list view's plain-language summary preserves the order. (Maps to FR-26c.)
+
+**AC-19 — Otherwise required:** Save fails if the Otherwise row is left blank, with a localized inline error pointing to that row. Every coded-output Calculation must terminate with a defined fallback. (Maps to FR-26c, FR-33.)
+
+### 9.4 UI states
+
+**AC-20 — Empty state on fresh deployment:** Opening the Test Rules page with zero rules in the system shows the empty-state block (icon, "No rules yet" title, explanatory subtitle, "+ Create your first rule" primary button). No empty table renders. (Maps to FR-36.)
+
+**AC-21 — Saving state.** Clicking Save while a server request is in flight: Save button shows "Saving…", Save and Cancel buttons are disabled, the rest of the editor stays visible and interactive. `aria-busy="true"` is on the Save button. (Maps to FR-38.)
+
+**AC-22 — Save-failed visual.** A save validation error renders an inline error block above the footer listing every problem, with `role="alert"`. Focus jumps to the first invalid field. The picker chip for an invalid input shows the `.ip-trigger.error` red border. (Maps to FR-39.)
+
+**AC-23 — Disable confirmation.** Clicking Disable Rule on an Active rule opens a Carbon Modal with kind="danger". The modal explains the consequence. Confirm disables the rule; Cancel leaves it Active. The trigger button regains focus on close. (Maps to FR-34, FR-40.)
+
+### 9.5 Batch operations
+
+**AC-24 — Multi-select reveals batch bar.** Selecting one or more rows via row checkboxes reveals the batch action bar above the table with the selected count, Enable / Disable / Export CSV / Delete buttons, and a Clear ✕. (Maps to FR-41, FR-42.)
+
+**AC-25 — Select-all in header.** The header checkbox selects every row currently rendered by the active filter. Toggling it again deselects. The state is `indeterminate` when some but not all visible rows are selected. (Maps to FR-41.)
+
+**AC-26 — Batch delete confirmation.** Clicking Delete with N rows selected opens a Carbon Modal warning that N rules will be deleted permanently. Confirm performs the delete; Cancel preserves selection. (Maps to FR-40, FR-42.)
+
+### 9.6 Accessibility
+
+**AC-27 — Keyboard end-to-end.** A user authors a complete rule using only the keyboard: Tab into rule name, Tab through trigger sample, Tab to first condition's input picker, Enter to open, type to search, arrow keys to navigate matches, Enter to select, Tab through predicate and value inputs, Tab through actions, Tab to Save, Enter. No mouse used. (Maps to NFR-A1, NFR-A2.)
+
+**AC-28 — Screen reader collapsible.** With a screen reader active, focusing a Test catalog data collapsible head announces "Test catalog data, collapsed, button. Expandable" (or similar per platform). Activating with Enter or Space expands and the announcement updates to "expanded." (Maps to NFR-A4.)
+
+**AC-29 — Disabled predicates accessible.** Disabled options in the predicate dropdown have their disabling reason in the option's label text so screen readers announce "is critically high, needs critical thresholds in the catalog, disabled." (Maps to NFR-A3.)
+
+---
+
+## 10. Out of Scope (Phase 2 and later)
+
+### 10.1 Phase 2 — power features
+
+The following are explicitly out of scope for MVP. The MVP data model and UI shell are designed to accept them additively without migration.
+
+- **Formula bar (Type-it) mode for Reflex** — typed text expression as alternative to Compose. Same AST.
+- **Technical-form toggle and DMN export** — show stored predicate calls + compiled numeric expressions; export to OMG DMN.
+- **Simulator** — paste sample inputs, trace which rules fire, see actions.
+- **Validation tests** — author asserts `(inputs → expected output)`; run on save.
+- **Decision-table mode for shared-trigger cascades** — multiple rules sharing one trigger test (HIV Reactive / Weak Reactive / Non-Reactive) authored as one decision table.
+- **Multi-step Calculated Values** — named intermediates feeding a final value (MELD-Na with caps and Na-adjustment, full CKD-EPI 2021). The current `if()` works for two-way branches; multi-step requires Phase 2 work.
+- **Flowchart panel** for branching calc values (eGFR by sex).
+- **Templates library** — searchable algorithm library with citations (Friedewald 1972, NKF-ASN 2021, WHO 2019). MVP may ship with 3–5 inline starter templates.
+- **Cascade preview overlay** — read-only diagram showing how rules chain.
+- **Conflict detection at save** — warn when two rules could fire on the same result.
+- **Trigger modes** — "On test result" vs "On test order" (cascade invisible to provider).
+- **`Send Alert` action type** — needs the alerts subsystem integration.
+- **Nested condition groups** with parens for `(A AND B) OR (C AND D)` shape rules. MVP supports flat AND/OR only.
+- **Run against historical results** — author can replay the last 30 days of patient results through the new rule to see how often it would have fired and what it would have ordered. Important for ISO 15189 sign-off but not required day 1.
+- **Drag-to-reorder** for decision-table rules. MVP uses larger up/down icon buttons.
+- **Carbon `Accordion`** replaces the custom collapsible component used in the mockups.
+- **Granular `RULES_REVIEW` permission** — sign-off step before Active.
+- **Per-rule revision history UI** — list of past versions with diffs.
+
+### 10.2 Phase 3 — deferred
+
+- **Algorithm-as-graph editor** — BPMN-style canvas for genuinely multi-step protocols (HIV 3-test national algorithm with retest, TB cascade with DST, newborn screening). The AST supports this; only the canvas UI is deferred.
+- **CQL / FHIR Clinical Reasoning export** — interoperability with external CDS engines.
+- **Cross-site rule templating / sharing** — export rules from one site for another to import.
+- **Delta-check predicates if catalog doesn't already carry delta thresholds** — requires catalog backfill work.
+- **Comprehensive per-rule analytics** (firing rate, false-positive rate, latency).
+- **Bulk import of analyzer parameter definitions** from instrument vendor profiles. MVP populates manually per test.
+- **Numeric-output Calculations using a decision-table view** (alternative to formula bar) — e.g., authoring MELD-Na's piecewise logic as a table. MVP keeps numeric calcs on formula bar; coded calcs use decision table.
+
+---
+
+## 11. Dependencies & Open Questions
+
+### 11.1 Dependencies
+
+- **Test Catalog metadata.** The MVP assumes the Test Catalog carries: reference range, critical thresholds, coded values, sample type, and LOINC code per test. Critical-threshold capture in particular has been confirmed by the user (2026-05-11) as already supported across all tests in the deployment.
+- **QC-table linkage to results.** Analyzer parameters captured in the QC table today must be associated with patient results at import time (see §4.6a). This is a new addition to the result-import code path and is the only new persistence work introduced by MVP.
+- **Panel as catalog entity.** MVP picker treats Panel as a first-class catalog entity. Confirmation needed (OQ-4).
+- **Carbon for React component versions.** Carbon `DataTable`, `ComboBox`, `MultiSelect`, `Select` (with optgroup + disabled options), `Tag`, `Toggle`, `InlineNotification` — all from `@carbon/react` ≥ 11.x.
+- **i18n infrastructure.** Existing `t()` helper and key registry in the OpenELIS frontend.
+- **Audit log infrastructure.** Storage of structured diffs per rule mutation and per catalog change.
+
+### 11.2 Open Questions
+
+- **OQ-1 — Permission granularity.** Adopt Option A (treat rules as part of the existing binary admin permission) or Option B (introduce `RULES_EDIT` and ship the permission system extension co-scoped with this feature)?
+- **OQ-2 — Existing rule migration.** Existing rules in `reflex` and `calculatedValue` legacy tables need a migration to the new `Rule` schema and `ConditionAST`. Plan: write a one-time migration script that lifts each existing rule's `ANY/ALL` + condition rows into a flat `ConditionGroup` with the matching predicate. The migration must be invertible for rollback.
+- **OQ-3 — Catalog schema gaps.** Confirm Test Catalog already stores: delta threshold per numeric test; LOINC code per test; coded value enumerations per coded test. If any are missing, MVP scope may need to absorb the schema work.
+- **OQ-4 — Panel as first-class entity.** Confirm OpenELIS already stores panels as composed entities with test membership. If not, MVP either includes a panel-management UI in Test Catalog or panels slide to Phase 2.
+- **OQ-5 — Cross-sample auto-order behavior.** When a cross-sample reflex fires, does OpenELIS auto-create a sample collection order, or does it queue a "needs collection" task for phlebotomy? Behavior depends on the existing collection workflow.
+- **OQ-6 — Flat vs nested condition groups in MVP.** Spec proposes flat AND/OR (no nesting) in MVP Compose. Confirm: are there real lab rules that require nested groups (e.g., `(A AND B) OR (C AND D)`)? If yes for MVP, the Compose builder needs a bracket affordance.
+- **OQ-7 — Sample-type scope on Reflex rules.** Calculated Values supports `Selected sample types`. Should Reflex also? If a TSH reflex should fire on Serum AND Plasma, the answer is yes — but the user's stated norm is same-sample reflex, which suggests no for MVP. Recommend deferring to Phase 2 unless a real-world case surfaces.
+- **OQ-8 — Default trigger mode.** MVP assumes "On test result" (legacy reflex behavior). Confirm no immediate need for "On test order" (cascade hidden from provider).
+- **OQ-9 — QC table linkage scope.** Confirmed (2026-05-11) that analyzer parameters are already captured in the QC table. Open: which subset of QC fields should be exposed per analyzer integration in MVP, and is the QC→Result association at import-time keyed by sample ID, run ID, or both? Answer determines storage shape in §4.6a.
+- **OQ-10 — Analyzer parameter catalog migration.** New `analyzerParameters` field on Test Catalog records. Migration approach: ship the field empty for all existing tests; lab IT populates parameter definitions per test as part of catalog setup. Alternatively, bulk-import seeds for common instruments (TB GenoType, GeneXpert, Cobas) via vendor profiles. Phase 2 work either way.
+- **OQ-11 — Coded calc destination existing in catalog.** Does OpenELIS today support creating a coded-result "destination" test that has no analyzer integration — i.e., a test whose result is only ever set by a Calculation rule? If not, MVP needs a small extension to Test Catalog to allow "computed result" as a test source.
+
+---
+
+## 12. References
+
+### 12.1 Mockups
+
+- `calculated-values-redesign-v2-preview.html` — Calculated Values formula bar pattern (numeric output), math view, live preview, sample-type scope.
+- `calc-decision-table-preview.html` — Calculated Values decision-table pattern (**coded output**), analyzer parameters as condition inputs. Canonical example: TB GenoType MTBDRplus interpretation.
+- `reflex-tests-redesign-preview.html` — Reflex Compose mode, predicate picker with availability, multi-action, searchable test/panel picker, Test Catalog reference.
+- `test-rules-list-view-preview.html` — Unified Rules / Algorithms / Multi-step list view, type filters, +New menu, catalog cross-reference.
+- `algorithm-as-graph-preview.html` — *Phase 2/3 reference.* Algorithm canvas and multi-step calc — not in MVP scope.
+
+### 12.2 Audit captures
+
+- Live audit of `/MasterListsPage/calculatedValue` and `/MasterListsPage/reflex` performed 2026-05-11 on testing.openelis-global.org. Findings documented in §1.1.
+
+### 12.3 Prior art
+
+- HL7 Clinical Quality Language (CQL) — semantic predicate naming conventions.
+- OMG Decision Model and Notation (DMN) — workflow + decision-table model that informs Phase 2 algorithm-as-graph.
+- IBM Carbon Design System — UI components and tokens.
+- Looker LookML, Notion formulas, Airtable filters — formula-bar + side-panel + math-view pattern.
+- WHO Consolidated Guidelines on HIV Testing Services (2019) — cascade modeling reference for Phase 2 algorithms.

--- a/mockup-viewer/public/designs/admin-config/algorithm-as-graph-preview.html
+++ b/mockup-viewer/public/designs/admin-config/algorithm-as-graph-preview.html
@@ -1,0 +1,831 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Algorithm-as-Graph — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Top-level tabs */
+    .top-tabs {
+      display: flex; gap: 0; margin-bottom: 1rem; border-bottom: 1px solid #e0e0e0;
+    }
+    .top-tab {
+      padding: 10px 18px; cursor: pointer; font-size: 14px; color: #525252;
+      background: transparent; border: none; border-bottom: 2px solid transparent;
+      font-weight: 500;
+    }
+    .top-tab.active { color: #0f62fe; border-bottom-color: #0f62fe; font-weight: 600; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+
+    /* Algorithm header */
+    .algo-header {
+      background: #fff; padding: 1rem 1.25rem; border: 1px solid #e0e0e0;
+      display: flex; justify-content: space-between; align-items: center;
+      margin-bottom: -1px;
+    }
+    .algo-header .info { display: flex; flex-direction: column; }
+    .algo-header h2 { margin: 0; font-size: 20px; font-weight: 400; }
+    .algo-header .meta { font-size: 12px; color: #6f6f6f; margin-top: 4px; }
+    .algo-toolbar {
+      display: flex; gap: 0.5rem; align-items: center;
+    }
+
+    /* Canvas panel */
+    .canvas-panel {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.5rem;
+      overflow-x: auto;
+    }
+    .canvas-toolbar {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 0.25rem 0.5rem 0.5rem;
+      font-size: 12px; color: #525252;
+    }
+    .canvas-toolbar .legend { display: flex; gap: 0.75rem; align-items: center; }
+    .legend-swatch {
+      display: inline-flex; align-items: center; gap: 4px; font-size: 11px;
+    }
+    .legend-swatch .box {
+      width: 12px; height: 12px; border: 1.5px solid;
+    }
+
+    /* SVG node styling controlled inline */
+    .node-rect { transition: stroke 0.15s, fill 0.15s; }
+    .node-rect.selected { stroke: #fa4d56 !important; stroke-width: 3 !important; }
+    .node-clickable:hover .node-rect { fill: #f4f9ff; }
+
+    /* Selected step editor (below canvas) */
+    .step-editor {
+      background: #fff; padding: 1.25rem; border: 1px solid #e0e0e0; border-top: 2px solid #fa4d56;
+    }
+    .step-editor h4 {
+      margin: 0 0 0.5rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .step-editor h4 .pill {
+      background: #fff1f1; color: #a2191f; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .step-editor .meta {
+      font-size: 12px; color: #6f6f6f; margin-bottom: 0.75rem;
+    }
+
+    /* Decision table */
+    .decision-table {
+      width: 100%; border-collapse: collapse; font-size: 13px; background: #fff;
+    }
+    .decision-table th, .decision-table td {
+      padding: 8px 12px; border: 1px solid #e0e0e0; text-align: left;
+      vertical-align: top;
+    }
+    .decision-table thead th {
+      background: #f4f4f4; font-size: 11px; text-transform: uppercase;
+      letter-spacing: 0.5px; color: #525252;
+    }
+    .decision-table .col-when { background: #fff8e1; color: #b28600; }
+    .decision-table .col-then { background: #defbe6; color: #0e6027; }
+    .decision-table .col-next { background: #edf5ff; color: #0043ce; }
+    .decision-table .dt-cell { font-family: 'IBM Plex Mono', monospace; font-size: 12px; }
+    .decision-table tbody tr:hover { background: #fafafa; }
+    .dt-link {
+      color: #0f62fe; cursor: pointer; text-decoration: underline; text-decoration-style: dotted;
+    }
+
+    /* Side info panel */
+    .info-grid {
+      display: grid; grid-template-columns: 2fr 1fr; gap: 1rem; margin-top: 1rem;
+    }
+    .info-panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .info-panel h4 {
+      margin: 0 0 0.5rem; font-size: 13px; font-weight: 600;
+    }
+    .info-panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500; margin-left: 6px;
+    }
+    .info-panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 130px; font-size: 12px; color: #161616; }
+    .sim-row select, .sim-row input {
+      flex: 1; padding: 4px 8px; font-size: 12px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-trace {
+      background: #f4f4f4; padding: 0.5rem; font-family: 'IBM Plex Mono', monospace;
+      font-size: 11px; line-height: 1.6; margin-top: 0.5rem;
+    }
+    .sim-trace .step { display: flex; gap: 6px; }
+    .sim-trace .step-num {
+      flex: 0 0 18px; background: #0f62fe; color: #fff; border-radius: 999px;
+      width: 18px; height: 18px; display: inline-flex; align-items: center; justify-content: center;
+      font-size: 10px;
+    }
+    .sim-trace .outcome {
+      background: #defbe6; color: #0e6027; padding: 2px 8px; border-radius: 4px;
+      font-weight: 600;
+    }
+    .sim-trace .terminal {
+      background: #fff1f1; color: #6f0000; padding: 2px 8px; border-radius: 4px;
+      font-weight: 600;
+    }
+
+    /* Multi-step calc */
+    .step-list {
+      display: flex; flex-direction: column; gap: 0.5rem;
+    }
+    .calc-step {
+      background: #fff; border: 1px solid #e0e0e0; padding: 0.75rem;
+      display: grid; grid-template-columns: 32px 1fr 100px; gap: 0.75rem; align-items: center;
+    }
+    .calc-step.selected { border-color: #fa4d56; border-left-width: 3px; }
+    .calc-step .num {
+      background: #0f62fe; color: #fff; border-radius: 999px;
+      width: 28px; height: 28px; display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 600; font-size: 13px;
+    }
+    .calc-step .body { display: flex; flex-direction: column; gap: 2px; }
+    .calc-step .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .calc-step .name code {
+      background: #f4f4f4; padding: 1px 6px; border-radius: 3px;
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #0043ce;
+      margin-left: 6px;
+    }
+    .calc-step .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; color: #525252;
+      padding: 4px 8px; background: #fafafa; border-left: 2px solid #c6c6c6;
+    }
+    .calc-step .value {
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      color: #0e6027; font-weight: 600; text-align: right;
+    }
+    .calc-step.final {
+      background: #defbe6; border-color: #198038;
+    }
+    .calc-step.final .num { background: #198038; }
+    .calc-step.final .value { font-size: 22px; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Algorithm-as-Graph &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #fff8e1; border-bottom: 1px solid #f1c21b; padding: 8px 2rem; font-size: 13px; color: #6b4a00;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Algorithm editor</strong> · <span style="background: #f1c21b; color: #6b4a00; padding: 1px 8px; border-radius: 3px; font-size: 11px; font-weight: 700;">PHASE 2</span>
+    &nbsp;<span style="color: #6b4a00;">— what would open when you click an Algorithm or Multi-step calc row in the list view. Not built in MVP; included as forward-compat reference.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // SHARED — token coloring of formula text
+    // ========================================================================
+    const KNOWN_TESTS = ['T1','T2','T3','SCr','Bili','INR','Na','HIV_Screen','HIV_Conf','HIV_Tie'];
+    const KNOWN_FNS   = ['min','max','log','ln','round','if','eq'];
+    const KEYWORDS    = ['AND','OR','NOT','IN'];
+    const PREDICATES  = ['isNormal','isOutsideNormal','isAboveNormal','isBelowNormal','isCritical','isCriticallyHigh','isCriticallyLow','isFlagged','isReactive','isPositive','isFemale','isMale'];
+    function tokenize(text) {
+      const re = /("[^"]*")|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=|\+|-|\*|\/)|([(),])|(\s+)|(.)/g;
+      const out = []; let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({k:'str', t:m[1]});
+        else if (m[2]) out.push({k:'num', t:m[2]});
+        else if (m[3]) {
+          const id = m[3];
+          if (KEYWORDS.includes(id.toUpperCase())) out.push({k:'bool', t:id});
+          else if (PREDICATES.includes(id)) out.push({k:'pred', t:id});
+          else if (KNOWN_TESTS.includes(id)) out.push({k:'var', t:id});
+          else if (KNOWN_FNS.includes(id)) out.push({k:'fn', t:id});
+          else out.push({k:'var', t:id}); // assume var for mockup
+        }
+        else if (m[4]) out.push({k:'op', t:m[4]});
+        else if (m[5]) out.push({k:'paren', t:m[5]});
+        else if (m[6]) out.push({k:'ws', t:m[6]});
+        else out.push({k:'other', t:m[7]});
+      }
+      return out;
+    }
+    function Tokenized({ text }) {
+      return <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>
+        {tokenize(text).map((t, i) =>
+          <span key={i} className={t.k === 'ws' ? '' : 'tok-' + t.k}>{t.t}</span>
+        )}
+      </span>;
+    }
+
+    // ========================================================================
+    // HIV 3-TEST ALGORITHM
+    // ========================================================================
+
+    // Node positions on the SVG canvas
+    const HIV_NODES = [
+      { id: 'T1',   kind: 'decision', title: 'Test 1: Screen',     subtitle: 'Determine HIV-1/2 (Whole Blood)', x: 460, y: 60, w: 200, h: 60 },
+      { id: 'EN',   kind: 'end-neg',  title: 'END: HIV Negative',   subtitle: 'Report final result',           x: 160, y: 200, w: 200, h: 50 },
+      { id: 'T2',   kind: 'decision', title: 'Test 2: Confirmatory',subtitle: 'Uni-Gold HIV (Whole Blood)',    x: 600, y: 195, w: 200, h: 60 },
+      { id: 'EP1',  kind: 'end-pos',  title: 'END: HIV Positive',   subtitle: 'Report final result',           x: 360, y: 335, w: 200, h: 50 },
+      { id: 'T3',   kind: 'decision', title: 'Test 3: Tiebreaker',  subtitle: 'SD Bioline (Whole Blood)',       x: 760, y: 330, w: 200, h: 60 },
+      { id: 'EP2',  kind: 'end-pos',  title: 'END: HIV Positive',   subtitle: 'Report + retest 14 days',       x: 560, y: 470, w: 200, h: 50 },
+      { id: 'EI',   kind: 'end-inc',  title: 'END: Inconclusive',   subtitle: 'Retest in 14 days',             x: 880, y: 470, w: 200, h: 50 },
+    ];
+    const HIV_EDGES = [
+      { from: 'T1',  to: 'T2',  label: 'Reactive',        side: 'right' },
+      { from: 'T1',  to: 'EN',  label: 'Non-Reactive',    side: 'left' },
+      { from: 'T2',  to: 'EP1', label: 'Reactive',        side: 'left' },
+      { from: 'T2',  to: 'T3',  label: 'Non-Reactive',    side: 'right' },
+      { from: 'T3',  to: 'EP2', label: 'Reactive',        side: 'left' },
+      { from: 'T3',  to: 'EI',  label: 'Non-Reactive',    side: 'right' },
+    ];
+
+    function nodeColor(kind) {
+      if (kind === 'decision') return { stroke: '#0f62fe', fill: '#fff' };
+      if (kind === 'end-pos')  return { stroke: '#198038', fill: '#defbe6' };
+      if (kind === 'end-neg')  return { stroke: '#525252', fill: '#f4f4f4' };
+      if (kind === 'end-inc')  return { stroke: '#b28600', fill: '#fff8e1' };
+      return { stroke: '#8d8d8d', fill: '#fff' };
+    }
+
+    function CanvasNode({ node, selected, onClick }) {
+      const c = nodeColor(node.kind);
+      return (
+        <g className="node-clickable" transform={`translate(${node.x}, ${node.y})`} onClick={onClick} style={{ cursor: 'pointer' }}>
+          <rect className={'node-rect' + (selected ? ' selected' : '')}
+                x={0} y={0} width={node.w} height={node.h} rx={6}
+                fill={c.fill} stroke={c.stroke} strokeWidth={1.5} />
+          <text x={node.w/2} y={22} textAnchor="middle" fontSize={13} fontWeight={600} fill="#161616">
+            {node.title}
+          </text>
+          <text x={node.w/2} y={42} textAnchor="middle" fontSize={11} fill="#6f6f6f">
+            {node.subtitle}
+          </text>
+        </g>
+      );
+    }
+
+    function CanvasEdge({ nodes, from, to, label }) {
+      const f = nodes.find(n => n.id === from);
+      const t = nodes.find(n => n.id === to);
+      const fx = f.x + f.w / 2;
+      const fy = f.y + f.h;
+      const tx = t.x + t.w / 2;
+      const ty = t.y;
+      // Bezier control points for a clean S-curve
+      const cy1 = fy + (ty - fy) * 0.6;
+      const cy2 = ty - (ty - fy) * 0.4;
+      const path = `M ${fx},${fy} C ${fx},${cy1} ${tx},${cy2} ${tx},${ty}`;
+      const midX = (fx + tx) / 2;
+      const midY = (fy + ty) / 2;
+      return (
+        <g>
+          <path d={path} fill="none" stroke="#8d8d8d" strokeWidth={1.5} markerEnd="url(#arrow)" />
+          <rect x={midX - 50} y={midY - 11} width={100} height={20} rx={3}
+                fill="#fff" stroke="#e0e0e0" />
+          <text x={midX} y={midY + 3} textAnchor="middle" fontSize={11} fontWeight={600}
+                fill="#525252" fontFamily="IBM Plex Mono">{label}</text>
+        </g>
+      );
+    }
+
+    // Decision table data for each clickable decision node
+    const HIV_TABLES = {
+      T1: {
+        title: 'Test 1: Screen (Determine HIV-1/2)',
+        meta: '3 outcomes · trigger sample = Whole Blood · per WHO 2019 algorithm for high-prevalence settings',
+        rows: [
+          { when: '"Reactive"',     then: '(record positive screen, proceed)',                     next: { id: 'T2', label: 'Test 2: Confirmatory' } },
+          { when: '"Weak Reactive"',then: '(record as ambiguous, proceed with caution)',           next: { id: 'T2', label: 'Test 2: Confirmatory' } },
+          { when: '"Non-Reactive"', then: 'Set HIV status: Negative; Add note: "Screening non-reactive"', next: { id: 'EN', label: 'END: HIV Negative' } },
+        ],
+      },
+      T2: {
+        title: 'Test 2: Confirmatory (Uni-Gold HIV)',
+        meta: '2 outcomes · only reached if Test 1 was Reactive or Weak Reactive',
+        rows: [
+          { when: '"Reactive"',     then: 'Set HIV status: Positive; Add external note with date and lot.', next: { id: 'EP1', label: 'END: HIV Positive' } },
+          { when: '"Non-Reactive"', then: '(record discordance, proceed to tiebreaker)',                next: { id: 'T3',  label: 'Test 3: Tiebreaker' } },
+        ],
+      },
+      T3: {
+        title: 'Test 3: Tiebreaker (SD Bioline)',
+        meta: '2 outcomes · only reached if Test 1 Reactive AND Test 2 Non-Reactive (discordant)',
+        rows: [
+          { when: '"Reactive"',     then: 'Set HIV status: Positive; Order retest in 14 days for serological confirmation.', next: { id: 'EP2', label: 'END: Positive + retest' } },
+          { when: '"Non-Reactive"', then: 'Set HIV status: Inconclusive; Order retest in 14 days.',  next: { id: 'EI',  label: 'END: Inconclusive' } },
+        ],
+      },
+    };
+
+    function HIVAlgorithm() {
+      const [selectedNode, setSelectedNode] = useState('T1');
+      const [simResult1, setSimResult1] = useState('Reactive');
+      const [simResult2, setSimResult2] = useState('Non-Reactive');
+      const [simResult3, setSimResult3] = useState('Reactive');
+
+      // Trace through the algorithm
+      const trace = [];
+      let final = null;
+      trace.push({ step: 'Test 1: Screen', input: simResult1, kind: 'decision' });
+      if (simResult1 === 'Non-Reactive') {
+        final = { kind: 'end-neg', label: 'HIV Negative' };
+      } else {
+        trace.push({ step: 'Test 2: Confirmatory', input: simResult2, kind: 'decision' });
+        if (simResult2 === 'Reactive') {
+          final = { kind: 'end-pos', label: 'HIV Positive' };
+        } else {
+          trace.push({ step: 'Test 3: Tiebreaker', input: simResult3, kind: 'decision' });
+          if (simResult3 === 'Reactive') {
+            final = { kind: 'end-pos', label: 'HIV Positive (with 14-day retest)' };
+          } else {
+            final = { kind: 'end-inc', label: 'Inconclusive (retest in 14 days)' };
+          }
+        }
+      }
+
+      const t = HIV_TABLES[selectedNode];
+
+      return (
+        <div>
+          <div className="algo-header">
+            <div className="info">
+              <h2>HIV 3-test national algorithm</h2>
+              <div className="meta">
+                Reflex Algorithm · 3 decision nodes · 4 final states · per WHO 2019 guidance for high-prevalence settings · last edited 2026-04-30 by p.diallo
+              </div>
+            </div>
+            <div className="algo-toolbar">
+              <span className="cds--tag cds--tag--green">Active</span>
+              <span className="cds--tag cds--tag--purple">Algorithm</span>
+              <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>Export DMN</button>
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 12 }}>Save changes</button>
+            </div>
+          </div>
+
+          <div className="canvas-panel">
+            <div className="canvas-toolbar">
+              <div className="legend">
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#0f62fe', background: '#fff' }}></span> Decision step (click to edit)</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#198038', background: '#defbe6' }}></span> Positive end state</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#525252', background: '#f4f4f4' }}></span> Negative end state</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#b28600', background: '#fff8e1' }}></span> Inconclusive end state</span>
+              </div>
+              <div>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 11 }}>+ Add step</button>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 11, marginLeft: 4 }}>Auto-arrange</button>
+              </div>
+            </div>
+            <svg viewBox="0 0 1120 560" style={{ width: '100%', height: 560, background: '#fff' }}>
+              <defs>
+                <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto">
+                  <path d="M0,0 L10,5 L0,10 Z" fill="#8d8d8d" />
+                </marker>
+              </defs>
+              {HIV_EDGES.map((e, i) => (
+                <CanvasEdge key={i} nodes={HIV_NODES} from={e.from} to={e.to} label={e.label} />
+              ))}
+              {HIV_NODES.map(node => (
+                <CanvasNode
+                  key={node.id}
+                  node={node}
+                  selected={node.id === selectedNode}
+                  onClick={() => setSelectedNode(node.id)}
+                />
+              ))}
+            </svg>
+          </div>
+
+          {/* Selected step editor */}
+          {t && (
+            <div className="step-editor">
+              <h4>{t.title} <span className="pill">Selected step</span></h4>
+              <div className="meta">{t.meta}</div>
+              <table className="decision-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 40 }}>#</th>
+                    <th className="col-when">When the result is…</th>
+                    <th className="col-then">Action</th>
+                    <th className="col-next" style={{ width: 240 }}>Next step</th>
+                    <th style={{ width: 30 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.rows.map((r, i) => (
+                    <tr key={i}>
+                      <td>{i + 1}</td>
+                      <td className="dt-cell"><Tokenized text={r.when} /></td>
+                      <td style={{ fontSize: 12 }}>{r.then}</td>
+                      <td className="dt-cell">
+                        <span className="dt-link" onClick={() => r.next.id !== selectedNode && setSelectedNode(r.next.id)}>
+                          → {r.next.label}
+                        </span>
+                      </td>
+                      <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              <div style={{ marginTop: 8 }}>
+                <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>+ Add outcome</button>
+                <span className="compact-hint" style={{ display: 'inline-block', marginLeft: 12 }}>
+                  Each outcome can point to another decision step, a final state, or "no further action."
+                </span>
+              </div>
+            </div>
+          )}
+
+          <div className="info-grid">
+            <div className="info-panel">
+              <h4>Simulator <span className="pill green">Sandbox</span></h4>
+              <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                Set hypothetical results for each test. The simulator traces the path through the algorithm.
+              </span>
+              <div className="sim-row">
+                <label>Test 1: Screen</label>
+                <select value={simResult1} onChange={e => setSimResult1(e.target.value)}>
+                  <option>Reactive</option><option>Weak Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-row">
+                <label>Test 2: Confirm</label>
+                <select value={simResult2} onChange={e => setSimResult2(e.target.value)} disabled={simResult1 === 'Non-Reactive'}>
+                  <option>Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-row">
+                <label>Test 3: Tiebreaker</label>
+                <select value={simResult3} onChange={e => setSimResult3(e.target.value)}
+                        disabled={simResult1 === 'Non-Reactive' || simResult2 === 'Reactive'}>
+                  <option>Reactive</option><option>Non-Reactive</option>
+                </select>
+              </div>
+              <div className="sim-trace">
+                {trace.map((s, i) => (
+                  <div key={i} className="step">
+                    <span className="step-num">{i + 1}</span>
+                    <span>{s.step}: result = <span className="tok-str">"{s.input}"</span></span>
+                  </div>
+                ))}
+                <div className="step" style={{ marginTop: 6 }}>
+                  <span className="step-num" style={{ background: final.kind === 'end-pos' ? '#198038' : final.kind === 'end-inc' ? '#b28600' : '#525252' }}>✓</span>
+                  <span className={final.kind === 'end-inc' ? 'terminal' : 'outcome'}>{final.label}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="info-panel">
+              <h4>Coverage &amp; conflicts</h4>
+              <div style={{ fontSize: 12, lineHeight: 1.6 }}>
+                <div style={{ color: '#0e6027' }}>✓ All Test 1 outcomes handled (3 of 3)</div>
+                <div style={{ color: '#0e6027' }}>✓ All Test 2 outcomes handled (2 of 2)</div>
+                <div style={{ color: '#0e6027' }}>✓ All Test 3 outcomes handled (2 of 2)</div>
+                <div style={{ color: '#0e6027' }}>✓ Every path terminates at a final state</div>
+                <div style={{ color: '#0e6027' }}>✓ No unreachable nodes</div>
+                <div style={{ color: '#b28600', marginTop: 6 }}>⚠ "Weak Reactive" from Test 1 routes to Test 2 same as "Reactive" — confirm with lab director if a distinct path is needed.</div>
+              </div>
+              <h4 style={{ marginTop: '0.75rem' }}>Audit</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                Created 2024-08-12 (p.diallo) · 14 revisions · last reviewed 2026-04-30
+              </div>
+              <h4 style={{ marginTop: '0.75rem' }}>References</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                WHO 2019 — Consolidated guidelines on HIV testing services<br/>
+                Ministry of Health national algorithm v3.2 (2024)
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // MELD-Na MULTI-STEP CALCULATION
+    // ========================================================================
+
+    const MELD_STEPS = [
+      // step number, name (used as variable in later steps), formula string, depends-on, units, function
+      { id: 's1', name: 'SCr_adj',          formula: 'max(min(SCr, 4.0), 1.0)',                                                      deps: ['SCr'],                  units: 'mg/dL', desc: 'Capped 1.0–4.0 (SCr above 4.0 capped per OPTN policy)' },
+      { id: 's2', name: 'Bili_adj',         formula: 'max(Bili, 1.0)',                                                                deps: ['Bili'],                 units: 'mg/dL', desc: 'Min 1.0 (log not defined < 1)' },
+      { id: 's3', name: 'INR_adj',          formula: 'max(INR, 1.0)',                                                                 deps: ['INR'],                  units: '',      desc: 'Min 1.0 (log not defined < 1)' },
+      { id: 's4', name: 'MELD_base',        formula: 'round(0.957 * ln(SCr_adj) + 0.378 * ln(Bili_adj) + 1.12 * ln(INR_adj) + 0.643) * 10', deps: ['SCr_adj','Bili_adj','INR_adj'], units: 'score', desc: 'MELD score before Na adjustment (OPTN 2002)' },
+      { id: 's5', name: 'MELD_na_unround',  formula: 'if(MELD_base >= 11, MELD_base + 1.32*(137-Na) - 0.033*MELD_base*(137-Na), MELD_base)', deps: ['MELD_base','Na'], units: 'score', desc: 'Na adjustment only when MELD_base ≥ 11 (UNOS 2016)' },
+      { id: 's6', name: 'MELD_Na',          formula: 'min(40, max(6, round(MELD_na_unround)))',                                       deps: ['MELD_na_unround'],     units: 'score', desc: 'Final score capped 6–40 (OPTN allocation policy)', final: true },
+    ];
+
+    function computeMeld(inputs) {
+      const SCr = +inputs.SCr, Bili = +inputs.Bili, INR = +inputs.INR, Na = +inputs.Na;
+      const SCr_adj = Math.max(Math.min(SCr, 4.0), 1.0);
+      const Bili_adj = Math.max(Bili, 1.0);
+      const INR_adj = Math.max(INR, 1.0);
+      const MELD_base = Math.round(0.957 * Math.log(SCr_adj) + 0.378 * Math.log(Bili_adj) + 1.12 * Math.log(INR_adj) + 0.643) * 10;
+      const MELD_na_unround = MELD_base >= 11
+        ? MELD_base + 1.32*(137-Na) - 0.033*MELD_base*(137-Na)
+        : MELD_base;
+      const MELD_Na = Math.min(40, Math.max(6, Math.round(MELD_na_unround)));
+      return { SCr_adj, Bili_adj, INR_adj, MELD_base, MELD_na_unround, MELD_Na };
+    }
+
+    // Position the step DAG horizontally
+    const MELD_NODES = [
+      // inputs (left)
+      { id: 'SCr',      kind: 'input',  label: 'SCr',  x: 40,  y: 40 },
+      { id: 'Bili',     kind: 'input',  label: 'Bili', x: 40,  y: 100 },
+      { id: 'INR',      kind: 'input',  label: 'INR',  x: 40,  y: 160 },
+      { id: 'Na',       kind: 'input',  label: 'Na',   x: 40,  y: 220 },
+      // step 1-3 (caps)
+      { id: 's1',       kind: 'step',   label: 'SCr_adj',         x: 200, y: 40 },
+      { id: 's2',       kind: 'step',   label: 'Bili_adj',        x: 200, y: 100 },
+      { id: 's3',       kind: 'step',   label: 'INR_adj',         x: 200, y: 160 },
+      // step 4
+      { id: 's4',       kind: 'step',   label: 'MELD_base',       x: 420, y: 100 },
+      // step 5
+      { id: 's5',       kind: 'step',   label: 'MELD_na_unround', x: 660, y: 160 },
+      // step 6 final
+      { id: 's6',       kind: 'final',  label: 'MELD_Na',         x: 900, y: 160 },
+    ];
+    const MELD_EDGES = [
+      { from: 'SCr',  to: 's1' },
+      { from: 'Bili', to: 's2' },
+      { from: 'INR',  to: 's3' },
+      { from: 's1',   to: 's4' },
+      { from: 's2',   to: 's4' },
+      { from: 's3',   to: 's4' },
+      { from: 's4',   to: 's5' },
+      { from: 'Na',   to: 's5' },
+      { from: 's5',   to: 's6' },
+    ];
+
+    function MeldNode({ node, selected, onClick }) {
+      const c = node.kind === 'input' ? { fill: '#fff1f1', stroke: '#a2191f' }
+             : node.kind === 'final' ? { fill: '#defbe6', stroke: '#198038' }
+             : { fill: '#fff', stroke: '#0f62fe' };
+      const w = node.kind === 'final' ? 130 : 110;
+      return (
+        <g transform={`translate(${node.x}, ${node.y})`}
+           onClick={onClick} style={{ cursor: 'pointer' }}>
+          <rect className={'node-rect' + (selected ? ' selected' : '')}
+                x={0} y={0} width={w} height={40} rx={6}
+                fill={c.fill} stroke={c.stroke} strokeWidth={1.5} />
+          <text x={w/2} y={25} textAnchor="middle"
+                fontSize={13} fontWeight={600}
+                fontFamily="IBM Plex Mono"
+                fill={node.kind === 'input' ? '#a2191f' : node.kind === 'final' ? '#0e6027' : '#0043ce'}>
+            {node.label}
+          </text>
+        </g>
+      );
+    }
+    function MeldEdge({ nodes, from, to }) {
+      const f = nodes.find(n => n.id === from);
+      const t = nodes.find(n => n.id === to);
+      const fw = f.kind === 'final' ? 130 : 110;
+      const tw = t.kind === 'final' ? 130 : 110;
+      const fx = f.x + fw;
+      const fy = f.y + 20;
+      const tx = t.x;
+      const ty = t.y + 20;
+      const midX = (fx + tx) / 2;
+      const path = `M ${fx},${fy} C ${midX},${fy} ${midX},${ty} ${tx},${ty}`;
+      return <path d={path} fill="none" stroke="#8d8d8d" strokeWidth={1.5} markerEnd="url(#arrow-meld)" />;
+    }
+
+    function MELDCalc() {
+      const [selectedStep, setSelectedStep] = useState('s5');
+      const [inputs, setInputs] = useState({ SCr: 1.8, Bili: 2.4, INR: 1.3, Na: 132 });
+      const v = computeMeld(inputs);
+      const setI = (k) => (e) => setInputs(s => ({ ...s, [k]: e.target.value }));
+
+      return (
+        <div>
+          <div className="algo-header">
+            <div className="info">
+              <h2>MELD-Na (Liver allocation score)</h2>
+              <div className="meta">
+                Multi-step calculation · 6 named intermediates · capped 6–40 · per UNOS 2016 policy · last edited 2026-03-22 by p.diallo
+              </div>
+            </div>
+            <div className="algo-toolbar">
+              <span className="cds--tag cds--tag--green">Active</span>
+              <span className="cds--tag cds--tag--purple">Multi-step</span>
+              <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>Export</button>
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 12 }}>Save changes</button>
+            </div>
+          </div>
+
+          <div className="canvas-panel">
+            <div className="canvas-toolbar">
+              <div className="legend">
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#a2191f', background: '#fff1f1' }}></span> Test result input</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#0f62fe', background: '#fff' }}></span> Intermediate (click to edit)</span>
+                <span className="legend-swatch"><span className="box" style={{ borderColor: '#198038', background: '#defbe6' }}></span> Final output</span>
+              </div>
+              <div><button className="cds--btn cds--btn--ghost" style={{ fontSize: 11 }}>+ Add step</button></div>
+            </div>
+            <svg viewBox="0 0 1050 290" style={{ width: '100%', height: 290, background: '#fff' }}>
+              <defs>
+                <marker id="arrow-meld" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto">
+                  <path d="M0,0 L10,5 L0,10 Z" fill="#8d8d8d" />
+                </marker>
+              </defs>
+              {MELD_EDGES.map((e, i) => (
+                <MeldEdge key={i} nodes={MELD_NODES} from={e.from} to={e.to} />
+              ))}
+              {MELD_NODES.map(node => (
+                <MeldNode key={node.id} node={node}
+                          selected={node.id === selectedStep}
+                          onClick={() => node.kind !== 'input' && setSelectedStep(node.id)} />
+              ))}
+            </svg>
+          </div>
+
+          <div className="info-grid" style={{ gridTemplateColumns: '1.4fr 1fr' }}>
+            <div className="info-panel">
+              <h4>Steps <span className="pill">In order</span></h4>
+              <div className="step-list">
+                {MELD_STEPS.map((s, i) => {
+                  const value = v[s.name];
+                  const fmt = typeof value === 'number'
+                    ? (Math.abs(value) > 100 ? value.toFixed(0) : value.toFixed(2))
+                    : value;
+                  const selected = selectedStep === s.id;
+                  return (
+                    <div key={s.id} className={'calc-step' + (s.final ? ' final' : '') + (selected ? ' selected' : '')}
+                         onClick={() => setSelectedStep(s.id)} style={{ cursor: 'pointer' }}>
+                      <div className="num">{i + 1}</div>
+                      <div className="body">
+                        <div className="name">
+                          {s.name}
+                          <code>= {s.units || '—'}</code>
+                        </div>
+                        <div className="formula">
+                          <Tokenized text={s.formula} />
+                        </div>
+                        <div className="compact-hint" style={{ fontStyle: 'normal' }}>{s.desc}</div>
+                      </div>
+                      <div className="value">{fmt}</div>
+                    </div>
+                  );
+                })}
+              </div>
+              <div className="compact-hint" style={{ marginTop: 6 }}>
+                Each step gets its own formula bar, units, and inline value. Edits to one step propagate through dependent steps automatically.
+              </div>
+            </div>
+
+            <div className="info-panel">
+              <h4>Simulator <span className="pill green">Sandbox</span></h4>
+              <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                Enter patient labs. Every step recomputes live; the dependency graph above lights up the path.
+              </span>
+              <div className="sim-row">
+                <label>SCr (Creatinine)</label>
+                <input type="number" step="0.1" value={inputs.SCr} onChange={setI('SCr')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mg/dL</span>
+              </div>
+              <div className="sim-row">
+                <label>Bili (Bilirubin)</label>
+                <input type="number" step="0.1" value={inputs.Bili} onChange={setI('Bili')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mg/dL</span>
+              </div>
+              <div className="sim-row">
+                <label>INR</label>
+                <input type="number" step="0.1" value={inputs.INR} onChange={setI('INR')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}></span>
+              </div>
+              <div className="sim-row">
+                <label>Na (Sodium)</label>
+                <input type="number" step="1" value={inputs.Na} onChange={setI('Na')} />
+                <span style={{ flex: '0 0 50px', fontSize: 11, color: '#6f6f6f' }}>mmol/L</span>
+              </div>
+
+              <div style={{ background: '#defbe6', padding: '0.75rem 1rem', marginTop: 12, borderLeft: '3px solid #198038' }}>
+                <div style={{ fontSize: 10, textTransform: 'uppercase', letterSpacing: 0.5, color: '#0e6027', fontWeight: 600 }}>
+                  Final MELD-Na
+                </div>
+                <div style={{ fontSize: 32, fontWeight: 600, color: '#0e6027', fontFamily: "'IBM Plex Mono', monospace" }}>
+                  {v.MELD_Na}
+                </div>
+                <div style={{ fontSize: 11, color: '#525252', marginTop: 4 }}>
+                  MELD_base = {v.MELD_base} · Na-adjusted = {v.MELD_na_unround.toFixed(2)} · capped to {v.MELD_Na}
+                </div>
+              </div>
+
+              <h4 style={{ marginTop: '0.75rem' }}>Validation tests</h4>
+              <div style={{ fontSize: 11, color: '#525252' }}>
+                <div>✓ SCr=1.0, Bili=1.0, INR=1.0, Na=140 → 6 (passes)</div>
+                <div>✓ SCr=2.0, Bili=3.0, INR=1.5, Na=130 → 21 (passes)</div>
+                <div>✓ SCr=5.0 (caps to 4.0), Bili=10, INR=2.5, Na=125 → 35 (passes)</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [tab, setTab] = useState('hiv');
+      const [briefOpen, setBriefOpen] = useState(true);
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Algorithm Editor</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Algorithm Editor <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>complex branching · DMN-inspired</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> When a rule has more than one decision point, promote
+              it to an <em>algorithm</em> — a named container of multiple decision tables wired
+              together by a workflow graph. Each node on the canvas is one decision table (Reflex)
+              or one named intermediate (Calculated Values). Click a node to open its editor below.
+              Conditions in the decision-table cells use <strong>semantic predicates</strong>
+              (<span className="tok-pred">isOutsideNormal</span>, <span className="tok-pred">isCritical</span>,{' '}
+              <span className="tok-pred">isReactive</span>, etc.) that compile to numeric expressions
+              using the Test Catalog's reference and critical ranges — so a range change in the
+              catalog updates every rule automatically. The simulator traces the path. Coverage and
+              conflict checks run across the whole graph. Algorithms are exportable as DMN —
+              the OMG standard that Camunda, FHIR Clinical Reasoning, and most modern CDS tools speak.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          <div className="top-tabs">
+            <button className={'top-tab' + (tab === 'hiv' ? ' active' : '')} onClick={() => setTab('hiv')}>
+              Reflex Algorithm — HIV 3-test national cascade
+            </button>
+            <button className={'top-tab' + (tab === 'meld' ? ' active' : '')} onClick={() => setTab('meld')}>
+              Multi-step Calculation — MELD-Na liver score
+            </button>
+          </div>
+
+          {tab === 'hiv' && <HIVAlgorithm />}
+          {tab === 'meld' && <MELDCalc />}
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What this view adds to the v2 design:</strong> Single-rule editing stays in the
+            Reflex / Calculated Values list pages. <em>Algorithm</em> is a new top-level concept that
+            composes multiple rules into a directed graph. The workflow canvas is the orchestration
+            layer (BPMN-style); decision tables and formula bars stay as the leaf editors. This is
+            the standard "DMN + BPMN-lite" combination that Camunda, Red Hat KIE, and FHIR Clinical
+            Reasoning all use to model complex clinical protocols. The trade-off: algorithms are
+            heavier to author than a single rule, so the system should only nudge users toward
+            algorithm mode when they have ≥ 2 decision points that depend on each other.
+            For genuinely terminal complexity (newborn screening with 60 conditions, multi-site
+            harmonization, ISO-15189 audit), the next layer up is full CQL — out of scope for this
+            preview but the algorithm AST should compile to CQL when needed.
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/mockup-viewer/public/designs/admin-config/calc-decision-table-preview.html
+++ b/mockup-viewer/public/designs/admin-config/calc-decision-table-preview.html
@@ -1,0 +1,1183 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Decision-Table Calculation — TB GenoType Interpretation — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-param { color: #6929c4; font-weight: 600; }  /* analyzer parameter */
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+
+    /* List view */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    table.cds--data-table { width: 100%; background: #fff; border: 1px solid #e0e0e0; border-top: none; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    .type-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 4px;
+      text-transform: uppercase; letter-spacing: 0.4px;
+    }
+    .type-chip.numeric { background: #defbe6; color: #0e6027; }
+    .type-chip.coded   { background: #e8daff; color: #491d8b; }
+
+    /* Expanded editor — decision table for coded calc */
+    .expanded {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-stack {
+      display: flex; flex-direction: column; gap: 0.75rem;
+    }
+
+    /* Collapsible card — used for catalog data and simulator */
+    .collapsible {
+      background: #fff; border: 1px solid #e0e0e0;
+    }
+    .collapsible-head {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.75rem 1rem; cursor: pointer; user-select: none;
+      background: #fafafa; border-bottom: 1px solid #e0e0e0;
+      width: 100%; border-left: none; border-right: none; border-top: none;
+      font-family: inherit; font-size: inherit; text-align: left;
+    }
+    .collapsible-head:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .collapsible-head.collapsed { border-bottom-color: transparent; }
+    .collapsible-head:hover { background: #f4f4f4; }
+    .collapsible-head .caret { font-size: 11px; color: #525252; }
+    .collapsible-head .title { font-size: 14px; font-weight: 600; flex: 0 0 auto; }
+    .collapsible-head .summary {
+      font-size: 12px; color: #6f6f6f; flex: 1; min-width: 0;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .collapsible-head .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .collapsible-head .pill.gray { background: #f4f4f4; color: #525252; }
+    .collapsible-head .pill.green { background: #defbe6; color: #0e6027; }
+    .collapsible-body { padding: 1rem; }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.coded  { background: #e8daff; color: #491d8b; }
+    .panel h4 .pill.green  { background: #defbe6; color: #0e6027; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* Output picker for coded destination */
+    .output-card {
+      background: #f4f9ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem;
+    }
+    .output-card .label { font-size: 10px; color: #0043ce; font-weight: 700; letter-spacing: 0.5px; }
+    .output-card .name { font-size: 16px; font-weight: 600; margin: 4px 0; }
+    .output-card .meta { font-size: 11px; color: #525252; font-family: 'IBM Plex Mono', monospace; }
+    .output-card .values {
+      font-size: 11px; color: #525252; margin-top: 4px;
+      display: flex; flex-wrap: wrap; gap: 4px;
+    }
+    .output-card .values .v {
+      background: #fff; border: 1px solid #c6c6c6; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+    }
+
+    /* Decision rule cards */
+    .dt-rule {
+      background: #fff; border: 1px solid #c6c6c6; margin-bottom: 0.75rem;
+      border-radius: 4px; overflow: hidden;
+    }
+    .dt-rule-header {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 0.5rem 0.75rem; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0;
+      font-size: 12px;
+    }
+    .dt-rule-header .num {
+      width: 22px; height: 22px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-weight: 600;
+    }
+    .dt-rule-header .title { font-weight: 600; color: #161616; flex: 1; }
+    .dt-rule-header .actions { display: flex; gap: 4px; }
+    .dt-rule-header .icon-btn {
+      background: #fff; border: 1px solid #c6c6c6; color: #525252; cursor: pointer; font-size: 14px;
+      padding: 4px 10px; min-width: 32px; min-height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+    }
+    .dt-rule-header .icon-btn:hover { background: #edf5ff; color: #0f62fe; border-color: #0f62fe; }
+    .dt-rule-header .icon-btn:focus-visible { outline: 2px solid #0f62fe; outline-offset: 1px; }
+    .dt-rule-header .icon-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .dt-rule-body { padding: 0.75rem; }
+
+    .compose-row {
+      display: grid; grid-template-columns: 56px 1fr 28px;
+      gap: 0.5rem; align-items: center; margin-bottom: 6px;
+    }
+    .compose-row .joiner {
+      background: #fff8e1; color: #b28600; font-size: 11px; font-weight: 700;
+      text-align: center; padding: 4px 6px; border-radius: 4px;
+      letter-spacing: 0.5px;
+    }
+    .compose-row .joiner.first { background: #d0e2ff; color: #0043ce; }
+    .compose-row select.joiner { padding: 4px 4px; border: 1px solid #c6c6c6; }
+    .compose-row .row-body {
+      display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;
+    }
+    .compose-row .row-body > select,
+    .compose-row .row-body > input {
+      padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .compose-row .row-body select { min-width: 180px; }
+    .compose-row .row-body input { width: 90px; }
+    .delete { background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px; }
+
+    /* THEN bar — picks the resulting coded value */
+    .then-bar {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 8px 10px; margin-top: 8px;
+      background: #defbe6; border-left: 3px solid #198038;
+    }
+    .then-bar .label {
+      font-size: 10px; color: #0e6027; font-weight: 700; letter-spacing: 0.5px;
+    }
+    .then-bar .equals { color: #525252; font-weight: 600; }
+    .then-bar select {
+      padding: 4px 10px; font-size: 14px; font-weight: 600;
+      border: none; border-bottom: 1px solid #198038; background: #fff;
+      color: #0e6027;
+    }
+
+    /* Otherwise row */
+    .otherwise {
+      background: #f4f4f4; border: 1px dashed #8d8d8d;
+      padding: 0.75rem; margin-bottom: 0.75rem; border-radius: 4px;
+    }
+    .otherwise .title {
+      font-size: 11px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px;
+      margin-bottom: 4px;
+    }
+    .otherwise .subtitle {
+      font-size: 11px; color: #6f6f6f; font-style: italic; margin-bottom: 6px;
+    }
+
+    /* + Add rule CTA */
+    .add-cta {
+      display: flex; align-items: center; justify-content: center; gap: 6px;
+      width: 100%; padding: 10px;
+      background: #fff; border: 1.5px dashed #0f62fe;
+      color: #0f62fe; font-size: 13px; font-weight: 600;
+      cursor: pointer; margin-top: 8px;
+    }
+    .add-cta:hover { background: #edf5ff; border-color: #0043ce; }
+    .add-cta .plus {
+      width: 20px; height: 20px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 14px; font-weight: 700;
+    }
+
+    /* Catalog reference panel */
+    .catalog-card {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+    .catalog-card .head {
+      display: flex; justify-content: space-between; align-items: center;
+      font-size: 13px; margin-bottom: 6px;
+    }
+    .catalog-card .head strong { color: #161616; }
+    .catalog-card .meta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; line-height: 1.6; }
+    .catalog-card .params-section {
+      margin-top: 8px; padding-top: 8px; border-top: 1px solid #e0e0e0;
+    }
+    .catalog-card .params-section .title {
+      font-size: 10px; color: #525252; text-transform: uppercase; letter-spacing: 0.5px;
+      margin-bottom: 6px; display: flex; justify-content: space-between;
+    }
+    .catalog-card .params-section .title .source {
+      color: #6929c4; font-weight: 600;
+    }
+    .param-row {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 4px 8px; background: #fff; border: 1px solid #e0e0e0;
+      margin-bottom: 4px; font-size: 12px;
+    }
+    .param-row .name { color: #6929c4; font-family: 'IBM Plex Mono', monospace; font-weight: 600; }
+    .param-row .kind {
+      background: #f6f2ff; color: #6929c4; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 170px; font-size: 12px; color: #161616; }
+    .sim-row input, .sim-row select {
+      flex: 1; padding: 4px 8px; font-size: 12px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-row .unit { flex: 0 0 50px; font-size: 11px; color: #6f6f6f; }
+    .sim-result {
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+      background: #defbe6; border-left: 3px solid #198038;
+    }
+    .sim-result .head { font-size: 11px; color: #0e6027; text-transform: uppercase; letter-spacing: 0.5px; }
+    .sim-result .value {
+      font-size: 18px; font-weight: 600; color: #0e6027; margin-top: 4px;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .sim-result .which {
+      font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .sim-result.indeterminate { background: #fff8e1; border-color: #f1c21b; }
+    .sim-result.indeterminate .head, .sim-result.indeterminate .value { color: #b28600; }
+
+    /* Test picker — chip-style trigger + dropdown panel */
+    .ip-wrap { position: relative; display: inline-block; max-width: 100%; }
+    .ip-trigger {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 4px 10px; min-height: 30px; max-width: 100%;
+      background: #f4f4f4; border: 1px solid #c6c6c6; border-radius: 4px;
+      font-size: 13px; cursor: pointer; font-family: inherit;
+    }
+    .ip-trigger:hover { background: #e8e8e8; border-color: #8d8d8d; }
+    .ip-trigger:focus { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .ip-trigger.empty { color: #6f6f6f; font-style: italic; }
+    .ip-trigger .caret { color: #525252; font-size: 10px; margin-left: 2px; flex-shrink: 0; }
+    .ip-trigger .ip-label {
+      color: #161616; font-style: normal;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      max-width: 480px;
+    }
+    .ip-trigger .ip-sub {
+      color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+      flex-shrink: 0;
+    }
+    .ip-trigger .clear-btn {
+      background: none; border: none; cursor: pointer; color: #6f6f6f;
+      padding: 0 2px 0 4px; font-size: 14px; line-height: 1;
+    }
+    .ip-trigger .clear-btn:hover { color: #a2191f; }
+    .ip-kind {
+      padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .ip-kind.result { background: #d0e2ff; color: #0043ce; }
+    .ip-kind.param  { background: #f6f2ff; color: #6929c4; }
+
+    .ip-pop {
+      position: absolute; top: calc(100% + 4px); left: 0;
+      min-width: 360px; max-width: 480px;
+      background: #fff; border: 1px solid #8d8d8d; border-radius: 4px;
+      z-index: 100; box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      overflow: hidden;
+    }
+    .ip-pop-search {
+      width: 100%; padding: 10px 12px; border: none; border-bottom: 1px solid #e0e0e0;
+      font-size: 13px; box-sizing: border-box; outline: none;
+      background: #fff;
+    }
+    .ip-pop-search:focus { background: #f4f9ff; }
+    .ip-pop-list { max-height: 280px; overflow-y: auto; }
+    .ip-item {
+      display: flex; align-items: center; gap: 10px;
+      width: 100%; padding: 8px 12px; background: none; border: none;
+      border-top: 1px solid #f4f4f4; cursor: pointer; text-align: left;
+      font-family: inherit; font-size: 13px;
+    }
+    .ip-item:hover { background: #edf5ff; }
+    .ip-item:first-child { border-top: none; }
+    .ip-item-body { flex: 1; min-width: 0; }
+    .ip-item-name { color: #161616; line-height: 1.3; }
+    .ip-item-meta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+      margin-top: 2px; line-height: 1.3;
+    }
+    .ip-pop-empty { padding: 16px; color: #6f6f6f; font-size: 12px; font-style: italic; text-align: center; }
+    .ip-pop-more { padding: 8px 12px; font-size: 11px; color: #6f6f6f; font-style: italic; border-top: 1px solid #f4f4f4; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Calculation with Coded Output &nbsp;|&nbsp; Decision-table mode · Analyzer parameters as inputs &nbsp;|&nbsp; OpenELIS Design Mockup
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Coded Calculation editor (Decision Table)</strong>
+    &nbsp;<span style="color: #6f6f6f;">— what expands inline when you click a calc row with a <em>coded</em> destination. For a <em>numeric</em> destination, see <a href="calculated-values-redesign-v2-preview.html" style="color: #0f62fe;">the formula-bar editor</a>.</span>
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">Loading…</div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    window.addEventListener('load', function () {
+      var missing = [];
+      if (typeof React === 'undefined')    missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined')    missing.push('Babel');
+      var s = document.getElementById('boot-status');
+      if (missing.length && s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Missing dependencies:</strong> ' + missing.join(', ');
+      }
+    });
+  </script>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // CATALOG — with analyzer parameters
+    // ========================================================================
+    const TESTS = {
+      // Sources of input
+      TB_GT: {
+        id: 'TB_GT', name: 'TB GenoType MTBDRplus (LPA)',
+        loinc: '88262-1', type: 'coded',
+        values: ['MTB detected', 'Not detected', 'Indeterminate'],
+        sample: 'Sputum',
+        // Raw analyzer parameters from QC-table linkage
+        analyzerParameters: [
+          { id: 'IC',        name: 'Internal Control valid',  type: 'coded',   values: ['Yes','No'] },
+          { id: 'rpoB_pres', name: 'rpoB band present',       type: 'coded',   values: ['Yes','No'] },
+          { id: 'rpoB_mp',   name: 'rpoB melting point',      type: 'numeric', units: '°C', refRange: [82.5, 86.5] },
+          { id: 'inhA_pres', name: 'inhA mutation present',   type: 'coded',   values: ['Yes','No'] },
+          { id: 'katG_pres', name: 'katG mutation present',   type: 'coded',   values: ['Yes','No'] },
+          { id: 'gyrA_pres', name: 'gyrA mutation present',   type: 'coded',   values: ['Yes','No','Not tested'] },
+        ],
+      },
+      TC: {
+        id: 'TC', name: 'Total Cholesterol', loinc: '2093-3', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [125, 200],
+      },
+      HDL: {
+        id: 'HDL', name: 'HDL Cholesterol', loinc: '2085-9', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [40, 60],
+      },
+      TRIG: {
+        id: 'TRIG', name: 'Triglycerides', loinc: '2571-8', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [0, 150],
+      },
+      // Destination tests
+      TB_INTERP: {
+        id: 'TB_INTERP', name: 'TB GenoType Resistance Interpretation',
+        loinc: 'local', type: 'coded',
+        values: [
+          'Wild type — no resistance detected',
+          'Rifampicin resistance suspected',
+          'Isoniazid resistance suspected',
+          'MDR-TB suspected (RIF + INH)',
+          'Invalid — repeat test',
+          'Indeterminate — review raw values',
+        ],
+        sample: 'Sputum',
+      },
+      LDL: {
+        id: 'LDL', name: 'LDL Cholesterol', loinc: '13457-7', type: 'numeric', units: 'mg/dL', sample: 'Serum', refRange: [0, 100],
+      },
+    };
+
+    // Catalog-based predicates (subset)
+    const PREDICATES = [
+      // Catalog-based numeric
+      { id: 'isNormal',         group: 'catalog', requires: 'refRange', label: 'is within the normal range', short: 'is normal' },
+      { id: 'isOutsideNormal',  group: 'catalog', requires: 'refRange', label: 'is outside the normal range', short: 'is outside normal' },
+      { id: 'isAboveNormal',    group: 'catalog', requires: 'refRange', label: 'is above the normal range', short: 'is above normal' },
+      { id: 'isBelowNormal',    group: 'catalog', requires: 'refRange', label: 'is below the normal range', short: 'is below normal' },
+      // Numeric value
+      { id: 'gt',      group: 'value', requires: 'numeric', valueInput: 'number', label: 'is greater than (>)', short: 'is greater than' },
+      { id: 'gte',     group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at least (≥)',     short: 'is at least' },
+      { id: 'lt',      group: 'value', requires: 'numeric', valueInput: 'number', label: 'is less than (<)',    short: 'is less than' },
+      { id: 'lte',     group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at most (≤)',      short: 'is at most' },
+      { id: 'between', group: 'value', requires: 'numeric', valueInput: 'range',  label: 'is between (inclusive)', short: 'is between' },
+      // Coded
+      { id: 'is',    group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is…',     short: 'is' },
+      { id: 'isNot', group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is not…', short: 'is not' },
+    ];
+
+    // For a given input source (test result or analyzer param), returns its metadata
+    function inputMeta(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return null;
+      if (paramId) return t.analyzerParameters?.find(p => p.id === paramId);
+      return t;
+    }
+    function inputLabel(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return '';
+      if (paramId) {
+        const p = t.analyzerParameters?.find(p => p.id === paramId);
+        return `${t.id}.${p?.id ?? '?'}`;
+      }
+      return testId;
+    }
+    function inputFullName(testId, paramId) {
+      const t = TESTS[testId];
+      if (!t) return '';
+      if (paramId) {
+        const p = t.analyzerParameters?.find(p => p.id === paramId);
+        return `${t.name} — ${p?.name ?? '?'}`;
+      }
+      return t.name;
+    }
+    function predicatesFor(meta) {
+      if (!meta) return [];
+      return PREDICATES.filter(p => {
+        if (p.requires === 'refRange') return Array.isArray(meta.refRange);
+        if (p.requires === 'numeric')  return meta.type === 'numeric';
+        if (p.requires === 'values')   return Array.isArray(meta.values);
+        return false;
+      });
+    }
+    function predicatePhrase(testId, paramId, predId, value) {
+      const meta = inputMeta(testId, paramId);
+      const p = PREDICATES.find(x => x.id === predId);
+      if (!meta || !p) return '';
+      const labelText = p.label.replace(/…$/, '').replace(/\s*\(.*?\)\s*$/, '').trim();
+      const baseName = paramId ? `${testId} ${meta.name}` : (TESTS[testId]?.name || testId);
+      const base = `${baseName} ${labelText}`;
+      if (!p.valueInput) return base;
+      if (p.valueInput === 'range') return value && value[0] != null && value[1] != null ? `${base} ${value[0]} and ${value[1]} ${meta.units || ''}`.trim() : `${base} …`;
+      if (p.valueInput === 'codedMulti') {
+        const list = Array.isArray(value) ? value : [];
+        if (list.length === 0) return `${base} …`;
+        if (list.length === 1) return `${base} ${list[0]}`;
+        if (list.length === 2) return `${base} ${list[0]} or ${list[1]}`;
+        return `${base} ${list.slice(0, -1).join(', ')}, or ${list[list.length - 1]}`;
+      }
+      return value != null && value !== '' ? `${base} ${value}${meta.units ? ' ' + meta.units : ''}` : `${base} …`;
+    }
+
+    // ========================================================================
+    // INPUT PICKER — chip-style trigger + dropdown with search inside
+    // Searches across test results AND analyzer parameters
+    // ========================================================================
+    function InputPicker({ value, onChange }) {
+      const [open, setOpen] = useState(false);
+      const [q, setQ] = useState('');
+
+      // Build a flat list of selectable inputs (test results + analyzer parameters)
+      const candidates = [];
+      Object.values(TESTS).forEach(t => {
+        if (t.type !== 'reflex' && t.id !== 'TB_INTERP' && t.id !== 'LDL') {
+          // Reported test result
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded · ' + t.values.length + ' values' : (t.units || 'numeric')}${t.sample ? ' · sample: ' + t.sample : ''}`,
+          });
+        }
+        (t.analyzerParameters || []).forEach(p => {
+          candidates.push({
+            kind: 'param', testId: t.id, paramId: p.id,
+            humanName: p.name,
+            parentName: t.name,
+            techId: `${t.id}.${p.id}`,
+            meta: `${p.type === 'coded' ? 'coded · ' + p.values.join(' / ') : (p.units || 'numeric')}${p.refRange ? ' · range ' + p.refRange[0] + '–' + p.refRange[1] : ''}`,
+          });
+        });
+      });
+      const filtered = candidates.filter(c =>
+        q === '' ||
+        (c.humanName + ' ' + (c.parentName || '') + ' ' + c.techId + ' ' + c.meta)
+          .toLowerCase().includes(q.toLowerCase())
+      );
+
+      const pick = (c) => {
+        onChange({ testId: c.testId, paramId: c.paramId });
+        setQ(''); setOpen(false);
+      };
+
+      // Chip display data
+      const selectedHumanName = value
+        ? (value.paramId
+            ? inputMeta(value.testId, value.paramId)?.name
+            : TESTS[value.testId]?.name)
+        : null;
+      const selectedTechId = value
+        ? (value.paramId ? `${value.testId}.${value.paramId}` : value.testId)
+        : null;
+
+      return (
+        <div className="ip-wrap">
+          <button type="button"
+                  className={'ip-trigger' + (value ? '' : ' empty')}
+                  onClick={() => setOpen(o => !o)}
+                  title={value ? `${selectedHumanName} (${selectedTechId})` : 'Pick a test result or analyzer parameter'}>
+            {value && (
+              <span className={'ip-kind ' + (value.paramId ? 'param' : 'result')}>
+                {value.paramId ? 'param' : 'result'}
+              </span>
+            )}
+            <span className="ip-label">{selectedHumanName || 'Pick input…'}</span>
+            {value && (
+              <span className="ip-sub">{selectedTechId}</span>
+            )}
+            {value && (
+              <span className="clear-btn" onClick={(e) => { e.stopPropagation(); onChange(null); setOpen(false); }}>
+                ×
+              </span>
+            )}
+            <span className="caret">{open ? '▴' : '▾'}</span>
+          </button>
+          {open && (
+            <>
+              <div style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+                   onClick={() => setOpen(false)} />
+              <div className="ip-pop">
+                <input type="text" className="ip-pop-search" autoFocus
+                       placeholder="Search by name, test, LOINC, units…"
+                       value={q} onChange={e => setQ(e.target.value)} />
+                <div className="ip-pop-list">
+                  {filtered.slice(0, 14).map((c, i) => (
+                    <button key={i} className="ip-item" onClick={() => pick(c)}>
+                      <span className={'ip-kind ' + c.kind}>{c.kind}</span>
+                      <span className="ip-item-body">
+                        <div className="ip-item-name">
+                          {c.kind === 'param'
+                            ? <><span style={{ color: '#6f6f6f' }}>{c.parentName} →</span> <strong>{c.humanName}</strong></>
+                            : <strong>{c.humanName}</strong>}
+                        </div>
+                        <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                      </span>
+                    </button>
+                  ))}
+                  {filtered.length === 0 && (
+                    <div className="ip-pop-empty">No matches.</div>
+                  )}
+                  {filtered.length > 14 && (
+                    <div className="ip-pop-more">…and {filtered.length - 14} more. Refine your search.</div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // COMPOSE ROW — a single condition inside one decision-table rule
+    // ========================================================================
+    function ConditionRow({ row, joiner, isFirst, onChange, onJoinerChange, onDelete }) {
+      const meta = row.input ? inputMeta(row.input.testId, row.input.paramId) : null;
+      const preds = meta ? predicatesFor(meta) : [];
+      const predDef = row.pred ? PREDICATES.find(p => p.id === row.pred) : null;
+
+      return (
+        <div className="compose-row">
+          {isFirst
+            ? <span className="joiner first">WHEN</span>
+            : <select className="joiner" value={joiner || 'AND'} onChange={e => onJoinerChange(e.target.value)}>
+                <option>AND</option><option>OR</option>
+              </select>}
+          <div className="row-body">
+            <InputPicker value={row.input} onChange={v => onChange({ ...row, input: v, pred: '', value: null })} />
+            {meta && (
+              <select value={row.pred} onChange={e => onChange({ ...row, pred: e.target.value, value: null })}>
+                <option value="">— pick a question —</option>
+                {preds.map(p => <option key={p.id} value={p.id}>{p.label}</option>)}
+              </select>
+            )}
+            {predDef && predDef.valueInput === 'number' && (
+              <>
+                <input type="number" step="any" placeholder="value"
+                       value={row.value ?? ''}
+                       onChange={e => onChange({ ...row, value: e.target.value === '' ? null : +e.target.value })} />
+                {meta.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{meta.units}</span>}
+              </>
+            )}
+            {predDef && predDef.valueInput === 'range' && (() => {
+              const v = row.value || [null, null];
+              return (
+                <>
+                  <input type="number" step="any" placeholder="low"
+                         value={v[0] ?? ''}
+                         onChange={e => onChange({ ...row, value: [e.target.value === '' ? null : +e.target.value, v[1]] })} />
+                  <span style={{ fontSize: 11, color: '#525252' }}>and</span>
+                  <input type="number" step="any" placeholder="high"
+                         value={v[1] ?? ''}
+                         onChange={e => onChange({ ...row, value: [v[0], e.target.value === '' ? null : +e.target.value] })} />
+                  {meta.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{meta.units}</span>}
+                </>
+              );
+            })()}
+            {predDef && predDef.valueInput === 'codedMulti' && (
+              <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 4 }}>
+                {meta.values.map(cv => {
+                  const selected = (row.value || []).includes(cv);
+                  return (
+                    <label key={cv} style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 3, padding: '2px 6px', background: selected ? '#d0e2ff' : '#f4f4f4', borderRadius: 3, cursor: 'pointer' }}>
+                      <input type="checkbox" checked={selected}
+                             onChange={e => {
+                               const cur = row.value || [];
+                               const next = e.target.checked ? [...cur, cv] : cur.filter(x => x !== cv);
+                               onChange({ ...row, value: next });
+                             }} />
+                      {cv}
+                    </label>
+                  );
+                })}
+              </span>
+            )}
+          </div>
+          <button className="delete" onClick={onDelete} title="Remove condition">×</button>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // DECISION RULE — one card in the decision table
+    // ========================================================================
+    function DecisionRule({ num, rule, destinationValues, onChange, onDelete, onMoveUp, onMoveDown, canUp, canDown }) {
+      const setRow = (i, newRow) => onChange({ ...rule, rows: rule.rows.map((r, idx) => idx === i ? newRow : r) });
+      const setJoiner = (i, val) => onChange({ ...rule, joiners: rule.joiners.map((j, idx) => idx === i ? val : j) });
+      const addRow = () => onChange({ ...rule, rows: [...rule.rows, { input: null, pred: '', value: null }], joiners: [...rule.joiners, 'AND'] });
+      const removeRow = (i) => onChange({ ...rule, rows: rule.rows.filter((_, idx) => idx !== i), joiners: rule.joiners.filter((_, idx) => idx !== i) });
+
+      return (
+        <div className="dt-rule">
+          <div className="dt-rule-header">
+            <span className="num">{num}</span>
+            <span className="title">Rule {num}</span>
+            <div className="actions">
+              {canUp   && <button className="icon-btn" onClick={onMoveUp}   title="Move up">▲</button>}
+              {canDown && <button className="icon-btn" onClick={onMoveDown} title="Move down">▼</button>}
+              <button className="icon-btn" style={{ color: '#a2191f' }} onClick={onDelete} title="Delete rule">🗑</button>
+            </div>
+          </div>
+          <div className="dt-rule-body">
+            {rule.rows.map((r, i) => (
+              <ConditionRow
+                key={i}
+                row={r}
+                joiner={rule.joiners[i]}
+                isFirst={i === 0}
+                onChange={nr => setRow(i, nr)}
+                onJoinerChange={v => setJoiner(i, v)}
+                onDelete={() => removeRow(i)}
+              />
+            ))}
+            <button className="cds--btn cds--btn--ghost" onClick={addRow} style={{ fontSize: 11, marginTop: 4 }}>
+              + Add condition
+            </button>
+
+            <div className="then-bar">
+              <span className="label">THEN result is</span>
+              <span className="equals">=</span>
+              <select value={rule.result || ''} onChange={e => onChange({ ...rule, result: e.target.value })}>
+                <option value="">— pick a result —</option>
+                {destinationValues.map(v => <option key={v} value={v}>{v}</option>)}
+              </select>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // EVALUATOR — runs the decision table against sample inputs
+    // ========================================================================
+    function evalRow(row, inputs) {
+      if (!row.input || !row.pred) return null;  // incomplete row — treat as unknown
+      const meta = inputMeta(row.input.testId, row.input.paramId);
+      const key = `${row.input.testId}${row.input.paramId ? '.' + row.input.paramId : ''}`;
+      const v = inputs[key];
+      if (v == null || v === '') return null;
+      const p = row.pred;
+      const val = row.value;
+      switch (p) {
+        case 'isNormal':         return v >= meta.refRange[0] && v <= meta.refRange[1];
+        case 'isOutsideNormal':  return v <  meta.refRange[0] || v >  meta.refRange[1];
+        case 'isAboveNormal':    return v >  meta.refRange[1];
+        case 'isBelowNormal':    return v <  meta.refRange[0];
+        case 'gt':  return val != null && +v >  val;
+        case 'gte': return val != null && +v >= val;
+        case 'lt':  return val != null && +v <  val;
+        case 'lte': return val != null && +v <= val;
+        case 'between': return val && val[0] != null && val[1] != null && +v >= val[0] && +v <= val[1];
+        case 'is':    return Array.isArray(val) && val.includes(v);
+        case 'isNot': return Array.isArray(val) && !val.includes(v);
+        default: return null;
+      }
+    }
+    function evalRule(rule, inputs) {
+      if (rule.rows.length === 0) return null;
+      const results = rule.rows.map(r => evalRow(r, inputs));
+      if (results.some(r => r === null)) return null; // incomplete — can't decide
+      let acc = results[0];
+      for (let i = 1; i < results.length; i++) {
+        const j = rule.joiners[i] || 'AND';
+        acc = (j === 'OR') ? (acc || results[i]) : (acc && results[i]);
+      }
+      return acc;
+    }
+    function evalDecisionTable(rules, otherwise, inputs) {
+      for (let i = 0; i < rules.length; i++) {
+        const r = evalRule(rules[i], inputs);
+        if (r === true) return { matched: i + 1, result: rules[i].result };
+      }
+      // None matched
+      return { matched: 'otherwise', result: otherwise };
+    }
+
+    // ========================================================================
+    // CALCULATIONS LIST DATA
+    // ========================================================================
+    const CALCS = [
+      {
+        id: 'calc-ldl',
+        name: 'LDL Cholesterol (Friedewald)',
+        outputKind: 'numeric',
+        destination: 'LDL',
+        summary: 'LDL = TC − HDL − Triglycerides/5',
+        edited: '2026-04-28 by p.diallo',
+      },
+      {
+        id: 'calc-tb',
+        name: 'TB GenoType Resistance Interpretation',
+        outputKind: 'coded',
+        destination: 'TB_INTERP',
+        summary: 'Maps LPA band pattern + melting points to interpretation (5 categories)',
+        edited: '2026-05-08 by m.kone',
+      },
+    ];
+
+    // ========================================================================
+    // TB EDITOR — the decision-table calc demo
+    // ========================================================================
+    function TBEditor() {
+      const dest = TESTS.TB_INTERP;
+
+      const [catalogOpen, setCatalogOpen] = useState(false);
+      const [simulatorOpen, setSimulatorOpen] = useState(true);
+      const [otherwise, setOtherwise] = useState('Indeterminate — review raw values');
+      const [rules, setRules] = useState([
+        {
+          id: 1,
+          rows: [{ input: { testId: 'TB_GT', paramId: 'IC' }, pred: 'is', value: ['No'] }],
+          joiners: [null],
+          result: 'Invalid — repeat test',
+        },
+        {
+          id: 2,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'rpoB_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'inhA_pres' }, pred: 'is', value: ['No']  },
+            { input: { testId: 'TB_GT', paramId: 'katG_pres' }, pred: 'is', value: ['No']  },
+            { input: { testId: 'TB_GT', paramId: 'rpoB_mp' },   pred: 'between', value: [82.5, 86.5] },
+          ],
+          joiners: [null, 'AND', 'AND', 'AND'],
+          result: 'Wild type — no resistance detected',
+        },
+        {
+          id: 3,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'rpoB_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'rpoB_mp' },   pred: 'isOutsideNormal', value: null },
+          ],
+          joiners: [null, 'AND'],
+          result: 'Rifampicin resistance suspected',
+        },
+        {
+          id: 4,
+          rows: [
+            { input: { testId: 'TB_GT', paramId: 'inhA_pres' }, pred: 'is', value: ['Yes'] },
+            { input: { testId: 'TB_GT', paramId: 'katG_pres' }, pred: 'is', value: ['Yes'] },
+          ],
+          joiners: [null, 'OR'],
+          result: 'Isoniazid resistance suspected',
+        },
+      ]);
+
+      const [inputs, setInputs] = useState({
+        'TB_GT.IC':        'Yes',
+        'TB_GT.rpoB_pres': 'Yes',
+        'TB_GT.rpoB_mp':   84.2,
+        'TB_GT.inhA_pres': 'No',
+        'TB_GT.katG_pres': 'No',
+      });
+      const setInput = (k, v) => setInputs(s => ({ ...s, [k]: v }));
+
+      const evalResult = evalDecisionTable(rules, otherwise, inputs);
+
+      const updateRule = (i, r) => setRules(arr => arr.map((x, idx) => idx === i ? r : x));
+      const deleteRule = (i)    => setRules(arr => arr.filter((_, idx) => idx !== i));
+      const addRule = () => setRules(arr => [...arr, {
+        id: Math.max(0, ...arr.map(r => r.id)) + 1,
+        rows: [{ input: null, pred: '', value: null }],
+        joiners: [null],
+        result: '',
+      }]);
+      const move = (i, dir) => setRules(arr => {
+        const j = i + dir;
+        if (j < 0 || j >= arr.length) return arr;
+        const copy = arr.slice();
+        [copy[i], copy[j]] = [copy[j], copy[i]];
+        return copy;
+      });
+
+      return (
+        <tr>
+          <td colSpan={5} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--purple">Coded output · {dest.values.length} possible values</span>
+                <span className="cds--tag cds--tag--warm-gray">Trigger sample: Sputum</span>
+                <span className="cds--tag cds--tag--cool-gray">{rules.length} rules + 1 otherwise</span>
+              </div>
+
+              <div className="editor-stack">
+
+                {/* TOP — Test catalog data (collapsible) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (catalogOpen ? '' : ' collapsed')}
+                          aria-expanded={catalogOpen}
+                          onClick={() => setCatalogOpen(o => !o)}>
+                    <span className="caret">{catalogOpen ? '▾' : '▸'}</span>
+                    <span className="title">Test catalog data</span>
+                    <span className="summary">
+                      {TESTS.TB_GT.name} ({TESTS.TB_GT.id}) · Sputum · {TESTS.TB_GT.analyzerParameters.length} analyzer parameters via QC linkage
+                    </span>
+                    <span className="pill gray">Reference</span>
+                  </button>
+                  {catalogOpen && (
+                    <div className="collapsible-body">
+                      <div className="catalog-card" style={{ margin: 0 }}>
+                        <div className="head">
+                          <span><strong>{TESTS.TB_GT.name}</strong> ({TESTS.TB_GT.id})</span>
+                          <span style={{ fontSize: 10, color: '#6f6f6f' }}>{TESTS.TB_GT.type}</span>
+                        </div>
+                        <div className="meta">
+                          <div>Sample: <strong>{TESTS.TB_GT.sample}</strong> · LOINC <strong>{TESTS.TB_GT.loinc}</strong></div>
+                          <div>Reported values: {TESTS.TB_GT.values.join(', ')}</div>
+                        </div>
+                        <div className="params-section">
+                          <div className="title">
+                            <span>Analyzer parameters</span>
+                            <span className="source">via QC table linkage · {TESTS.TB_GT.analyzerParameters.length} captured</span>
+                          </div>
+                          {TESTS.TB_GT.analyzerParameters.map(p => (
+                            <div key={p.id} className="param-row">
+                              <div>
+                                <div style={{ color: '#161616', fontSize: 13, fontWeight: 600 }}>{p.name}</div>
+                                <div style={{ fontSize: 11, color: '#6929c4', fontFamily: 'monospace' }}>{TESTS.TB_GT.id}.{p.id}</div>
+                              </div>
+                              <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-end', gap: 2 }}>
+                                <span className="kind">{p.type}</span>
+                                <span style={{ fontSize: 10, color: '#6f6f6f', fontFamily: 'monospace' }}>
+                                  {p.type === 'coded' ? p.values.join('/') : `${p.units || 'numeric'}${p.refRange ? ` · ${p.refRange[0]}–${p.refRange[1]}` : ''}`}
+                                </span>
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                        <div style={{ marginTop: 6, fontSize: 11, color: '#0f62fe' }}>
+                          → <a href="#" style={{ color: '#0f62fe' }}>Edit in Test Catalog</a>
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                {/* MIDDLE — Rule definition (full width) */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill coded">Decision Table</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="TB GenoType Resistance Interpretation"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4', fontSize: 14 }} />
+                  </div>
+
+                  {/* Destination test card — drives the output type */}
+                  <div className="output-card">
+                    <div className="label">OUTPUT GOES TO</div>
+                    <div className="name">{dest.name} <span style={{ fontWeight: 400, color: '#6f6f6f', fontSize: 13 }}>({dest.id})</span></div>
+                    <div className="meta">Coded result · {dest.values.length} possible values</div>
+                    <div className="values">
+                      {dest.values.map(v => <span key={v} className="v">{v}</span>)}
+                    </div>
+                    <div className="compact-hint" style={{ marginTop: 6 }}>
+                      Because the destination is a coded test, the editor uses a <strong>decision table</strong> instead of a formula bar.
+                      Each row maps a condition to one of the possible result values. <strong>First match wins.</strong>
+                    </div>
+                  </div>
+
+                  {rules.map((rule, i) => (
+                    <DecisionRule
+                      key={rule.id}
+                      num={i + 1}
+                      rule={rule}
+                      destinationValues={dest.values}
+                      onChange={r => updateRule(i, r)}
+                      onDelete={() => deleteRule(i)}
+                      onMoveUp={() => move(i, -1)}
+                      onMoveDown={() => move(i, +1)}
+                      canUp={i > 0}
+                      canDown={i < rules.length - 1}
+                    />
+                  ))}
+
+                  <div className="otherwise">
+                    <div className="title">Otherwise (if no rule above matches)</div>
+                    <div className="subtitle">A catch-all so every input produces a defined output. Required.</div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <span style={{ fontSize: 11, color: '#0e6027', fontWeight: 700 }}>THEN result is =</span>
+                      <select value={otherwise} onChange={e => setOtherwise(e.target.value)}
+                              style={{ padding: 4, fontSize: 14, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', flex: 1 }}>
+                        {dest.values.map(v => <option key={v} value={v}>{v}</option>)}
+                      </select>
+                    </div>
+                  </div>
+
+                  <button className="add-cta" onClick={addRule}>
+                    <span className="plus">+</span>
+                    <span>Add another rule</span>
+                    <span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f', marginLeft: 6 }}>(evaluated top-down; first match wins)</span>
+                  </button>
+                </div>
+
+                {/* BOTTOM — Simulator (collapsible) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (simulatorOpen ? '' : ' collapsed')}
+                          aria-expanded={simulatorOpen}
+                          onClick={() => setSimulatorOpen(o => !o)}>
+                    <span className="caret">{simulatorOpen ? '▾' : '▸'}</span>
+                    <span className="title">Simulator</span>
+                    <span className="summary">
+                      {typeof evalResult.matched === 'number'
+                        ? `Current inputs → Rule ${evalResult.matched} → ${evalResult.result}`
+                        : `Current inputs → Otherwise → ${evalResult.result}`}
+                    </span>
+                    <span className="pill green">Sandbox</span>
+                  </button>
+                  {simulatorOpen && (
+                    <div className="collapsible-body">
+                      <span className="compact-hint" style={{ display: 'block', marginBottom: 10 }}>
+                        Enter values for each input. The simulator runs the rules top-down and reports the first match.
+                      </span>
+                      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))', gap: '0.5rem 1.5rem' }}>
+                        {TESTS.TB_GT.analyzerParameters.map(p => {
+                          const k = `TB_GT.${p.id}`;
+                          return (
+                            <div key={p.id} className="sim-row" style={{ marginBottom: 0 }}>
+                              <label>{p.name}</label>
+                              {p.type === 'coded' ? (
+                                <select value={inputs[k] ?? ''} onChange={e => setInput(k, e.target.value)}>
+                                  {p.values.map(v => <option key={v} value={v}>{v}</option>)}
+                                </select>
+                              ) : (
+                                <input type="number" step="0.1" value={inputs[k] ?? ''} onChange={e => setInput(k, e.target.value === '' ? '' : +e.target.value)} />
+                              )}
+                              <span className="unit">{p.units || ''}</span>
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      <div className={'sim-result' + (typeof evalResult.matched === 'string' ? ' indeterminate' : '')}>
+                        <div className="head">Computed result</div>
+                        <div className="value">{evalResult.result || '—'}</div>
+                        <div className="which">
+                          {typeof evalResult.matched === 'number'
+                            ? `Matched Rule ${evalResult.matched} (top-down evaluation)`
+                            : 'No rule matched — fell through to Otherwise.'}
+                        </div>
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation cases</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState('calc-tb');
+      const [briefOpen, setBriefOpen] = useState(true);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <a href="#">Test Rules</a> / <span>TB GenoType Resistance Interpretation</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Calculated Value — Coded Output <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>decision-table mode · analyzer parameters as inputs</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>What's new here:</strong> A Calculation can write either a <em>numeric</em> result (formula bar)
+              or a <em>coded</em> result (decision table). The choice is driven by the destination test in the Test
+              Catalog. For coded outputs, each rule in the decision table is a Compose-style condition block — same
+              predicate vocabulary as Reflex — paired with a result picker showing the destination test's possible
+              values. First match wins, top-down. A required <em>Otherwise</em> row guarantees every input gets a
+              defined output.
+              <br /><br />
+              Condition inputs aren't limited to test results. <strong>Analyzer parameters</strong> (melting points,
+              band-present flags, internal-control validity, Ct values) are first-class — sourced from the existing
+              QC table that already captures them and associated with the result at import time. The TB GenoType
+              example below references six analyzer parameters and the test's reported result, mixing numeric and
+              coded predicates in one rule.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          <div className="toolbar">
+            <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>
+              <input style={{ border: 'none', borderBottom: '1px solid #8d8d8d', padding: '6px 10px', width: 260, fontSize: 14, background: '#f4f4f4' }}
+                     placeholder="Search calculations…" />
+              <span style={{ background: '#f4f4f4', padding: '4px 10px', fontSize: 12, borderRadius: 999, border: '1px solid #e0e0e0' }}>Output: All ▾</span>
+              <span style={{ background: '#f4f4f4', padding: '4px 10px', fontSize: 12, borderRadius: 999, border: '1px solid #e0e0e0' }}>Sample: All ▾</span>
+            </div>
+            <button className="cds--btn cds--btn--primary" style={{ fontSize: 13 }}>+ New calculation</button>
+          </div>
+
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 120 }}>Output</th>
+                  <th>Name / summary</th>
+                  <th style={{ width: 220 }}>Destination</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                </tr>
+              </thead>
+              <tbody>
+                {CALCS.map(c => {
+                  const isExpanded = expandedId === c.id;
+                  const dest = TESTS[c.destination];
+                  return (
+                    <React.Fragment key={c.id}>
+                      <tr style={{ background: isExpanded ? '#edf5ff' : 'transparent', cursor: 'pointer' }}
+                          onClick={() => setExpandedId(isExpanded ? null : c.id)}>
+                        <td>
+                          <button style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                            {isExpanded ? '▾' : '▸'}
+                          </button>
+                        </td>
+                        <td>
+                          <span className={'type-chip ' + c.outputKind}>{c.outputKind}</span>
+                        </td>
+                        <td>
+                          <div className="rule-name">{c.name}</div>
+                          <div style={{ fontSize: 12, color: '#525252', marginTop: 2 }}>{c.summary}</div>
+                        </td>
+                        <td style={{ fontSize: 12 }}>
+                          <div>{dest.name}</div>
+                          <div style={{ color: '#6f6f6f', fontFamily: 'monospace', fontSize: 11 }}>
+                            {c.outputKind === 'coded' ? `coded · ${dest.values.length} values` : `numeric · ${dest.units || ''}`}
+                          </div>
+                        </td>
+                        <td style={{ fontSize: 12, color: '#6f6f6f' }}>{c.edited}</td>
+                      </tr>
+                      {isExpanded && c.id === 'calc-tb' && <TBEditor />}
+                      {isExpanded && c.id !== 'calc-tb' && (
+                        <tr>
+                          <td colSpan={5} style={{ padding: '1rem 2rem', background: '#fafafa', fontSize: 13, color: '#525252' }}>
+                            (Editor for <strong>{c.name}</strong> would render the formula bar pattern from the v2 Calculated Values preview — numeric output uses formula bar; coded output uses decision table.)
+                          </td>
+                        </tr>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What this preview adds to the MVP scope:</strong> Coded-output Calculations
+            via a decision-table editor (each rule is a Compose-style condition block + a result-value
+            picker; first match wins; required Otherwise row). Analyzer parameters as first-class
+            condition inputs alongside test results (sourced from the existing QC table linkage,
+            associated with results at import time). The same predicate vocabulary works on
+            results and analyzer parameters interchangeably. The output kind is driven by the
+            destination test in the Test Catalog — pick a numeric destination and the editor shows
+            the formula bar from v2; pick a coded destination and it shows this decision table.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message;
+      }
+    }
+  </script>
+</body>
+</html>

--- a/mockup-viewer/public/designs/admin-config/calculated-values-redesign-v2-preview.html
+++ b/mockup-viewer/public/designs/admin-config/calculated-values-redesign-v2-preview.html
@@ -1,0 +1,1283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Calculated Value Rules v2 — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 280px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .browse-btn {
+      background: #fff; padding: 4px 12px; font-size: 12px; border: 1px solid #0f62fe;
+      color: #0f62fe; cursor: pointer;
+    }
+    .browse-btn.open { background: #0f62fe; color: #fff; }
+
+    /* Library drawer */
+    .library-drawer {
+      background: #fff; border: 1px solid #e0e0e0; border-bottom: none;
+      padding: 1rem;
+    }
+    .library-drawer h4 { margin: 0 0 0.5rem; font-size: 13px; }
+    .library-search {
+      width: 320px; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 14px; margin-bottom: 0.75rem;
+    }
+    .library-grid {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.5rem;
+    }
+    .library-card {
+      padding: 0.75rem 1rem; border: 1px solid #e0e0e0; cursor: pointer;
+      transition: border-color 0.15s;
+    }
+    .library-card:hover { border-color: #0f62fe; background: #f4f9ff; }
+    .library-card .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .library-card .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .library-card .src { font-size: 10px; color: #8d8d8d; margin-top: 4px; }
+
+    /* DataTable rules */
+    table.cds--data-table { width: 100%; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    /* Tokenized rendering shared */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-paren { color: #525252; }
+    .tok-unknown {
+      color: #a2191f; text-decoration: underline wavy #da1e28; text-underline-offset: 3px;
+    }
+
+    .rule-summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+
+    /* Expanded editor */
+    .expanded-tile {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 1.25rem;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      color: #161616; display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+    .panel h4 .pill.warn { background: #fff8e1; color: #b28600; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* Formula bar — textarea + overlay */
+    .formula-bar-wrap {
+      position: relative; background: #fff; border: 1px solid #8d8d8d;
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      padding: 10px 12px;
+      transition: border-color 0.15s;
+    }
+    .formula-bar-wrap:focus-within { border-color: #0f62fe; outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .formula-overlay {
+      position: absolute; top: 10px; left: 12px; right: 12px;
+      pointer-events: none; white-space: pre-wrap; word-wrap: break-word;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: #161616;
+    }
+    .formula-input {
+      position: relative; width: 100%; min-height: 1.4em; resize: vertical;
+      border: none; outline: none; background: transparent;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: transparent; caret-color: #161616;
+    }
+    .formula-prompt {
+      font-size: 11px; color: #525252; margin-top: 4px; display: flex; gap: 0.5rem;
+    }
+    .formula-prompt .err { color: #a2191f; }
+    .formula-prompt .ok { color: #0e6027; }
+
+    /* Autocomplete dropdown */
+    .ac-pop {
+      position: absolute; top: 100%; left: 0; right: 0; margin-top: 2px;
+      background: #fff; border: 1px solid #8d8d8d; max-height: 200px; overflow-y: auto;
+      z-index: 10; font-family: 'IBM Plex Sans', sans-serif; font-size: 13px;
+    }
+    .ac-item {
+      padding: 6px 10px; cursor: pointer; display: flex; justify-content: space-between;
+    }
+    .ac-item:hover, .ac-item.sel { background: #edf5ff; }
+    .ac-item .ac-meta { color: #6f6f6f; font-size: 11px; font-family: 'IBM Plex Mono', monospace; }
+    .ac-item .ac-kind {
+      font-size: 10px; padding: 1px 6px; border-radius: 999px; align-self: center;
+    }
+    .ac-kind.var { background: #d0e2ff; color: #0043ce; }
+    .ac-kind.fn { background: #e8daff; color: #491d8b; }
+    .ac-kind.attr { background: #fff1f1; color: #a2191f; }
+
+    /* Math view */
+    .math-view {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 1rem;
+      display: flex; flex-wrap: wrap; gap: 8px; align-items: center;
+      font-size: 15px;
+    }
+    .math-pill {
+      display: inline-flex; flex-direction: column; align-items: flex-start;
+      padding: 4px 10px; border-radius: 4px; line-height: 1.1;
+    }
+    .math-pill.var { background: #d0e2ff; color: #0043ce; }
+    .math-pill.attr { background: #fff1f1; color: #a2191f; }
+    .math-pill.fn { background: #e8daff; color: #491d8b; }
+    .math-pill .label { font-weight: 600; font-size: 14px; }
+    .math-pill .units { font-size: 10px; opacity: 0.75; }
+    .math-op {
+      color: #d12771; font-weight: 700; font-size: 18px; padding: 0 2px;
+    }
+    .math-num {
+      background: #defbe6; color: #0e6027; padding: 4px 10px; border-radius: 4px;
+      font-weight: 600;
+    }
+    .math-fraction {
+      display: inline-flex; flex-direction: column; align-items: center;
+      padding: 0 4px;
+    }
+    .math-fraction .top, .math-fraction .bot { padding: 2px 4px; }
+    .math-fraction .bar { border-top: 2px solid #161616; width: 100%; margin: 2px 0; }
+    .math-paren { font-size: 22px; color: #525252; }
+
+    /* Sample-type scope */
+    .scope-block {
+      background: #f4f4f4; padding: 0.75rem; border: 1px solid #e0e0e0;
+    }
+    .scope-toggle {
+      display: flex; gap: 1rem; margin-bottom: 0.5rem;
+    }
+    .scope-toggle label {
+      font-size: 13px; cursor: pointer; display: flex; align-items: center; gap: 4px;
+    }
+    .scope-chips {
+      display: flex; gap: 4px; flex-wrap: wrap; align-items: center;
+      padding: 6px; background: #fff; border: 1px solid #e0e0e0; min-height: 38px;
+    }
+    .scope-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      background: #d0e2ff; color: #0043ce;
+      padding: 2px 4px 2px 10px; border-radius: 999px;
+      font-size: 12px; font-weight: 600;
+    }
+    .scope-chip .x {
+      cursor: pointer; padding: 0 6px; opacity: 0.6;
+      font-size: 14px; line-height: 1;
+    }
+    .scope-chip .x:hover { opacity: 1; }
+    .scope-add {
+      background: none; border: 1px dashed #8d8d8d; color: #525252;
+      padding: 2px 10px; font-size: 12px; cursor: pointer; border-radius: 999px;
+    }
+    .scope-add:hover { border-color: #0f62fe; color: #0f62fe; }
+    .scope-empty { color: #6f6f6f; font-style: italic; font-size: 12px; }
+    .scope-pop {
+      background: #fff; border: 1px solid #8d8d8d; padding: 4px 0; margin-top: 4px;
+      max-height: 200px; overflow-y: auto; width: 200px;
+    }
+    .scope-pop .opt {
+      padding: 4px 12px; font-size: 13px; cursor: pointer;
+    }
+    .scope-pop .opt:hover { background: #edf5ff; }
+    .scope-pop .opt.checked { color: #0f62fe; font-weight: 600; }
+
+    /* Variable/function side panel */
+    .var-panel { background: #f4f4f4; padding: 0.75rem; }
+    .var-tabs { display: flex; gap: 0; border-bottom: 1px solid #e0e0e0; margin-bottom: 0.5rem; }
+    .var-tab {
+      padding: 6px 12px; cursor: pointer; font-size: 13px; color: #525252;
+      border-bottom: 2px solid transparent;
+    }
+    .var-tab.active { color: #0f62fe; border-bottom-color: #0f62fe; font-weight: 600; }
+    .var-search {
+      width: 100%; padding: 4px 8px; font-size: 13px; border: none;
+      border-bottom: 1px solid #8d8d8d; background: #fff; margin-bottom: 0.5rem;
+    }
+    .var-list { max-height: 220px; overflow-y: auto; }
+    .var-item {
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 6px 8px; cursor: pointer; font-size: 13px;
+    }
+    .var-item:hover { background: #e8e8e8; }
+    .var-item .vlabel { display: flex; flex-direction: column; }
+    .var-item .vname { color: #161616; }
+    .var-item .vmeta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; }
+    .var-item .vinsert {
+      background: #0f62fe; color: #fff; border: none; padding: 2px 8px;
+      font-size: 11px; cursor: pointer;
+    }
+
+    /* Live preview */
+    .preview-row {
+      display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem;
+    }
+    .preview-row label { flex: 0 0 180px; font-size: 13px; color: #161616; }
+    .preview-row input {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .preview-row select {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .preview-row .units { flex: 0 0 60px; font-size: 12px; color: #6f6f6f; }
+
+    .computed {
+      background: #defbe6; border-left: 3px solid #198038;
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+    }
+    .computed .label { font-size: 11px; color: #0e6027; text-transform: uppercase; letter-spacing: 0.5px; }
+    .computed .value { font-size: 28px; font-weight: 600; color: #0e6027; font-family: 'IBM Plex Mono', monospace; }
+    .computed .units { font-size: 14px; color: #525252; margin-left: 6px; }
+    .computed .flag { font-size: 12px; color: #525252; margin-top: 4px; }
+
+    /* Flowchart for branching rules */
+    .flow-wrap {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 1.25rem;
+      display: flex; flex-direction: column; align-items: center;
+    }
+    .flow-diamond {
+      background: #fff; border: 2px solid #b28600;
+      transform: rotate(45deg); width: 140px; height: 140px;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .flow-diamond .inner {
+      transform: rotate(-45deg); text-align: center; font-size: 12px; padding: 6px;
+      font-family: 'IBM Plex Mono', monospace;
+    }
+    .flow-branches {
+      display: flex; gap: 2rem; margin-top: 1.5rem; width: 100%;
+      justify-content: center; align-items: flex-start;
+    }
+    .flow-branch {
+      flex: 1; max-width: 360px; background: #fff; border: 1px solid #e0e0e0;
+      padding: 0.75rem;
+    }
+    .flow-branch .label {
+      font-size: 12px; font-weight: 600; padding: 4px 10px; border-radius: 999px;
+      display: inline-block; margin-bottom: 0.5rem;
+    }
+    .flow-branch.true .label { background: #defbe6; color: #0e6027; }
+    .flow-branch.false .label { background: #d0e2ff; color: #0043ce; }
+    .flow-branch .formula {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+      background: #fafafa; padding: 8px; border-left: 3px solid #c6c6c6;
+    }
+    .flow-arrow {
+      color: #525252; font-size: 20px; margin: 0 0.5rem;
+    }
+
+    /* Validation tests */
+    .vt-row {
+      display: grid; grid-template-columns: 2fr 1fr 1fr 30px; gap: 0.5rem;
+      align-items: center; padding: 6px 0; font-size: 13px;
+      border-bottom: 1px solid #f4f4f4;
+    }
+    .vt-row .vt-name { font-family: 'IBM Plex Mono', monospace; font-size: 11px; }
+    .vt-row .vt-pass { color: #0e6027; font-weight: 600; }
+    .vt-row .vt-fail { color: #a2191f; font-weight: 600; }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview v2 — Calculated Value Rules &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Numeric Calculation editor</strong>
+    &nbsp;<span style="color: #6f6f6f;">— what expands inline when you click a calc row with a <em>numeric</em> destination. For a <em>coded</em> destination, see <a href="calc-decision-table-preview.html" style="color: #0f62fe;">the decision-table editor</a>.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo, useRef, useEffect } = React;
+
+    // ========================================================================
+    // DOMAIN DATA
+    // ========================================================================
+    const TEST_RESULTS = [
+      { id: 'TC',     name: 'Total Cholesterol',     loinc: '2093-3',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'HDL',    name: 'HDL Cholesterol',       loinc: '2085-9',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'TRIG',   name: 'Triglycerides',         loinc: '2571-8',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'SCr',    name: 'Serum Creatinine',      loinc: '2160-0',  units: 'mg/dL', sample: 'Serum' },
+      { id: 'NA',     name: 'Sodium',                loinc: '2951-2',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'K',      name: 'Potassium',             loinc: '2823-3',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'CL',     name: 'Chloride',              loinc: '2075-0',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'HCO3',   name: 'Bicarbonate',           loinc: '1963-8',  units: 'mmol/L', sample: 'Serum' },
+      { id: 'ALB',    name: 'Albumin',               loinc: '1751-7',  units: 'g/dL',   sample: 'Serum' },
+      { id: 'CA',     name: 'Calcium, Total',        loinc: '17861-6', units: 'mg/dL',  sample: 'Serum' },
+      { id: 'BIL',    name: 'Bilirubin, Total',      loinc: '1975-2',  units: 'mg/dL',  sample: 'Serum' },
+      { id: 'INR',    name: 'INR',                   loinc: '6301-6',  units: '',       sample: 'Plasma' },
+      { id: 'WT',     name: 'Body Weight',           loinc: '29463-7', units: 'kg',     sample: 'Whole Blood' },
+      { id: 'HT',     name: 'Body Height',           loinc: '8302-2',  units: 'm',      sample: 'Whole Blood' },
+      { id: 'ALT',    name: 'ALT',                   loinc: '1742-6',  units: 'U/L',    sample: 'Serum' },
+      { id: 'AST',    name: 'AST',                   loinc: '1920-8',  units: 'U/L',    sample: 'Serum' },
+    ];
+    const PATIENT_ATTRS = [
+      { id: 'Age', name: 'Age', units: 'years' },
+      { id: 'Sex', name: 'Sex (M/F)', units: '(M/F)' },
+      { id: 'Weight', name: 'Weight', units: 'kg' },
+    ];
+    const FUNCTIONS = [
+      { id: 'min',   name: 'min(a, b)',     desc: 'Smaller of two values' },
+      { id: 'max',   name: 'max(a, b)',     desc: 'Larger of two values' },
+      { id: 'mean',  name: 'mean(a, ...)',  desc: 'Arithmetic mean' },
+      { id: 'log',   name: 'log(x)',        desc: 'Natural log' },
+      { id: 'pow',   name: 'pow(x, n)',     desc: 'x raised to n' },
+      { id: 'round', name: 'round(x, n)',   desc: 'Round to n decimals' },
+      { id: 'if',    name: 'if(cond, a, b)',desc: 'Conditional — true branch a, false branch b' },
+      { id: 'eq',    name: 'eq(a, b)',      desc: 'Equality test' },
+    ];
+
+    const VAR_BY_ID  = Object.fromEntries(TEST_RESULTS.map(v => [v.id, v]));
+    const ATTR_BY_ID = Object.fromEntries(PATIENT_ATTRS.map(v => [v.id, v]));
+    const FN_BY_ID   = Object.fromEntries(FUNCTIONS.map(v => [v.id, v]));
+
+    // ========================================================================
+    // TOKENIZER — for syntax highlighting and linting
+    // ========================================================================
+    function tokenize(text) {
+      const re = /(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|([+\-*\/=<>])|([(),])|(\s+)|(.)/g;
+      const out = [];
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({ kind: 'num', text: m[1] });
+        else if (m[2]) {
+          const id = m[2];
+          if (VAR_BY_ID[id])  out.push({ kind: 'var', text: id });
+          else if (FN_BY_ID[id])   out.push({ kind: 'fn',  text: id });
+          else if (ATTR_BY_ID[id]) out.push({ kind: 'attr',text: id });
+          else out.push({ kind: 'unknown', text: id });
+        }
+        else if (m[3]) out.push({ kind: 'op', text: m[3] });
+        else if (m[4]) out.push({ kind: 'paren', text: m[4] });
+        else if (m[5]) out.push({ kind: 'ws', text: m[5] });
+        else out.push({ kind: 'other', text: m[6] });
+      }
+      return out;
+    }
+
+    function lint(tokens) {
+      const issues = [];
+      const unknowns = tokens.filter(t => t.kind === 'unknown');
+      if (unknowns.length) {
+        issues.push({ kind: 'err', msg: `Unknown identifier${unknowns.length > 1 ? 's' : ''}: ${unknowns.map(u => u.text).join(', ')}` });
+      }
+      // paren balance
+      let depth = 0;
+      for (const t of tokens) {
+        if (t.kind === 'paren' && t.text === '(') depth++;
+        else if (t.kind === 'paren' && t.text === ')') depth--;
+        if (depth < 0) { issues.push({ kind: 'err', msg: 'Unmatched closing paren' }); break; }
+      }
+      if (depth > 0) issues.push({ kind: 'err', msg: `${depth} unclosed paren${depth > 1 ? 's' : ''}` });
+      // unit awareness — sample heuristic: TRIG/5 fine, but Weight + Height would warn
+      // (skipped here in mockup to keep code shorter)
+      return issues;
+    }
+
+    // ========================================================================
+    // SAMPLE-TYPE SCOPE — apply to all sample types, or a selected subset
+    // ========================================================================
+    const ALL_SAMPLE_TYPES = [
+      'Serum', 'Plasma', 'Whole Blood', 'EDTA Tube', 'Dry Tube', 'DBS',
+      'Urines', 'Fluid', 'Sputum', 'Respiratory Swab',
+      'Tissue antemortem', 'Tissue post mortem',
+      'Histopathology specimen', 'Immunohistochemistry specimen'
+    ];
+
+    function SampleScope({ mode, selected, onModeChange, onChange }) {
+      const [popOpen, setPopOpen] = useState(false);
+      const remaining = ALL_SAMPLE_TYPES.filter(s => !selected.includes(s));
+      return (
+        <div className="scope-block">
+          <div style={{ fontSize: 11, color: '#525252', marginBottom: 6, textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Applies to
+          </div>
+          <div className="scope-toggle">
+            <label>
+              <input type="radio" checked={mode === 'all'}
+                     onChange={() => onModeChange('all')} />
+              All sample types
+            </label>
+            <label>
+              <input type="radio" checked={mode === 'selected'}
+                     onChange={() => onModeChange('selected')} />
+              Selected sample types
+            </label>
+          </div>
+          {mode === 'selected' && (
+            <>
+              <div className="scope-chips">
+                {selected.length === 0 && <span className="scope-empty">No sample types selected — rule will not fire</span>}
+                {selected.map(s => (
+                  <span key={s} className="scope-chip">
+                    {s}
+                    <span className="x" onClick={() => onChange(selected.filter(x => x !== s))}>×</span>
+                  </span>
+                ))}
+                {remaining.length > 0 && (
+                  <button className="scope-add" onClick={() => setPopOpen(o => !o)}>
+                    + Add sample type ▾
+                  </button>
+                )}
+              </div>
+              {popOpen && (
+                <div className="scope-pop">
+                  {remaining.map(s => (
+                    <div key={s} className="opt" onClick={() => { onChange([...selected, s]); setPopOpen(false); }}>
+                      {s}
+                    </div>
+                  ))}
+                </div>
+              )}
+              <div className="compact-hint">
+                The rule writes the calculated value back to the same sample type the inputs came from.
+                If multiple are selected, the same formula evaluates separately for each sample type.
+              </div>
+            </>
+          )}
+          {mode === 'all' && (
+            <div className="compact-hint">
+              Rule fires whenever every input test has a numeric result, regardless of sample type.
+              Useful when a test can be ordered on multiple specimens (e.g. Creatinine on Serum or Plasma).
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA BAR — textarea with syntax-highlighted overlay
+    // ========================================================================
+    function FormulaBar({ value, onChange, autocompleteAt, suggestions, onPick }) {
+      const tokens = tokenize(value);
+      const issues = lint(tokens);
+      const taRef = useRef(null);
+
+      return (
+        <div>
+          <div className="formula-bar-wrap">
+            <div className="formula-overlay">
+              {tokens.map((t, i) => (
+                <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+              ))}
+              {value === '' && <span style={{ color: '#a8a8a8' }}>Type a formula… (autocomplete on test names, LOINC, functions)</span>}
+            </div>
+            <textarea
+              ref={taRef}
+              className="formula-input"
+              value={value}
+              onChange={e => onChange(e.target.value)}
+              spellCheck={false}
+              rows={Math.max(1, value.split('\n').length)}
+            />
+            {suggestions && suggestions.length > 0 && (
+              <div className="ac-pop">
+                {suggestions.map((s, i) => (
+                  <div key={s.id} className={'ac-item' + (i === 0 ? ' sel' : '')} onClick={() => onPick(s)}>
+                    <span>
+                      <span className={'ac-kind ' + s.kind}>{s.kind === 'fn' ? 'fn' : s.kind === 'attr' ? 'attr' : 'test'}</span>
+                      &nbsp;<strong>{s.id}</strong> &nbsp;<span style={{ color: '#525252' }}>{s.name}</span>
+                    </span>
+                    <span className="ac-meta">{s.meta}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="formula-prompt">
+            {issues.length === 0
+              ? <span className="ok">✓ Valid syntax · {tokens.filter(t=>t.kind==='var').length} variable(s) referenced</span>
+              : issues.map((i, idx) => <span key={idx} className="err">⚠ {i.msg}</span>)}
+            <span style={{ marginLeft: 'auto', color: '#0f62fe', cursor: 'pointer' }}>
+              Press @ for variable picker · Ctrl+Space for functions
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // MATH VIEW — render formula in math notation with colored variable pills
+    // ========================================================================
+    function MathPill({ kind, name, units }) {
+      return (
+        <span className={'math-pill ' + kind}>
+          <span className="label">{name}</span>
+          {units && <span className="units">{units}</span>}
+        </span>
+      );
+    }
+    function MathOp({ op }) { return <span className="math-op">{op}</span>; }
+    function MathNum({ n }) { return <span className="math-num">{n}</span>; }
+    function MathFraction({ top, bot }) {
+      return (
+        <span className="math-fraction">
+          <span className="top">{top}</span>
+          <span className="bar"></span>
+          <span className="bot">{bot}</span>
+        </span>
+      );
+    }
+
+    // LDL: TC − HDL − (Trig / 5)
+    function LDLMathView() {
+      return (
+        <div className="math-view">
+          <MathPill kind="var" name="Total Cholesterol" units="mg/dL" />
+          <MathOp op="−" />
+          <MathPill kind="var" name="HDL" units="mg/dL" />
+          <MathOp op="−" />
+          <MathFraction
+            top={<MathPill kind="var" name="Triglycerides" units="mg/dL" />}
+            bot={<MathNum n="5" />}
+          />
+        </div>
+      );
+    }
+
+    // eGFR: rendered top of formula (the parts before the conditional split)
+    function EGFRMathView() {
+      return (
+        <div className="math-view">
+          <MathNum n="142" />
+          <MathOp op="×" />
+          <span style={{ fontFamily: "'IBM Plex Mono', monospace", color: '#491d8b', fontWeight: 600 }}>min</span>
+          <span className="math-paren">(</span>
+          <MathFraction
+            top={<MathPill kind="var" name="SCr" units="mg/dL" />}
+            bot={<span style={{ fontFamily: 'monospace', color: '#491d8b' }}>κ</span>}
+          />
+          <span style={{ color: '#d12771' }}>,</span>
+          <MathNum n="1" />
+          <span className="math-paren">)</span>
+          <MathOp op="^" />
+          <span style={{ fontFamily: 'monospace', color: '#491d8b' }}>α</span>
+          <MathOp op="×" />
+          <span style={{ fontStyle: 'italic', color: '#6f6f6f' }}>… (κ, α depend on Sex — see branches below)</span>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // VARIABLE / FUNCTION SIDE PANEL
+    // ========================================================================
+    function VariablePanel({ onInsert }) {
+      const [tab, setTab] = useState('tests');
+      const [q, setQ] = useState('');
+      const items = tab === 'tests' ? TEST_RESULTS
+                  : tab === 'attrs' ? PATIENT_ATTRS
+                  : FUNCTIONS;
+      const filtered = items.filter(i =>
+        (i.name + (i.id || '') + (i.desc || '') + (i.loinc || '')).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="var-panel">
+          <div className="var-tabs">
+            <div className={'var-tab' + (tab === 'tests' ? ' active' : '')} onClick={() => setTab('tests')}>Test Results</div>
+            <div className={'var-tab' + (tab === 'attrs' ? ' active' : '')} onClick={() => setTab('attrs')}>Patient Attributes</div>
+            <div className={'var-tab' + (tab === 'fns'   ? ' active' : '')} onClick={() => setTab('fns')}>Functions</div>
+          </div>
+          <input
+            className="var-search"
+            placeholder={'Search ' + (tab === 'tests' ? 'test name, LOINC' : tab === 'attrs' ? 'attribute' : 'function') + '…'}
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="var-list">
+            {filtered.map(item => (
+              <div key={item.id} className="var-item" onClick={() => onInsert(item, tab)}>
+                <div className="vlabel">
+                  <span className="vname">{item.name}</span>
+                  <span className="vmeta">
+                    {tab === 'tests' && `${item.id} · ${item.units} · ${item.sample}${item.loinc ? ' · LOINC ' + item.loinc : ''}`}
+                    {tab === 'attrs' && `${item.id} · ${item.units}`}
+                    {tab === 'fns' && item.desc}
+                  </span>
+                </div>
+                <button className="vinsert">Insert</button>
+              </div>
+            ))}
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // LDL EDITOR — pure arithmetic, formula bar + math view
+    // ========================================================================
+    function LDLEditor() {
+      const [formula, setFormula] = useState('TC - HDL - TRIG / 5');
+      const [tc, setTc] = useState(195);
+      const [hdl, setHdl] = useState(48);
+      const [trig, setTrig] = useState(150);
+      const [advanced, setAdvanced] = useState(false);
+      // Sample-type scope — LDL is valid on Serum or Plasma (fasting)
+      const [scopeMode, setScopeMode] = useState('selected');
+      const [scopeSelected, setScopeSelected] = useState(['Serum', 'Plasma']);
+      const scopeSummary = scopeMode === 'all'
+        ? 'All sample types'
+        : scopeSelected.length === 0 ? 'no sample types — will not fire'
+        : scopeSelected.join(', ');
+
+      const ldl = Math.round(tc - hdl - trig / 5);
+      const flag = ldl < 100 ? 'Optimal (<100)'
+                  : ldl < 130 ? 'Near optimal (100–129)'
+                  : ldl < 160 ? 'Borderline high (130–159)'
+                  : ldl < 190 ? 'High (160–189)'
+                  : 'Very high (≥190)';
+
+      // Mock autocomplete: when current word is a partial identifier
+      const cursorWord = (formula.match(/[A-Za-z_][A-Za-z0-9_]*$/) || [''])[0];
+      const suggestions = cursorWord.length > 0
+        ? [...TEST_RESULTS.map(t => ({ id: t.id, name: t.name, kind: 'var', meta: `${t.units} · ${t.sample}${t.loinc ? ' · '+t.loinc : ''}` })),
+           ...FUNCTIONS.map(f => ({ id: f.id, name: f.name, kind: 'fn', meta: f.desc })),
+           ...PATIENT_ATTRS.map(a => ({ id: a.id, name: a.name, kind: 'attr', meta: a.units }))]
+            .filter(s => s.id.toLowerCase().startsWith(cursorWord.toLowerCase()) && s.id !== cursorWord)
+            .slice(0, 5)
+        : [];
+
+      const insertFromPicker = (item, tab) => {
+        const id = item.id;
+        setFormula(f => (f.endsWith(' ') || f === '') ? f + id : f + ' ' + id);
+      };
+      const onPickAc = (s) => {
+        setFormula(f => f.replace(/[A-Za-z_][A-Za-z0-9_]*$/, s.id));
+      };
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Applies to: {scopeSummary}</span>
+                <span className="cds--tag cds--tag--teal">Output: mg/dL</span>
+              </div>
+
+              <div className="editor-grid">
+                {/* LEFT — formula bar + math view + side panel */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">Formula bar</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="LDL Cholesterol (Friedewald)"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                  </div>
+
+                  <div className="panel-section">
+                    <SampleScope
+                      mode={scopeMode} selected={scopeSelected}
+                      onModeChange={setScopeMode} onChange={setScopeSelected}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Formula
+                    </label>
+                    <FormulaBar
+                      value={formula}
+                      onChange={setFormula}
+                      suggestions={suggestions}
+                      onPick={onPickAc}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Rendered (read-only)
+                    </label>
+                    <LDLMathView />
+                    <div className="compact-hint">
+                      Variables shown with units. Reviewers sign off on this view, not the text.
+                    </div>
+                  </div>
+
+                  <div className="panel-section" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '0.75rem' }}>
+                    <div>
+                      <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                        Insert from library
+                      </label>
+                      <VariablePanel onInsert={insertFromPicker} />
+                    </div>
+                    <div>
+                      <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                        Output (Final Result)
+                      </label>
+                      <div style={{ padding: 8, background: '#f4f4f4' }}>
+                        <div style={{ marginBottom: 6 }}>
+                          <span style={{ fontSize: 11, color: '#6f6f6f' }}>Destination test</span>
+                          <select defaultValue="LDL"
+                                  style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }}>
+                            <option value="LDL">LDL Cholesterol (LOINC 13457-7)</option>
+                          </select>
+                        </div>
+                        <div style={{ display: 'flex', gap: 6 }}>
+                          <div style={{ flex: 1 }}>
+                            <span style={{ fontSize: 11, color: '#6f6f6f' }}>Units</span>
+                            <select defaultValue="mg/dL"
+                                    style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }}>
+                              <option>mg/dL</option><option>mmol/L</option>
+                            </select>
+                          </div>
+                          <div style={{ flex: 1 }}>
+                            <span style={{ fontSize: 11, color: '#6f6f6f' }}>Decimals</span>
+                            <input type="number" defaultValue="0"
+                                   style={{ display: 'block', width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', marginTop: 2 }} />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* RIGHT — live preview + validation tests */}
+                <div className="panel">
+                  <h4>Live preview <span className="pill green">Sandbox</span></h4>
+                  <div className="panel-section">
+                    <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+                      Edit the formula on the left or change inputs here. Output recomputes live.
+                    </span>
+                    <div className="preview-row">
+                      <label>Total Cholesterol (TC)</label>
+                      <input type="number" value={tc} onChange={e => setTc(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>HDL Cholesterol (HDL)</label>
+                      <input type="number" value={hdl} onChange={e => setHdl(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Triglycerides (TRIG)</label>
+                      <input type="number" value={trig} onChange={e => setTrig(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+
+                    <div className="computed">
+                      <div className="label">Computed LDL</div>
+                      <div>
+                        <span className="value">{ldl}</span>
+                        <span className="units">mg/dL</span>
+                      </div>
+                      <div className="flag">Flag: {flag}</div>
+                      {trig >= 400 && (
+                        <div className="cds--inline-notification cds--inline-notification--warning"
+                             style={{ marginTop: 8, padding: '6px 10px', fontSize: 12 }}>
+                          ⚠ Friedewald is not valid when Triglycerides ≥ 400 mg/dL. Direct LDL recommended.
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 6 }}>
+                      Validation tests &nbsp;
+                      <button onClick={() => setAdvanced(a => !a)}
+                              style={{ fontSize: 11, background: 'none', border: 'none', color: '#0f62fe', cursor: 'pointer' }}>
+                        {advanced ? 'Hide' : 'Show all'}
+                      </button>
+                    </label>
+                    <div className="vt-row" style={{ fontWeight: 600, fontSize: 11, color: '#525252', borderBottom: '1px solid #e0e0e0' }}>
+                      <span>Inputs</span><span>Expected</span><span>Got</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">TC=195, HDL=48, Trig=150</span>
+                      <span>117</span><span className="vt-pass">117 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">TC=240, HDL=35, Trig=200</span>
+                      <span>165</span><span className="vt-pass">165 ✓</span><span></span>
+                    </div>
+                    {advanced && (
+                      <>
+                        <div className="vt-row">
+                          <span className="vt-name">TC=180, HDL=60, Trig=90</span>
+                          <span>102</span><span className="vt-pass">102 ✓</span><span></span>
+                        </div>
+                        <div className="vt-row">
+                          <span className="vt-name">TC=220, HDL=40, Trig=420</span>
+                          <span>—</span><span className="vt-fail">— (skip: Trig≥400)</span><span></span>
+                        </div>
+                      </>
+                    )}
+                    <button className="cds--btn cds--btn--ghost" style={{ marginTop: 6, fontSize: 12 }}>+ Add validation case</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation tests</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // eGFR EDITOR — branching, formula bar + flowchart panel
+    // ========================================================================
+    function EGFREditor() {
+      const [formula, setFormula] = useState(
+        "if(eq(Sex, F),\n  142 * pow(min(SCr/0.7, 1), -0.241) * pow(max(SCr/0.7, 1), -1.200) * pow(0.9938, Age) * 1.012,\n  142 * pow(min(SCr/0.9, 1), -0.302) * pow(max(SCr/0.9, 1), -1.200) * pow(0.9938, Age))"
+      );
+      const [scr, setScr] = useState(1.1);
+      const [age, setAge] = useState(54);
+      const [sex, setSex] = useState('F');
+      // eGFR: Serum and Plasma both valid for creatinine
+      const [scopeMode, setScopeMode] = useState('selected');
+      const [scopeSelected, setScopeSelected] = useState(['Serum', 'Plasma']);
+      const scopeSummary = scopeMode === 'all'
+        ? 'All sample types'
+        : scopeSelected.length === 0 ? 'no sample types — will not fire'
+        : scopeSelected.join(', ');
+
+      const k = sex === 'F' ? 0.7 : 0.9;
+      const a1 = sex === 'F' ? -0.241 : -0.302;
+      const sexBoost = sex === 'F' ? 1.012 : 1;
+      const egfr = Math.round(
+        142 * Math.pow(Math.min(scr/k, 1), a1) * Math.pow(Math.max(scr/k, 1), -1.2) * Math.pow(0.9938, age) * sexBoost
+      );
+      const stage = egfr >= 90 ? 'G1 (≥90)'
+                  : egfr >= 60 ? 'G2 (60–89)'
+                  : egfr >= 45 ? 'G3a (45–59)'
+                  : egfr >= 30 ? 'G3b (30–44)'
+                  : egfr >= 15 ? 'G4 (15–29)' : 'G5 (<15)';
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Applies to: {scopeSummary}</span>
+                <span className="cds--tag cds--tag--teal">Output: mL/min/1.73m²</span>
+                <span className="cds--tag cds--tag--purple">Branching · 2 paths</span>
+              </div>
+
+              <div className="editor-grid">
+                {/* LEFT — formula bar */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">Formula bar</span> <span className="pill warn">Branching detected</span></h4>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                    <input type="text" defaultValue="eGFR (CKD-EPI 2021, race-free)"
+                           style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                  </div>
+
+                  <div className="panel-section">
+                    <SampleScope
+                      mode={scopeMode} selected={scopeSelected}
+                      onModeChange={setScopeMode} onChange={setScopeSelected}
+                    />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Formula
+                    </label>
+                    <FormulaBar value={formula} onChange={setFormula} suggestions={[]} onPick={() => {}} />
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 4 }}>
+                      Branch view <span className="compact-hint" style={{ display: 'inline' }}>— appears automatically when formula uses <code>if()</code></span>
+                    </label>
+                    <div className="flow-wrap">
+                      <div className="flow-diamond"><div className="inner">eq(<span className="tok-attr">Sex</span>, F)</div></div>
+                      <div className="flow-branches">
+                        <div className="flow-branch true">
+                          <div className="label">True · Female</div>
+                          <div className="formula">
+                            <span className="tok-num">142</span> <span className="tok-op">*</span> <span className="tok-fn">pow</span>(<span className="tok-fn">min</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.7</span>, <span className="tok-num">1</span>), <span className="tok-num">-0.241</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-fn">max</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.7</span>, <span className="tok-num">1</span>), <span className="tok-num">-1.200</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-num">0.9938</span>, <span className="tok-attr">Age</span>) <span className="tok-op">*</span> <span className="tok-num">1.012</span>
+                          </div>
+                        </div>
+                        <div className="flow-branch false">
+                          <div className="label">False · Male</div>
+                          <div className="formula">
+                            <span className="tok-num">142</span> <span className="tok-op">*</span> <span className="tok-fn">pow</span>(<span className="tok-fn">min</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.9</span>, <span className="tok-num">1</span>), <span className="tok-num">-0.302</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-fn">max</span>(<span className="tok-var">SCr</span>/<span className="tok-num">0.9</span>, <span className="tok-num">1</span>), <span className="tok-num">-1.200</span>) <span className="tok-op">*</span><br/>
+                            <span className="tok-fn">pow</span>(<span className="tok-num">0.9938</span>, <span className="tok-attr">Age</span>)
+                          </div>
+                        </div>
+                      </div>
+                      <div style={{ marginTop: '0.75rem' }}>
+                        <button className="cds--btn cds--btn--ghost" style={{ fontSize: 12 }}>+ Add branch (e.g. pediatric)</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                {/* RIGHT — live preview */}
+                <div className="panel">
+                  <h4>Live preview <span className="pill green">Sandbox</span></h4>
+                  <div className="panel-section">
+                    <div className="preview-row">
+                      <label>Serum Creatinine (SCr)</label>
+                      <input type="number" step="0.1" value={scr} onChange={e => setScr(+e.target.value || 0)} />
+                      <span className="units">mg/dL</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Age</label>
+                      <input type="number" value={age} onChange={e => setAge(+e.target.value || 0)} />
+                      <span className="units">years</span>
+                    </div>
+                    <div className="preview-row">
+                      <label>Sex</label>
+                      <select value={sex} onChange={e => setSex(e.target.value)}>
+                        <option value="F">F</option><option value="M">M</option>
+                      </select>
+                      <span className="units"></span>
+                    </div>
+
+                    <div className="computed">
+                      <div className="label">Computed eGFR</div>
+                      <div>
+                        <span className="value">{egfr}</span>
+                        <span className="units">mL/min/1.73m²</span>
+                      </div>
+                      <div className="flag">CKD stage: {stage}</div>
+                      <div className="flag" style={{ color: '#525252' }}>
+                        Branch taken: <strong>{sex === 'F' ? 'True · Female' : 'False · Male'}</strong>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <label style={{ fontSize: 12, color: '#525252', display: 'block', marginBottom: 6 }}>
+                      Validation tests
+                    </label>
+                    <div className="vt-row" style={{ fontWeight: 600, fontSize: 11, color: '#525252', borderBottom: '1px solid #e0e0e0' }}>
+                      <span>Inputs</span><span>Expected</span><span>Got</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=1.1, Age=54, Sex=F</span>
+                      <span>61</span><span className="vt-pass">61 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=0.9, Age=40, Sex=M</span>
+                      <span>105</span><span className="vt-pass">105 ✓</span><span></span>
+                    </div>
+                    <div className="vt-row">
+                      <span className="vt-name">SCr=2.4, Age=68, Sex=F</span>
+                      <span>21</span><span className="vt-pass">21 ✓</span><span></span>
+                    </div>
+                    <button className="cds--btn cds--btn--ghost" style={{ marginTop: 6, fontSize: 12 }}>+ Add validation case</button>
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run validation tests</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // RULE LIST DATA — with rich tokenized summaries
+    // ========================================================================
+    const RULES = [
+      { id: 1, name: 'BMI', status: 'active',
+        formula: 'WT / pow(HT, 2)',
+        destination: 'BMI (kg/m²)', scope: 'all',  scopeList: [],
+        edited: '2026-04-12 by m.kone' },
+      { id: 2, name: 'LDL Cholesterol (Friedewald)', status: 'active',
+        formula: 'TC - HDL - TRIG / 5',
+        destination: 'LDL Cholesterol (mg/dL)', scope: 'selected', scopeList: ['Serum', 'Plasma'],
+        edited: '2026-04-28 by p.diallo' },
+      { id: 3, name: 'eGFR (CKD-EPI 2021)', status: 'active', branching: true,
+        formula: 'if(eq(Sex, F), 142 * pow(min(SCr/0.7,1), -0.241) * ..., 142 * pow(min(SCr/0.9,1), -0.302) * ...)',
+        destination: 'eGFR (mL/min/1.73m²)', scope: 'selected', scopeList: ['Serum', 'Plasma'],
+        edited: '2026-03-04 by p.diallo' },
+      { id: 4, name: 'Anion Gap', status: 'active',
+        formula: 'NA - (CL + HCO3)',
+        destination: 'Anion Gap (mmol/L)', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-02-18 by m.kone' },
+      { id: 5, name: 'Corrected Calcium', status: 'active',
+        formula: 'CA + 0.8 * (4 - ALB)',
+        destination: 'Corrected Calcium (mg/dL)', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-04-21 by m.kone' },
+      { id: 6, name: 'AST/ALT Ratio (De Ritis)', status: 'active',
+        formula: 'AST / ALT',
+        destination: 'AST/ALT Ratio', scope: 'selected', scopeList: ['Serum'],
+        edited: '2026-03-30 by m.kone' },
+      { id: 7, name: 'MELD-Na', status: 'disabled', branching: true,
+        formula: 'round(...) + ... (capped 6–40)',
+        destination: 'MELD Score', scope: 'selected', scopeList: ['Serum'],
+        edited: '2025-11-09 by p.diallo' },
+      { id: 8, name: 'Albumin Conversion mg/dL → g/L', status: 'active',
+        formula: 'ALB * 10',
+        destination: 'Albumin g/L', scope: 'all', scopeList: [],
+        edited: '2026-01-15 by m.kone' },
+    ];
+
+    function FormulaSummary({ text }) {
+      const tokens = tokenize(text);
+      return (
+        <span className="rule-summary">
+          {tokens.map((t, i) => (
+            <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+          ))}
+        </span>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA LIBRARY DRAWER (replaces the rigid templates strip)
+    // ========================================================================
+    const LIBRARY = [
+      { name: 'BMI',                    formula: 'Weight / Height²',                   src: 'WHO' },
+      { name: 'LDL (Friedewald)',       formula: 'TC − HDL − Trig/5',                  src: 'Friedewald 1972' },
+      { name: 'LDL (Martin-Hopkins)',   formula: 'TC − HDL − Trig/adjFactor(Trig,nonHDL)', src: 'Martin 2013' },
+      { name: 'eGFR (CKD-EPI 2021)',    formula: '142 × min(SCr/κ,1)^α × … × Age × Sex',src: 'NKF-ASN 2021' },
+      { name: 'eGFR (MDRD)',            formula: '175 × SCr^-1.154 × Age^-0.203 × …',  src: 'Levey 1999' },
+      { name: 'Cockcroft-Gault CrCl',   formula: '(140−Age)×Wt / (72×SCr) × 0.85 if F',src: 'Cockcroft 1976' },
+      { name: 'Anion Gap',              formula: 'Na − (Cl + HCO₃)',                   src: 'standard' },
+      { name: 'Corrected Calcium',      formula: 'Ca + 0.8 × (4 − Albumin)',           src: 'Payne 1973' },
+      { name: 'MELD-Na',                formula: 'MELD + 1.32×(137−Na) − 0.033×MELD×(137−Na)', src: 'OPTN' },
+      { name: 'Child-Pugh score',       formula: 'sum of 5 categorical points',        src: 'Pugh 1973' },
+      { name: 'A:G Ratio',              formula: 'Alb / (Total Protein − Alb)',        src: 'standard' },
+      { name: 'Globulin',               formula: 'Total Protein − Albumin',            src: 'standard' },
+      { name: 'Bilirubin direct→indirect', formula: 'Total Bili − Direct Bili',        src: 'standard' },
+      { name: 'BUN/Creatinine ratio',   formula: 'BUN / Creatinine',                   src: 'standard' },
+      { name: 'Free water deficit',     formula: '0.6 × Wt × (Na/140 − 1)',            src: 'Adrogue 2000' },
+      { name: 'Fractional excretion Na', formula: '(UNa×Cr) / (PNa×UCr) × 100',         src: 'standard' },
+    ];
+
+    function LibraryDrawer({ onClose }) {
+      const [q, setQ] = useState('');
+      const filtered = LIBRARY.filter(t =>
+        (t.name + t.formula + t.src).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="library-drawer">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <h4>Formula library &nbsp;<span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f' }}>{LIBRARY.length} entries · search by name, citation, or formula text</span></h4>
+            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#525252', fontSize: 16 }}>✕</button>
+          </div>
+          <input
+            className="library-search"
+            placeholder="Search formulas (e.g. 'eGFR', 'Friedewald', 'Calcium')…"
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="library-grid">
+            {filtered.map(tpl => (
+              <div key={tpl.name} className="library-card">
+                <div className="name">{tpl.name}</div>
+                <div className="formula">{tpl.formula}</div>
+                <div className="src">{tpl.src}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 11, color: '#6f6f6f' }}>
+            Picking a template prefills the formula bar and copies its validation cases. You can edit either freely afterward.
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState(2); // LDL pre-expanded
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [libraryOpen, setLibraryOpen] = useState(false);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Calculated Value Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Calculated Value Rules
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>v2 design brief:</strong> Formula bar with syntax highlighting, autocomplete,
+              and inline linting is the primary input — power users type, beginners discover via
+              the side panel. A read-only <em>math view</em> renders the same formula in proper
+              notation with units (the QA artifact reviewers sign off on). When the formula uses
+              <code> if()</code>, a flowchart panel appears showing each branch separately. Templates
+              live behind a searchable library, not a rigid strip. <strong>Sample-type scope</strong>
+              lets the rule apply to <em>all</em> sample types or to a <em>selected subset</em> —
+              e.g. LDL fires on both Serum and Plasma; eGFR fires on Serum and Plasma; BMI applies
+              to all sample types. The list view shows the scope on each rule.
+              Both LDL (arithmetic) and eGFR (branching) editors are pre-expanded so you can compare.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search rules by name, test, or destination…" />
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Sample: All ▾</span>
+              <span className="filter-pill">Destination: All ▾</span>
+            </div>
+            <div>
+              <button className={'browse-btn' + (libraryOpen ? ' open' : '')}
+                      onClick={() => setLibraryOpen(o => !o)}
+                      style={{ marginRight: 8 }}>
+                Browse formula library
+              </button>
+              <button className="cds--btn cds--btn--primary">+ New calculation</button>
+            </div>
+          </div>
+
+          {libraryOpen && <LibraryDrawer onClose={() => setLibraryOpen(false)} />}
+
+          {/* Rule list */}
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 90 }}>Status</th>
+                  <th>Rule</th>
+                  <th>Destination</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                  <th style={{ width: 60 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {RULES.map(rule => (
+                  <React.Fragment key={rule.id}>
+                    <tr style={{ background: expandedId === rule.id ? '#edf5ff' : 'transparent' }}>
+                      <td>
+                        <button
+                          onClick={() => setExpandedId(expandedId === rule.id ? null : rule.id)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                          {expandedId === rule.id ? '▾' : '▸'}
+                        </button>
+                      </td>
+                      <td>
+                        {rule.status === 'active'
+                          ? <span className="cds--tag cds--tag--green">Active</span>
+                          : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                        {rule.branching && <span className="cds--tag cds--tag--purple" style={{ marginLeft: 4 }}>Branching</span>}
+                      </td>
+                      <td>
+                        <div className="rule-name">{rule.name}</div>
+                        <FormulaSummary text={rule.formula} />
+                      </td>
+                      <td style={{ fontSize: 13 }}>
+                        <div>{rule.destination}</div>
+                        <div style={{ fontSize: 11, color: '#6f6f6f', marginTop: 2 }}>
+                          {rule.scope === 'all'
+                            ? <span style={{ color: '#0043ce' }}>→ all sample types</span>
+                            : <>→ {rule.scopeList.map((s, i) => (
+                                <span key={s} className="cds--tag cds--tag--cool-gray" style={{ marginRight: 2, fontSize: 10 }}>{s}</span>
+                              ))}</>}
+                        </div>
+                      </td>
+                      <td style={{ fontSize: 12, color: '#6f6f6f' }}>{rule.edited}</td>
+                      <td>
+                        <span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span>
+                      </td>
+                    </tr>
+                    {expandedId === rule.id && rule.id === 2 && <LDLEditor />}
+                    {expandedId === rule.id && rule.id === 3 && <EGFREditor />}
+                    {expandedId === rule.id && rule.id !== 2 && rule.id !== 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#f4f4f4', fontSize: 13, color: '#525252' }}>
+                          (Editor for <strong>{rule.name}</strong> would render in the same formula-bar layout.
+                          {rule.branching ? ' Flowchart panel would appear because this rule uses if().' : ' No flowchart panel — pure arithmetic.'})
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What changed vs. v1:</strong> Chip canvas removed as the primary input — typing in
+            the formula bar is faster and beginners still get discovery through the side panel.
+            Math-view rendering moved beneath the bar as the read-only QA artifact. Flowchart panel
+            now appears <em>only</em> when the formula uses <code>if()</code> — eGFR and MELD-Na get
+            it, BMI and LDL don't. Templates moved from a fixed six-card strip into a searchable
+            library drawer with citations (Friedewald 1972, NKF-ASN 2021, Cockcroft 1976, etc.).
+            Both the formula bar and the math view are <em>views on the same AST</em> — typing
+            updates both, picking a template populates both.
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/mockup-viewer/public/designs/admin-config/reflex-tests-redesign-preview.html
+++ b/mockup-viewer/public/designs/admin-config/reflex-tests-redesign-preview.html
@@ -1,0 +1,2379 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reflex Test Rules — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 280px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .browse-btn {
+      background: #fff; padding: 4px 12px; font-size: 12px; border: 1px solid #0f62fe;
+      color: #0f62fe; cursor: pointer;
+    }
+    .browse-btn.open { background: #0f62fe; color: #fff; }
+
+    /* Library drawer */
+    .library-drawer {
+      background: #fff; border: 1px solid #e0e0e0; border-bottom: none;
+      padding: 1rem;
+    }
+    .library-drawer h4 { margin: 0 0 0.5rem; font-size: 13px; }
+    .library-search {
+      width: 320px; padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 14px; margin-bottom: 0.75rem;
+    }
+    .library-grid {
+      display: grid; grid-template-columns: repeat(2, 1fr); gap: 0.5rem;
+    }
+    .library-card {
+      padding: 0.75rem 1rem; border: 1px solid #e0e0e0; cursor: pointer;
+    }
+    .library-card:hover { border-color: #0f62fe; background: #f4f9ff; }
+    .library-card .name { font-weight: 600; font-size: 13px; color: #161616; }
+    .library-card .shape {
+      font-family: 'IBM Plex Mono', monospace; font-size: 11px; color: #525252; margin-top: 4px;
+    }
+    .library-card .src { font-size: 10px; color: #8d8d8d; margin-top: 4px; }
+
+    /* DataTable */
+    table.cds--data-table { width: 100%; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }  /* semantic predicate (raw form) */
+    .phrase {
+      display: inline-flex; align-items: baseline; gap: 4px;
+      background: #f4f9ff; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Sans', sans-serif; font-size: 12px;
+      color: #161616; margin: 0 2px;
+    }
+    .phrase strong { font-weight: 600; color: #161616; }
+    .phrase em { color: #0072c3; font-style: normal; font-weight: 500; }
+    .tok-unknown {
+      color: #a2191f; text-decoration: underline wavy #da1e28; text-underline-offset: 3px;
+    }
+
+    /* Searchable test/panel picker (in ActionRow) */
+    .tp-picker { position: relative; flex: 1 1 100%; min-width: 280px; }
+    .tp-input-wrap {
+      display: flex; align-items: center; gap: 6px;
+      background: #f4f4f4; border-bottom: 1px solid #8d8d8d; padding: 4px 8px;
+    }
+    .tp-input-wrap:focus-within { border-color: #0f62fe; background: #fff; }
+    .tp-input {
+      flex: 1; border: none; outline: none; background: transparent;
+      font-size: 13px; padding: 2px 0;
+    }
+    .tp-selected {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: #d0e2ff; color: #0043ce; padding: 2px 8px; border-radius: 4px;
+      font-size: 12px; font-weight: 600;
+    }
+    .tp-selected .clear { cursor: pointer; opacity: 0.7; }
+    .tp-selected .clear:hover { opacity: 1; }
+    .tp-selected .kind {
+      background: #fff; color: #0043ce; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .tp-pop {
+      position: absolute; top: 100%; left: 0; right: 0; z-index: 30; margin-top: 2px;
+      background: #fff; border: 1px solid #8d8d8d;
+      max-height: 320px; overflow-y: auto;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+    }
+    .tp-scope {
+      display: flex; gap: 1rem; padding: 8px 10px; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0; font-size: 12px;
+    }
+    .tp-scope label { cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+    .tp-scope .warn-pill {
+      background: #fff8e1; color: #b28600; font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 3px; margin-left: 4px;
+    }
+    .tp-warn {
+      background: #fff8e1; color: #6b4a00; padding: 6px 10px;
+      font-size: 11px; border-bottom: 1px solid #f1c21b;
+    }
+    .tp-section {
+      padding: 6px 10px; background: #fafafa;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+      color: #525252; font-weight: 600;
+    }
+    .tp-item {
+      padding: 6px 10px; cursor: pointer; display: flex; align-items: center; gap: 8px;
+      border-top: 1px solid #f4f4f4; font-size: 13px;
+    }
+    .tp-item:hover { background: #edf5ff; }
+    .tp-item .label { flex: 1; }
+    .tp-item .label .name { color: #161616; }
+    .tp-item .label .meta { font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; margin-top: 2px; }
+    .tp-item .sample-chip {
+      background: #f4f4f4; color: #525252; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px;
+    }
+    .tp-item .kind-chip {
+      background: #d0e2ff; color: #0043ce; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .tp-item .kind-chip.panel { background: #e8daff; color: #491d8b; }
+    .tp-empty { padding: 12px; color: #6f6f6f; font-size: 12px; text-align: center; font-style: italic; }
+
+    /* Prominent + Add CTA — used for adding conditions and actions */
+    .add-cta {
+      display: flex; align-items: center; justify-content: center; gap: 6px;
+      width: 100%; padding: 10px;
+      background: #fff; border: 1.5px dashed #0f62fe;
+      color: #0f62fe; font-size: 13px; font-weight: 600;
+      cursor: pointer; margin-top: 8px;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .add-cta:hover { background: #edf5ff; border-color: #0043ce; }
+    .add-cta .plus {
+      width: 20px; height: 20px; border-radius: 999px;
+      background: #0f62fe; color: #fff;
+      display: inline-flex; align-items: center; justify-content: center;
+      font-size: 14px; font-weight: 700;
+    }
+    .add-cta:hover .plus { background: #0043ce; }
+    .add-cta .hint {
+      font-weight: 400; font-size: 11px; color: #6f6f6f; margin-left: 8px;
+    }
+
+    /* Compose mode — row-list builder */
+    .compose-block {
+      background: #fafafa; border: 1px solid #e0e0e0; padding: 0.75rem;
+    }
+    .compose-row {
+      display: grid; grid-template-columns: 56px 140px 1fr 28px;
+      gap: 0.5rem; align-items: center; margin-bottom: 6px;
+    }
+    .compose-row .joiner {
+      background: #fff8e1; color: #b28600; font-size: 11px; font-weight: 700;
+      text-align: center; padding: 4px 6px; border-radius: 4px;
+      letter-spacing: 0.5px;
+    }
+    .compose-row .joiner.first {
+      background: #d0e2ff; color: #0043ce;
+    }
+    .compose-row select {
+      padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #fff; font-size: 13px;
+    }
+    .compose-row .pred-pick {
+      display: flex; gap: 4px; align-items: center;
+    }
+    .compose-row .pred-pick .tok-pred {
+      background: #cfeaff; padding: 4px 10px; border-radius: 4px; font-family: 'IBM Plex Mono', monospace;
+      font-size: 12px;
+    }
+    .compose-row .delete {
+      background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px;
+    }
+    .mode-tabs {
+      display: inline-flex; border: 1px solid #c6c6c6; border-radius: 4px; overflow: hidden;
+      margin-left: 0.5rem;
+    }
+    .mode-tabs button {
+      background: #fff; border: none; padding: 4px 12px; font-size: 12px; cursor: pointer;
+    }
+    .mode-tabs button.active { background: #0f62fe; color: #fff; }
+
+    /* Predicate index panel */
+    .pred-index {
+      background: #f4f4f4; padding: 0.75rem; border: 1px solid #e0e0e0;
+    }
+    .pred-test {
+      background: #fff; padding: 0.5rem 0.75rem; margin-bottom: 6px; border: 1px solid #e0e0e0;
+    }
+    .pred-test .head {
+      font-family: 'IBM Plex Mono', monospace; font-weight: 600;
+      color: #0043ce; font-size: 13px; margin-bottom: 4px;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .pred-test .meta {
+      font-size: 10px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+    }
+    .pred-list {
+      display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px;
+    }
+    .pred-pill {
+      background: #cfeaff; color: #0072c3; padding: 2px 8px; border-radius: 4px;
+      font-size: 11px; font-weight: 600; cursor: pointer; font-family: 'IBM Plex Mono', monospace;
+      display: inline-flex; align-items: center; gap: 3px;
+    }
+    .pred-pill:hover { background: #0072c3; color: #fff; }
+    .pred-pill .why {
+      font-size: 9px; opacity: 0.7; font-family: 'IBM Plex Sans', sans-serif;
+      font-weight: 400;
+    }
+
+    .rule-summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+    .rule-when-then {
+      display: flex; align-items: center; gap: 0.5rem; margin-top: 4px;
+      flex-wrap: wrap;
+    }
+    .rule-when-then .when, .rule-when-then .then {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+    .rule-when-then .label {
+      font-size: 10px; padding: 2px 6px; border-radius: 999px; font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    .rule-when-then .label.w { background: #fff8e1; color: #b28600; }
+    .rule-when-then .label.t { background: #defbe6; color: #0e6027; }
+    .rule-when-then .arrow { color: #525252; }
+
+    /* Expanded editor */
+    .expanded-tile {
+      padding: 1.25rem; background: #f4f4f4; border-top: 2px solid #0f62fe;
+    }
+    .editor-grid {
+      display: grid; grid-template-columns: 1.1fr 1fr; gap: 1.25rem;
+    }
+    .editor-stack {
+      display: flex; flex-direction: column; gap: 0.75rem;
+    }
+
+    /* Collapsible card — for catalog data and simulator */
+    .collapsible {
+      background: #fff; border: 1px solid #e0e0e0;
+    }
+    .collapsible-head {
+      display: flex; align-items: center; gap: 0.75rem;
+      padding: 0.75rem 1rem; cursor: pointer; user-select: none;
+      background: #fafafa; border-bottom: 1px solid #e0e0e0;
+      width: 100%; border-left: none; border-right: none; border-top: none;
+      font-family: inherit; font-size: inherit; text-align: left;
+    }
+    .collapsible-head:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .collapsible-head.collapsed { border-bottom-color: transparent; }
+    .collapsible-head:hover { background: #f4f4f4; }
+    .collapsible-head .caret { font-size: 11px; color: #525252; }
+    .collapsible-head .col-title { font-size: 14px; font-weight: 600; flex: 0 0 auto; }
+    .collapsible-head .col-summary {
+      font-size: 12px; color: #6f6f6f; flex: 1; min-width: 0;
+      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+    .collapsible-head .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .collapsible-head .pill.gray { background: #f4f4f4; color: #525252; }
+    .collapsible-head .pill.green { background: #defbe6; color: #0e6027; }
+    .collapsible-body { padding: 1rem; }
+
+    /* === Unified InputPicker — chip-trigger + dropdown panel === */
+    .ip-wrap { position: relative; display: inline-block; max-width: 100%; }
+    .ip-trigger {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 4px 10px; min-height: 30px; max-width: 100%;
+      background: #f4f4f4; border: 1px solid #c6c6c6; border-radius: 4px;
+      font-size: 13px; cursor: pointer; font-family: inherit;
+    }
+    .ip-trigger:hover { background: #e8e8e8; border-color: #8d8d8d; }
+    .ip-trigger:focus, .ip-trigger:focus-visible { outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .ip-trigger.empty { color: #6f6f6f; font-style: italic; }
+    .ip-trigger.error { border-color: #da1e28; background: #fff1f1; }
+    .ip-trigger .caret { color: #525252; font-size: 10px; margin-left: 2px; flex-shrink: 0; }
+    .ip-trigger .ip-label {
+      color: #161616; font-style: normal;
+      white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      max-width: 420px;
+    }
+    .ip-trigger .ip-sub {
+      color: #6f6f6f; font-family: 'IBM Plex Mono', monospace; font-size: 11px;
+      flex-shrink: 0;
+    }
+    .ip-trigger .clear-btn {
+      background: none; border: none; cursor: pointer; color: #6f6f6f;
+      padding: 0 2px 0 4px; font-size: 14px; line-height: 1;
+    }
+    .ip-trigger .clear-btn:hover { color: #a2191f; }
+    .ip-kind {
+      padding: 2px 6px; border-radius: 3px; font-size: 10px; font-weight: 600;
+      text-transform: uppercase; letter-spacing: 0.3px;
+    }
+    .ip-kind.result { background: #d0e2ff; color: #0043ce; }
+    .ip-kind.param  { background: #f6f2ff; color: #6929c4; }
+    .ip-kind.panel  { background: #e8daff; color: #491d8b; }
+    .ip-pop {
+      position: absolute; top: calc(100% + 4px); left: 0;
+      min-width: 380px; max-width: 520px;
+      background: #fff; border: 1px solid #8d8d8d; border-radius: 4px;
+      z-index: 100; box-shadow: 0 4px 16px rgba(0,0,0,0.15);
+      overflow: hidden;
+    }
+    .ip-pop-search {
+      width: 100%; padding: 10px 12px; border: none; border-bottom: 1px solid #e0e0e0;
+      font-size: 13px; box-sizing: border-box; outline: none; background: #fff;
+    }
+    .ip-pop-search:focus { background: #f4f9ff; }
+    .ip-pop-scope {
+      display: flex; gap: 1rem; padding: 6px 10px; background: #f4f4f4;
+      border-bottom: 1px solid #e0e0e0; font-size: 12px;
+    }
+    .ip-pop-scope label { cursor: pointer; display: inline-flex; align-items: center; gap: 4px; }
+    .ip-pop-scope .warn-pill {
+      background: #fff8e1; color: #b28600; font-size: 10px; font-weight: 600;
+      padding: 1px 6px; border-radius: 3px; margin-left: 4px;
+    }
+    .ip-pop-warn {
+      background: #fff8e1; color: #6b4a00; padding: 6px 10px;
+      font-size: 11px; border-bottom: 1px solid #f1c21b;
+    }
+    .ip-pop-list { max-height: 280px; overflow-y: auto; }
+    .ip-section {
+      padding: 6px 10px; background: #fafafa;
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+      color: #525252; font-weight: 600;
+    }
+    .ip-item {
+      display: flex; align-items: center; gap: 10px;
+      width: 100%; padding: 8px 12px; background: none; border: none;
+      border-top: 1px solid #f4f4f4; cursor: pointer; text-align: left;
+      font-family: inherit; font-size: 13px;
+    }
+    .ip-item:hover, .ip-item:focus { background: #edf5ff; outline: none; }
+    .ip-item-body { flex: 1; min-width: 0; }
+    .ip-item-name { color: #161616; line-height: 1.3; }
+    .ip-item-meta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+      margin-top: 2px; line-height: 1.3;
+    }
+    .ip-item .sample-chip {
+      background: #f4f4f4; color: #525252; padding: 1px 6px; border-radius: 3px;
+      font-size: 10px; flex-shrink: 0;
+    }
+    .ip-pop-empty { padding: 16px; color: #6f6f6f; font-size: 12px; font-style: italic; text-align: center; }
+    .ip-pop-more { padding: 8px 12px; font-size: 11px; color: #6f6f6f; font-style: italic; border-top: 1px solid #f4f4f4; }
+
+    /* === Empty state === */
+    .empty-state {
+      padding: 3rem 2rem; text-align: center; background: #fafafa;
+      border: 2px dashed #c6c6c6; border-radius: 4px;
+    }
+    .empty-state .icon {
+      font-size: 32px; color: #8d8d8d; margin-bottom: 0.5rem;
+    }
+    .empty-state .title {
+      font-size: 16px; font-weight: 600; color: #161616; margin-bottom: 4px;
+    }
+    .empty-state .desc {
+      font-size: 13px; color: #525252; margin-bottom: 1rem;
+    }
+
+    /* === Inline validation error === */
+    .field-error {
+      color: #a2191f; font-size: 11px; margin-top: 4px;
+      display: flex; align-items: center; gap: 4px;
+    }
+    .save-error {
+      background: #fff1f1; border-left: 3px solid #da1e28;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px;
+    }
+    .save-error .title { color: #6f0000; font-weight: 600; margin-bottom: 4px; }
+    .save-error ul { margin: 0; padding-left: 1.2rem; color: #a2191f; font-size: 12px; }
+
+    /* === Confirmation modal === */
+    .modal-overlay {
+      position: fixed; inset: 0; background: rgba(22, 22, 22, 0.5); z-index: 200;
+      display: flex; align-items: center; justify-content: center;
+    }
+    .modal-panel {
+      background: #fff; min-width: 480px; max-width: 560px;
+      box-shadow: 0 16px 24px rgba(0,0,0,0.18);
+    }
+    .modal-head { padding: 1rem 1.25rem; border-bottom: 1px solid #e0e0e0; }
+    .modal-title { font-size: 18px; font-weight: 400; }
+    .modal-body { padding: 1rem 1.25rem; font-size: 13px; color: #161616; }
+    .modal-foot {
+      padding: 1rem 1.25rem; border-top: 1px solid #e0e0e0;
+      display: flex; gap: 0.5rem; justify-content: flex-end;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      color: #161616; display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #e8daff; color: #491d8b; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .panel h4 .pill.green { background: #defbe6; color: #0e6027; }
+    .panel h4 .pill.amber { background: #fff8e1; color: #b28600; }
+    .panel h4 .pill.gray { background: #f4f4f4; color: #525252; }
+    .panel-section { margin-top: 1rem; }
+    .panel-section:first-child { margin-top: 0; }
+    .badge-row { display: flex; gap: 6px; margin-bottom: 0.75rem; flex-wrap: wrap; }
+
+    /* WHEN block — formula bar */
+    .formula-bar-wrap {
+      position: relative; background: #fff; border: 1px solid #8d8d8d;
+      font-family: 'IBM Plex Mono', monospace; font-size: 14px;
+      padding: 10px 12px;
+    }
+    .formula-bar-wrap:focus-within { border-color: #0f62fe; outline: 2px solid #0f62fe; outline-offset: -2px; }
+    .formula-overlay {
+      position: absolute; top: 10px; left: 12px; right: 12px;
+      pointer-events: none; white-space: pre-wrap; word-wrap: break-word;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+    }
+    .formula-input {
+      position: relative; width: 100%; min-height: 1.4em; resize: vertical;
+      border: none; outline: none; background: transparent;
+      font-family: inherit; font-size: inherit; line-height: 1.4;
+      color: transparent; caret-color: #161616;
+    }
+    .formula-prompt {
+      font-size: 11px; color: #525252; margin-top: 4px; display: flex; gap: 0.5rem;
+    }
+    .formula-prompt .err { color: #a2191f; }
+    .formula-prompt .ok { color: #0e6027; }
+
+    /* WHEN/THEN labels */
+    .block-label {
+      display: inline-block;
+      font-size: 10px; padding: 3px 10px; border-radius: 999px;
+      font-weight: 700; letter-spacing: 0.5px; margin-bottom: 6px;
+    }
+    .block-label.when { background: #fff8e1; color: #b28600; }
+    .block-label.then { background: #defbe6; color: #0e6027; }
+
+    /* Action list */
+    .action-row {
+      display: grid; grid-template-columns: 140px 1fr 36px;
+      gap: 0.5rem; align-items: center; padding: 6px 0;
+      border-bottom: 1px dashed #e0e0e0;
+    }
+    .action-row select, .action-row input {
+      width: 100%; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .action-row .a-fields { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
+    .action-row .a-fields > * { flex: 1; min-width: 140px; }
+    .action-row .delete-btn {
+      background: none; border: none; color: #a2191f; cursor: pointer; font-size: 16px;
+    }
+    .action-tag {
+      display: inline-block; padding: 2px 8px; border-radius: 4px;
+      font-size: 11px; font-weight: 600;
+    }
+    .action-tag.order { background: #d0e2ff; color: #0043ce; }
+    .action-tag.note { background: #fff1f1; color: #a2191f; }
+    .action-tag.alert { background: #ffd6e8; color: #9f1853; }
+    .action-tag.priority { background: #fff8e1; color: #b28600; }
+    .action-tag.panel { background: #e8daff; color: #491d8b; }
+
+    /* Decision table mode */
+    .decision-table {
+      width: 100%; border-collapse: collapse; font-size: 13px;
+      background: #fff;
+    }
+    .decision-table th, .decision-table td {
+      padding: 8px 12px; border: 1px solid #e0e0e0; text-align: left;
+      vertical-align: top;
+    }
+    .decision-table thead th {
+      background: #f4f4f4; font-size: 11px; text-transform: uppercase;
+      letter-spacing: 0.5px; color: #525252;
+    }
+    .decision-table .col-header-when { background: #fff8e1; color: #b28600; }
+    .decision-table .col-header-then { background: #defbe6; color: #0e6027; }
+    .decision-table tbody tr:hover { background: #fafafa; }
+    .decision-table .dt-cell {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+    .mode-toggle {
+      display: inline-flex; border: 1px solid #c6c6c6; border-radius: 4px; overflow: hidden;
+      margin-left: 0.5rem;
+    }
+    .mode-toggle button {
+      background: #fff; border: none; padding: 4px 10px; font-size: 12px; cursor: pointer;
+    }
+    .mode-toggle button.active { background: #0f62fe; color: #fff; }
+
+    /* Simulator */
+    .sim-row {
+      display: flex; align-items: center; gap: 0.75rem; margin-bottom: 0.5rem;
+    }
+    .sim-row label { flex: 0 0 160px; font-size: 13px; color: #161616; }
+    .sim-row input, .sim-row select {
+      flex: 1; padding: 4px 8px; font-size: 13px;
+      border: none; border-bottom: 1px solid #8d8d8d; background: #f4f4f4;
+    }
+    .sim-result {
+      padding: 0.75rem 1rem; margin-top: 0.75rem;
+      border-left: 3px solid;
+    }
+    .sim-result.fires { background: #defbe6; border-color: #198038; }
+    .sim-result.idle { background: #f4f4f4; border-color: #c6c6c6; }
+    .sim-result .head {
+      font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600;
+    }
+    .sim-result.fires .head { color: #0e6027; }
+    .sim-result.idle .head { color: #525252; }
+    .sim-result .body {
+      font-size: 14px; margin-top: 4px;
+    }
+    .sim-result .action-line {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+      padding: 4px 0;
+    }
+
+    /* Cascade view */
+    .cascade {
+      display: flex; align-items: center; gap: 0.5rem; padding: 0.75rem;
+      background: #fafafa; border: 1px solid #e0e0e0;
+      overflow-x: auto;
+    }
+    .cascade .node {
+      flex: 0 0 auto; padding: 6px 10px; font-size: 12px;
+      border-radius: 4px; font-family: 'IBM Plex Mono', monospace;
+      white-space: nowrap;
+    }
+    .cascade .node.trigger { background: #fff8e1; color: #b28600; border: 1px solid #f1c21b; }
+    .cascade .node.action { background: #defbe6; color: #0e6027; border: 1px solid #24a148; }
+    .cascade .node.chain { background: #d0e2ff; color: #0043ce; border: 1px solid #4589ff; }
+    .cascade .arr { color: #525252; font-size: 14px; }
+
+    /* Conflict notification */
+    .conflict {
+      background: #fff1f1; border-left: 3px solid #da1e28;
+      padding: 0.5rem 0.75rem; font-size: 12px; color: #6f0000;
+      margin-top: 0.5rem;
+    }
+
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 1rem;
+    }
+    .compact-hint { font-size: 11px; color: #6f6f6f; margin-top: 4px; font-style: italic; }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Reflex Test Rules &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div style="background: #f4f4f4; border-bottom: 1px solid #c6c6c6; padding: 8px 2rem; font-size: 13px; color: #525252;">
+    <a href="test-rules-list-view-preview.html" style="color: #0f62fe; text-decoration: none; font-weight: 600;">← Test Rules list view</a>
+    &nbsp;/&nbsp;
+    <strong>Reflex rule editor</strong>
+    &nbsp;<span style="color: #6f6f6f;">— this is what expands inline when you click a Reflex rule row in the list view, shown at full width.</span>
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">
+    Loading…
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    window.addEventListener('error', function (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Error:</strong> ' + (e.message || 'unknown') +
+          (e.filename ? ' &nbsp;<em>' + e.filename.split('/').pop() + ':' + e.lineno + '</em>' : '');
+      }
+    });
+    window.addEventListener('load', function () {
+      var missing = [];
+      if (typeof React === 'undefined')    missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined')    missing.push('Babel');
+      var s = document.getElementById('boot-status');
+      if (missing.length && s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Missing dependencies:</strong> ' + missing.join(', ') +
+          '. Network may be blocking cdnjs.cloudflare.com / unpkg.com.';
+      }
+    });
+  </script>
+
+  <script type="text/babel">
+    const { useState, useMemo } = React;
+
+    // ========================================================================
+    // DOMAIN DATA
+    // ========================================================================
+    const TESTS = [
+      { id: 'TSH',       name: 'TSH',                        loinc: '3016-3',  type: 'numeric',   units: 'µIU/mL', sample: 'Serum',
+        refRange: [0.4, 4.5],     criticalRange: [0.1, 10],    deltaPct: 50 },
+      { id: 'FT4',       name: 'Free T4',                    loinc: '3024-7',  type: 'numeric',   units: 'ng/dL',  sample: 'Serum',
+        refRange: [0.8, 1.8],     criticalRange: [0.4, 4.0],   deltaPct: 30 },
+      { id: 'HIV_Screen',name: 'HIV-1/2 Ab Screen (Rapid)',  loinc: '49560-6', type: 'coded',     values: ['Reactive','Weak Reactive','Non-Reactive'], sample: 'Whole Blood' },
+      { id: 'HIV1_Conf', name: 'HIV-1 Confirmatory (WB)',    loinc: '7917-8',  type: 'coded',     values: ['Positive','Negative','Indeterminate'], sample: 'Serum' },
+      { id: 'WBC',       name: 'WBC Count',                  loinc: '6690-2',  type: 'numeric',   units: '10⁹/L',  sample: 'EDTA Tube',
+        refRange: [4.0, 11.0],    criticalRange: [2.0, 30.0],  deltaPct: 25 },
+      { id: 'HGB',       name: 'Hemoglobin',                 loinc: '718-7',   type: 'numeric',   units: 'g/dL',   sample: 'EDTA Tube',
+        refRange: [12.0, 17.5],   criticalRange: [7.0, 20.0],  deltaPct: 20 },
+      { id: 'PLT',       name: 'Platelets',                  loinc: '777-3',   type: 'numeric',   units: '10⁹/L',  sample: 'EDTA Tube',
+        refRange: [150, 400],     criticalRange: [50, 1000],   deltaPct: 30 },
+      { id: 'GLU',       name: 'Glucose',                    loinc: '2345-7',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum',
+        refRange: [70, 110],      criticalRange: [40, 500],    deltaPct: 30 },
+      { id: 'CR',        name: 'Creatinine',                 loinc: '2160-0',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum',
+        refRange: [0.7, 1.3],     criticalRange: [0.3, 10.0],  deltaPct: 30 },
+      { id: 'Nitrites',  name: 'Urine Nitrites',             loinc: '5802-4',  type: 'coded',     values: ['Negative','Positive'], sample: 'Urines' },
+      { id: 'Leuk',      name: 'Urine Leukocytes',           loinc: '5799-2',  type: 'coded',     values: ['Negative','Trace','+','++','+++'], sample: 'Urines' },
+      { id: 'UC',        name: 'Urine Culture',              loinc: '630-4',   type: 'reflex',    sample: 'Urines' },
+      { id: 'StrepA',    name: 'Strep A RADT',               loinc: '17656-0', type: 'coded',     values: ['Positive','Negative'], sample: 'Respiratory Swab' },
+      { id: 'ThroatCx',  name: 'Throat Culture',             loinc: '587-3',   type: 'reflex',    sample: 'Respiratory Swab' },
+      { id: 'Diff',      name: 'Manual WBC Differential',    loinc: '764-1',   type: 'reflex',    sample: 'EDTA Tube' },
+      { id: 'Retic',     name: 'Reticulocyte Count',         loinc: '4679-7',  type: 'numeric',   units: '%',      sample: 'EDTA Tube' },
+      { id: 'IronPanel', name: 'Iron Panel',                 loinc: 'panel',   type: 'reflex',    sample: 'Serum' },
+      { id: 'Lactate',   name: 'Lactate',                    loinc: '32693-4', type: 'numeric',   units: 'mmol/L', sample: 'Serum',
+        refRange: [0.5, 2.0],     criticalRange: [0.2, 4.0],   deltaPct: 30 },
+      { id: 'TPOAb',     name: 'Thyroid Peroxidase Ab',       loinc: '8099-1',  type: 'numeric',   units: 'IU/mL',  sample: 'Serum', refRange: [0, 34] },
+      { id: 'TgAb',      name: 'Thyroglobulin Ab',            loinc: '8095-9',  type: 'numeric',   units: 'IU/mL',  sample: 'Serum', refRange: [0, 115] },
+      // Additional tests to make the picker search meaningful
+      { id: 'T3',        name: 'Total T3',                    loinc: '3053-6',  type: 'numeric',   units: 'ng/dL',  sample: 'Serum', refRange: [80, 200] },
+      { id: 'T4',        name: 'Total T4',                    loinc: '3026-2',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [4.5, 12.0] },
+      { id: 'BUN',       name: 'Blood Urea Nitrogen',         loinc: '3094-0',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [7, 25] },
+      { id: 'eGFR',      name: 'eGFR',                        loinc: '62238-1', type: 'numeric',   units: 'mL/min', sample: 'Serum', refRange: [60, 120] },
+      { id: 'CO2',       name: 'CO₂ / Bicarbonate (CMP)',     loinc: '2028-9',  type: 'numeric',   units: 'mmol/L', sample: 'Serum', refRange: [22, 30] },
+      { id: 'Phos',      name: 'Phosphorus',                  loinc: '2777-1',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [2.5, 4.5] },
+      { id: 'Mg',        name: 'Magnesium',                   loinc: '2601-3',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [1.7, 2.2] },
+      { id: 'TP',        name: 'Total Protein',               loinc: '2885-2',  type: 'numeric',   units: 'g/dL',   sample: 'Serum', refRange: [6.0, 8.3] },
+      { id: 'ALP',       name: 'Alkaline Phosphatase',        loinc: '6768-6',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [44, 147] },
+      { id: 'GGT',       name: 'GGT',                         loinc: '2324-2',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [9, 48] },
+      { id: 'BiliD',     name: 'Bilirubin, Direct',           loinc: '1968-7',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [0, 0.3] },
+      { id: 'BiliT',     name: 'Bilirubin, Total',            loinc: '1975-2',  type: 'numeric',   units: 'mg/dL',  sample: 'Serum', refRange: [0.1, 1.2] },
+      { id: 'Amylase',   name: 'Amylase',                     loinc: '1798-8',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [25, 125] },
+      { id: 'Lipase',    name: 'Lipase',                      loinc: '3040-3',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [0, 160] },
+      { id: 'CK',        name: 'Creatine Kinase',             loinc: '2157-6',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [22, 198] },
+      { id: 'LDH',       name: 'LDH',                         loinc: '2532-0',  type: 'numeric',   units: 'U/L',    sample: 'Serum', refRange: [125, 220] },
+      { id: 'Trop',      name: 'Troponin I (High-sens)',      loinc: '67151-1', type: 'numeric',   units: 'ng/L',   sample: 'Serum', refRange: [0, 14], criticalRange: [0, 100] },
+      { id: 'BNP',       name: 'BNP',                         loinc: '30934-4', type: 'numeric',   units: 'pg/mL',  sample: 'Serum', refRange: [0, 100] },
+      { id: 'HbA1c',     name: 'Hemoglobin A1c',              loinc: '4548-4',  type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [4.0, 5.6] },
+      { id: 'Fe',        name: 'Iron, Serum',                 loinc: '2498-4',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [60, 170] },
+      { id: 'TIBC',      name: 'Total Iron-Binding Capacity', loinc: '2500-7',  type: 'numeric',   units: 'µg/dL',  sample: 'Serum', refRange: [240, 450] },
+      { id: 'Ferritin',  name: 'Ferritin',                    loinc: '2276-4',  type: 'numeric',   units: 'ng/mL',  sample: 'Serum', refRange: [12, 300] },
+      { id: 'PT',        name: 'Prothrombin Time',            loinc: '5902-2',  type: 'numeric',   units: 'sec',    sample: 'Plasma', refRange: [10, 13] },
+      { id: 'PTT',       name: 'Partial Thromboplastin Time', loinc: '14979-9', type: 'numeric',   units: 'sec',    sample: 'Plasma', refRange: [25, 35] },
+      { id: 'DDimer',    name: 'D-Dimer',                     loinc: '48065-7', type: 'numeric',   units: 'µg/mL',  sample: 'Plasma', refRange: [0, 0.5] },
+      { id: 'Procalc',   name: 'Procalcitonin',               loinc: '33959-8', type: 'numeric',   units: 'ng/mL',  sample: 'Serum', refRange: [0, 0.1] },
+      { id: 'BloodCx',   name: 'Blood Culture',               loinc: '600-7',   type: 'reflex',    sample: 'Whole Blood' },
+      { id: 'RBC',       name: 'Red Blood Cell Count',        loinc: '789-8',   type: 'numeric',   units: '10¹²/L', sample: 'EDTA Tube', refRange: [4.2, 5.9] },
+      { id: 'HCT',       name: 'Hematocrit',                  loinc: '4544-3',  type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [36, 50] },
+      { id: 'MCV',       name: 'MCV',                         loinc: '787-2',   type: 'numeric',   units: 'fL',     sample: 'EDTA Tube', refRange: [80, 100] },
+      { id: 'RDW',       name: 'RDW',                         loinc: '788-0',   type: 'numeric',   units: '%',      sample: 'EDTA Tube', refRange: [11.5, 14.5] },
+    ];
+
+    // Panels — composed of multiple tests, run on one sample
+    const PANELS = [
+      { id: 'PANEL_BMP',    name: 'Basic Metabolic Panel (BMP)',       sample: 'Serum',     tests: ['NA','K','CL','CO2','BUN','CR','GLU','CA'] },
+      { id: 'PANEL_CMP',    name: 'Comprehensive Metabolic Panel (CMP)',sample: 'Serum',    tests: ['NA','K','CL','CO2','BUN','CR','GLU','CA','ALB','TP','AST','ALT','ALP','BiliT'] },
+      { id: 'PANEL_LIPID',  name: 'Lipid Panel',                       sample: 'Serum',     tests: ['TC','HDL','TRIG','LDL'] },
+      { id: 'PANEL_HEPATIC',name: 'Hepatic Function Panel (LFTs)',     sample: 'Serum',     tests: ['AST','ALT','ALP','GGT','BiliT','BiliD','ALB','TP'] },
+      { id: 'PANEL_THYROID',name: 'Thyroid Panel',                     sample: 'Serum',     tests: ['TSH','FT4','T3','T4'] },
+      { id: 'PANEL_THYRAB', name: 'Thyroid Antibody Panel',            sample: 'Serum',     tests: ['TPOAb','TgAb'] },
+      { id: 'PANEL_IRON',   name: 'Iron Studies',                      sample: 'Serum',     tests: ['Fe','TIBC','Ferritin'] },
+      { id: 'PANEL_CARDIAC',name: 'Cardiac Panel',                     sample: 'Serum',     tests: ['Trop','CK','BNP','LDH'] },
+      { id: 'PANEL_SEPSIS', name: 'Sepsis Panel',                      sample: 'Serum',     tests: ['Lactate','Procalc'] },
+      { id: 'PANEL_COAG',   name: 'Coagulation Panel',                 sample: 'Plasma',    tests: ['PT','PTT','INR','DDimer'] },
+      { id: 'PANEL_ANEMIA', name: 'Anemia Workup',                     sample: 'EDTA Tube', tests: ['HGB','RBC','MCV','RDW','Retic'] },
+      { id: 'PANEL_CBC',    name: 'CBC with Differential',             sample: 'EDTA Tube', tests: ['WBC','RBC','HGB','HCT','PLT','MCV','RDW','Diff'] },
+    ];
+    const PANEL_BY_ID = Object.fromEntries(PANELS.map(p => [p.id, p]));
+    const ATTRS = [
+      { id: 'Age',    name: 'Age',    units: 'years' },
+      { id: 'Sex',    name: 'Sex',    units: '(M/F)' },
+      { id: 'Sample', name: 'Sample', units: '(type)' },
+    ];
+    const KEYWORDS = ['AND', 'OR', 'NOT', 'IN'];
+
+    // Semantic predicates — compile to numeric expressions at save time
+    // using the test catalog's reference/critical ranges. Available per-test
+    // based on what metadata the test has.
+    const PREDICATES = [
+      // Catalog-based (no value input)
+      { id: 'isNormal',             group: 'catalog',  requires: 'refRange',      label: 'is within the normal range',         short: 'is normal',                 desugar: (id, t)    => `${id} >= ${t.refRange[0]} AND ${id} <= ${t.refRange[1]}` },
+      { id: 'isOutsideNormal',      group: 'catalog',  requires: 'refRange',      label: 'is outside the normal range',        short: 'is outside normal',         desugar: (id, t)    => `${id} < ${t.refRange[0]} OR ${id} > ${t.refRange[1]}` },
+      { id: 'isAboveNormal',        group: 'catalog',  requires: 'refRange',      label: 'is above the normal range',          short: 'is above normal',           desugar: (id, t)    => `${id} > ${t.refRange[1]}` },
+      { id: 'isBelowNormal',        group: 'catalog',  requires: 'refRange',      label: 'is below the normal range',          short: 'is below normal',           desugar: (id, t)    => `${id} < ${t.refRange[0]}` },
+      { id: 'isCritical',           group: 'catalog',  requires: 'criticalRange', label: 'is at a critical value (either direction)', short: 'is critical',        desugar: (id, t)    => `${id} <= ${t.criticalRange[0]} OR ${id} >= ${t.criticalRange[1]}` },
+      { id: 'isCriticallyHigh',     group: 'catalog',  requires: 'criticalRange', label: 'is critically high',                 short: 'is critically high',        desugar: (id, t)    => `${id} >= ${t.criticalRange[1]}` },
+      { id: 'isCriticallyLow',      group: 'catalog',  requires: 'criticalRange', label: 'is critically low',                  short: 'is critically low',         desugar: (id, t)    => `${id} <= ${t.criticalRange[0]}` },
+      { id: 'isFlagged',            group: 'catalog',  requires: 'refRange',      label: 'has an abnormal flag',               short: 'is flagged',                desugar: (id, t)    => `flag(${id}) != "N"` },
+      { id: 'changedSignificantly', group: 'catalog',  requires: 'deltaPct',      label: 'has changed significantly from the prior result', short: 'changed significantly', desugar: (id, t) => `abs(${id} - prior(${id})) / prior(${id}) * 100 >= ${t.deltaPct}` },
+
+      // Specific-value comparison (numeric tests; takes a number input)
+      { id: 'gt',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is greater than (>)',    short: 'is greater than',     desugar: (id, t, v) => `${id} > ${v}` },
+      { id: 'gte',         group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at least (≥)',         short: 'is at least',         desugar: (id, t, v) => `${id} >= ${v}` },
+      { id: 'lt',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is less than (<)',        short: 'is less than',        desugar: (id, t, v) => `${id} < ${v}` },
+      { id: 'lte',         group: 'value', requires: 'numeric', valueInput: 'number', label: 'is at most (≤)',          short: 'is at most',          desugar: (id, t, v) => `${id} <= ${v}` },
+      { id: 'eq',          group: 'value', requires: 'numeric', valueInput: 'number', label: 'is exactly (=)',          short: 'equals',              desugar: (id, t, v) => `${id} == ${v}` },
+      { id: 'between',     group: 'value', requires: 'numeric', valueInput: 'range',  label: 'is between (inclusive)',  short: 'is between',          desugar: (id, t, v) => v ? `${id} >= ${v[0]} AND ${id} <= ${v[1]}` : `${id} between ?` },
+
+      // Coded values — just "is" and "is not", each takes one or more values
+      { id: 'is',    group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is…',     short: 'is',
+        desugar: (id, t, vs) => {
+          const list = Array.isArray(vs) ? vs : [];
+          if (list.length === 0) return `${id} is ?`;
+          if (list.length === 1) return `${id} == "${list[0]}"`;
+          return `${id} IN (${list.map(v => '"' + v + '"').join(', ')})`;
+        } },
+      { id: 'isNot', group: 'coded', requires: 'values', valueInput: 'codedMulti', label: 'is not…', short: 'is not',
+        desugar: (id, t, vs) => {
+          const list = Array.isArray(vs) ? vs : [];
+          if (list.length === 0) return `${id} is not ?`;
+          if (list.length === 1) return `${id} != "${list[0]}"`;
+          return `${id} NOT IN (${list.map(v => '"' + v + '"').join(', ')})`;
+        } },
+    ];
+
+    // Build natural-language phrase including any value input
+    function predicatePhrase(testIdOrInput, predId, value, mode = 'full') {
+      // Accept either a string testId (legacy) or an input object { testId, paramId? }
+      let testId, paramId, meta;
+      if (typeof testIdOrInput === 'string') {
+        testId = testIdOrInput; paramId = null; meta = TEST_BY_ID[testId];
+      } else if (testIdOrInput) {
+        testId = testIdOrInput.testId; paramId = testIdOrInput.paramId;
+        const t = TEST_BY_ID[testId];
+        meta = paramId ? (t?.analyzerParameters || []).find(p => p.id === paramId) : t;
+      }
+      const p = PREDICATES.find(p => p.id === predId);
+      if (!meta || !p) return '';
+      const labelText = (mode === 'short' ? p.short : p.label).replace(/…$/, '').replace(/\s*\(.*?\)\s*$/, '').trim();
+      const displayName = paramId ? `${testId} ${meta.name}` : (TEST_BY_ID[testId]?.name || testId);
+      const base = `${displayName} ${labelText}`;
+      if (!p.valueInput)               return base;
+      if (p.valueInput === 'range')    return value && value[0] != null && value[1] != null ? `${base} ${value[0]} and ${value[1]}` : `${base} …`;
+      if (p.valueInput === 'codedMulti') {
+        const list = Array.isArray(value) ? value : [];
+        if (list.length === 0) return `${base} …`;
+        if (list.length === 1) return `${base} ${list[0]}`;
+        if (list.length === 2) return `${base} ${list[0]} or ${list[1]}`;
+        return `${base} ${list.slice(0, -1).join(', ')}, or ${list[list.length-1]}`;
+      }
+      const unit = meta.units ? ' ' + meta.units : '';
+      return value != null && value !== '' ? `${base} ${value}${unit}` : `${base} …`;
+    }
+    const PRED_IDS = PREDICATES.map(p => p.id);
+
+    function predicatesFor(test) {
+      return PREDICATES.filter(p => predicateAvailable(p, test));
+    }
+
+    function predicateAvailable(p, test) {
+      if (!test) return false;
+      if (p.requires === 'refRange')      return Array.isArray(test.refRange);
+      if (p.requires === 'criticalRange') return Array.isArray(test.criticalRange);
+      if (p.requires === 'deltaPct')      return typeof test.deltaPct === 'number';
+      if (p.requires === 'values')        return Array.isArray(test.values);
+      if (p.requires === 'numeric')       return test.type === 'numeric';
+      return false;
+    }
+
+    const REQUIREMENT_REASONS = {
+      refRange:      'a reference range in the catalog',
+      criticalRange: 'critical thresholds in the catalog',
+      deltaPct:      'a delta threshold in the catalog',
+      values:        'coded values in the catalog',
+      numeric:       'a numeric test type',
+    };
+
+    const PREDICATE_GROUPS = [
+      { id: 'catalog', label: 'Catalog-based (uses test\'s reference / critical ranges)' },
+      { id: 'value',   label: 'Specific value (enter your own threshold)' },
+      { id: 'coded',   label: 'Coded value (pick from test\'s possible values)' },
+    ];
+
+    const TEST_BY_ID = Object.fromEntries(TESTS.map(t => [t.id, t]));
+    const ATTR_BY_ID = Object.fromEntries(ATTRS.map(a => [a.id, a]));
+
+    // ========================================================================
+    // TOKENIZER for boolean condition expressions
+    // ========================================================================
+    function tokenize(text) {
+      const re = /("[^"]*"|'[^']*')|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=)|([(),])|(\s+)|(.)/g;
+      const out = [];
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({ kind: 'str', text: m[1] });
+        else if (m[2]) out.push({ kind: 'num', text: m[2] });
+        else if (m[3]) {
+          const id = m[3];
+          if (KEYWORDS.includes(id.toUpperCase())) out.push({ kind: 'bool', text: id });
+          else if (PRED_IDS.includes(id))     out.push({ kind: 'pred', text: id });
+          else if (TEST_BY_ID[id])  out.push({ kind: 'var', text: id });
+          else if (ATTR_BY_ID[id]) out.push({ kind: 'attr', text: id });
+          else out.push({ kind: 'unknown', text: id });
+        }
+        else if (m[4]) out.push({ kind: 'op', text: m[4] });
+        else if (m[5]) out.push({ kind: 'paren', text: m[5] });
+        else if (m[6]) out.push({ kind: 'ws', text: m[6] });
+        else out.push({ kind: 'other', text: m[7] });
+      }
+      return out;
+    }
+    function lint(tokens) {
+      const issues = [];
+      const unknowns = tokens.filter(t => t.kind === 'unknown');
+      if (unknowns.length) {
+        issues.push({ kind: 'err', msg: `Unknown identifier${unknowns.length > 1 ? 's' : ''}: ${unknowns.map(u => u.text).join(', ')}` });
+      }
+      let depth = 0;
+      for (const t of tokens) {
+        if (t.kind === 'paren' && t.text === '(') depth++;
+        else if (t.kind === 'paren' && t.text === ')') depth--;
+        if (depth < 0) { issues.push({ kind: 'err', msg: 'Unmatched closing paren' }); break; }
+      }
+      if (depth > 0) issues.push({ kind: 'err', msg: `${depth} unclosed paren${depth > 1 ? 's' : ''}` });
+      // Single =  warning
+      if (tokens.some(t => t.kind === 'op' && t.text === '=')) {
+        issues.push({ kind: 'warn', msg: 'Use == for equality (single = is assignment)' });
+      }
+      return issues;
+    }
+
+    // ========================================================================
+    // TEST CATALOG REFERENCE — compact metadata card per test in the rule
+    // (No predicate chips — predicates live in the Compose picker with
+    // disabled+reason for unsupported ones.)
+    // ========================================================================
+    function TestCatalogRef({ testIds }) {
+      return (
+        <div className="pred-index">
+          {testIds.map(tid => {
+            const t = TEST_BY_ID[tid];
+            if (!t) return null;
+            return (
+              <div key={tid} className="pred-test">
+                <div className="head">
+                  <span><strong>{t.name}</strong> <span style={{ fontWeight: 400, color: '#6f6f6f', fontSize: 11 }}>({tid})</span></span>
+                  <span style={{ fontSize: 10, color: '#6f6f6f' }}>{t.values ? 'coded result' : (t.units ? t.units : t.type)}</span>
+                </div>
+                <div className="meta" style={{ lineHeight: 1.6 }}>
+                  {t.refRange      ? <div>Reference range: <strong>{t.refRange[0]}–{t.refRange[1]} {t.units}</strong></div>      : <div style={{ color: '#a8a8a8' }}>No reference range set</div>}
+                  {t.criticalRange ? <div>Critical thresholds: <strong>≤{t.criticalRange[0]} or ≥{t.criticalRange[1]}</strong></div> : <div style={{ color: '#a8a8a8' }}>No critical thresholds set</div>}
+                  {t.deltaPct      ? <div>Delta threshold: <strong>{t.deltaPct}%</strong></div> : <div style={{ color: '#a8a8a8' }}>No delta threshold set</div>}
+                  {t.values        && <div>Coded values: <strong>{t.values.join(', ')}</strong></div>}
+                </div>
+                <div style={{ marginTop: 6, fontSize: 11, color: '#0f62fe' }}>
+                  → <a href="#" style={{ color: '#0f62fe' }}>Edit in Test Catalog</a>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // CONDITION FORMULA BAR
+    // ========================================================================
+    function ConditionBar({ value, onChange }) {
+      const tokens = tokenize(value);
+      const issues = lint(tokens);
+      const varCount = tokens.filter(t => t.kind === 'var').length;
+      const attrCount = tokens.filter(t => t.kind === 'attr').length;
+      return (
+        <div>
+          <div className="formula-bar-wrap">
+            <div className="formula-overlay">
+              {tokens.map((t, i) => (
+                <span key={i} className={t.kind === 'ws' ? '' : `tok-${t.kind}`}>{t.text}</span>
+              ))}
+              {value === '' && <span style={{ color: '#a8a8a8' }}>Type a condition… e.g. TSH &gt; 4.5 OR TSH &lt; 0.4</span>}
+            </div>
+            <textarea
+              className="formula-input"
+              value={value}
+              onChange={e => onChange(e.target.value)}
+              spellCheck={false}
+              rows={Math.max(1, value.split('\n').length)}
+            />
+          </div>
+          <div className="formula-prompt">
+            {issues.filter(i => i.kind === 'err').length === 0 && issues.filter(i => i.kind === 'warn').length === 0
+              ? <span className="ok">✓ Valid · references {varCount} test{varCount !== 1 ? 's' : ''}{attrCount ? `, ${attrCount} patient attr${attrCount !== 1 ? 's' : ''}` : ''}</span>
+              : issues.map((i, idx) => <span key={idx} className={i.kind === 'err' ? 'err' : 'warn'} style={{ color: i.kind === 'warn' ? '#b28600' : '#a2191f' }}>{i.kind === 'err' ? '⚠' : '!'} {i.msg}</span>)}
+            <span style={{ marginLeft: 'auto', color: '#0f62fe' }}>
+              Insert: test names, AND/OR/NOT, "coded values"
+            </span>
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // ACTION LIST
+    // ========================================================================
+    const ACTION_TYPES = [
+      { id: 'order',    label: 'Order Test or Panel', tag: 'order' },
+      { id: 'note_int', label: 'Internal Note',       tag: 'note' },
+      { id: 'note_ext', label: 'External Note',       tag: 'note' },
+      { id: 'alert',    label: 'Send Alert',          tag: 'alert' },
+      // 'Set Priority' removed — was redundant with Order Test's priority field. Phase 2 may add "escalate trigger priority" if a clear use case surfaces.
+    ];
+
+    // ========================================================================
+    // SEARCHABLE TEST + PANEL PICKER
+    // ========================================================================
+    function TestOrPanelPicker({ value, onChange, triggerSample }) {
+      // value: { kind: 'test'|'panel', id }
+      const [q, setQ] = useState('');
+      const [open, setOpen] = useState(false);
+      const [scope, setScope] = useState('same'); // 'same' or 'any'
+
+      const selected = value
+        ? (value.kind === 'panel'
+            ? PANELS.find(p => p.id === value.id)
+            : TEST_BY_ID[value.id])
+        : null;
+
+      const sampleFilter = (scope === 'same' && triggerSample) ? triggerSample : null;
+      const ql = q.toLowerCase();
+      const tests = TESTS.filter(t => {
+        if (sampleFilter && t.sample !== sampleFilter) return false;
+        if (t.type === 'reflex') return q ? (t.name + t.id).toLowerCase().includes(ql) : true; // include orderable reflex tests too
+        return q === '' || (t.name + ' ' + t.id + ' ' + (t.loinc || '')).toLowerCase().includes(ql);
+      });
+      const panels = PANELS.filter(p => {
+        if (sampleFilter && p.sample !== sampleFilter) return false;
+        return q === '' || (p.name + ' ' + p.tests.join(' ')).toLowerCase().includes(ql);
+      });
+      const totalMatches = tests.length + panels.length;
+
+      const pick = (kind, id) => {
+        onChange({ kind, id });
+        setQ('');
+        setOpen(false);
+      };
+
+      return (
+        <div className="tp-picker">
+          <div className="tp-input-wrap" onClick={() => setOpen(true)}>
+            {selected ? (
+              <span className="tp-selected">
+                <span className="kind">{value.kind === 'panel' ? 'panel' : 'test'}</span>
+                {selected.name} <span style={{ opacity: 0.6, fontWeight: 400 }}>({selected.id})</span>
+                <span className="clear" onClick={(e) => { e.stopPropagation(); onChange(null); setOpen(true); }}>✕</span>
+              </span>
+            ) : null}
+            <input className="tp-input"
+                   placeholder={selected ? 'Change…' : `Search tests and panels (${TESTS.length + PANELS.length} available)…`}
+                   value={q}
+                   onChange={e => { setQ(e.target.value); setOpen(true); }}
+                   onFocus={() => setOpen(true)}
+                   onBlur={() => setTimeout(() => setOpen(false), 200)} />
+          </div>
+          {open && (
+            <div className="tp-pop">
+              <div className="tp-scope">
+                <label>
+                  <input type="radio" checked={scope === 'same'} onChange={() => setScope('same')} />
+                  Same sample type{triggerSample ? ` (${triggerSample})` : ''} only
+                </label>
+                <label>
+                  <input type="radio" checked={scope === 'any'} onChange={() => setScope('any')} />
+                  All sample types
+                  <span className="warn-pill">requires new collection</span>
+                </label>
+              </div>
+              {scope === 'any' && (
+                <div className="tp-warn">
+                  ⚠ Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. The lab will need to collect a new specimen.
+                </div>
+              )}
+              {totalMatches === 0 && (
+                <div className="tp-empty">
+                  No matches. {scope === 'same' && triggerSample
+                    ? `Try "All sample types" — only ${triggerSample} tests/panels shown.`
+                    : 'Try a different search term.'}
+                </div>
+              )}
+              {tests.length > 0 && (
+                <>
+                  <div className="tp-section">Tests · {tests.length} matching</div>
+                  {tests.slice(0, 12).map(t => (
+                    <div key={t.id} className="tp-item" onMouseDown={() => pick('test', t.id)}>
+                      <span className="kind-chip">Test</span>
+                      <span className="label">
+                        <div className="name">{t.name}</div>
+                        <div className="meta">{t.id} · {t.loinc ? `LOINC ${t.loinc}` : t.type} {t.units ? '· ' + t.units : ''}</div>
+                      </span>
+                      <span className="sample-chip">{t.sample}</span>
+                    </div>
+                  ))}
+                  {tests.length > 12 && (
+                    <div className="tp-empty" style={{ padding: '6px', fontSize: 11 }}>
+                      …and {tests.length - 12} more. Refine your search.
+                    </div>
+                  )}
+                </>
+              )}
+              {panels.length > 0 && (
+                <>
+                  <div className="tp-section">Panels · {panels.length} matching</div>
+                  {panels.slice(0, 8).map(p => (
+                    <div key={p.id} className="tp-item" onMouseDown={() => pick('panel', p.id)}>
+                      <span className="kind-chip panel">Panel</span>
+                      <span className="label">
+                        <div className="name">{p.name}</div>
+                        <div className="meta">{p.tests.length} tests: {p.tests.join(', ')}</div>
+                      </span>
+                      <span className="sample-chip">{p.sample}</span>
+                    </div>
+                  ))}
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    function ActionRow({ action, onChange, onDelete, triggerSample }) {
+      const type = ACTION_TYPES.find(a => a.id === action.type) || ACTION_TYPES[0];
+      return (
+        <div className="action-row">
+          <select value={action.type} onChange={e => onChange({ ...action, type: e.target.value })}>
+            {ACTION_TYPES.map(a => <option key={a.id} value={a.id}>{a.label}</option>)}
+          </select>
+          <div className="a-fields">
+            {action.type === 'order' && (
+              <>
+                <UnifiedInputPicker
+                  mode="target"
+                  value={action.target}
+                  onChange={v => onChange({ ...action, target: v })}
+                  triggerSample={triggerSample} />
+                <select value={action.priority || 'routine'} onChange={e => onChange({ ...action, priority: e.target.value })}
+                        style={{ flex: '0 0 110px' }}>
+                  <option value="routine">Routine</option>
+                  <option value="stat">STAT</option>
+                  <option value="urgent">Urgent</option>
+                </select>
+                <input type="text" placeholder="Reason (visible on order)" value={action.reason || ''}
+                       onChange={e => onChange({ ...action, reason: e.target.value })}
+                       style={{ flex: '1 1 200px' }} />
+              </>
+            )}
+            {(action.type === 'note_int' || action.type === 'note_ext') && (
+              <input type="text" placeholder={action.type === 'note_int' ? 'Internal note (visible to lab staff)' : 'External note (visible to clinician)'}
+                     value={action.note || ''} onChange={e => onChange({ ...action, note: e.target.value })} />
+            )}
+            {action.type === 'alert' && (
+              <>
+                <select>
+                  <option>Critical Value Alert</option>
+                  <option>Reportable Disease (notify MOH)</option>
+                  <option>Provider Notification</option>
+                </select>
+                <input type="text" placeholder="Alert message" />
+              </>
+            )}
+          </div>
+          <button className="delete-btn" onClick={onDelete} title="Remove action">×</button>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // SAMPLE RULE DATA (with structured WHEN/THEN)
+    // ========================================================================
+    const RULES = [
+      {
+        id: 1, name: 'Thyroid panel reflex — TSH abnormal + FT4 < 0.7', status: 'active',
+        when: 'isOutsideNormal(TSH) AND lt(FT4, 0.7)',
+        whenSummary: [
+          { t:'pred', v:'isOutsideNormal' }, { t:'paren', v:'(' }, { t:'var', v:'TSH' }, { t:'paren', v:')' },
+          { t:'bool', v:'AND' },
+          { t:'pred', v:'lt' }, { t:'paren', v:'(' }, { t:'var', v:'FT4' }, { t:'paren', v:',' }, { t:'num', v:'0.7' }, { t:'paren', v:')' }
+        ],
+        actions: [
+          { type: 'order', target: { kind: 'panel', id: 'PANEL_THYRAB' }, priority: 'routine', reason: 'Thyroid antibody workup' },
+          { type: 'note_ext', note: 'Auto reflex per lab policy' },
+        ],
+        thenSummary: 'Order Thyroid Antibody Panel + external note',
+        edited: '2026-04-22 by m.kone',
+      },
+      {
+        id: 2, name: 'HIV Screen Reactive → confirmatory', status: 'active', cascadeGroup: 'HIV',
+        when: 'HIV_Screen == "Reactive"',
+        whenSummary: [
+          { t:'var', v:'HIV_Screen' }, { t:'op', v:'==' }, { t:'str', v:'"Reactive"' }
+        ],
+        actions: [
+          { type: 'order', test: 'HIV1_Conf', priority: 'routine', reason: 'Reactive screen — confirm by Western Blot' },
+          { type: 'note_ext', note: 'Screening result reactive. Confirmatory test ordered automatically per national algorithm.' }
+        ],
+        thenSummary: 'Order HIV-1 Confirmatory + external note',
+        edited: '2026-04-15 by p.diallo',
+      },
+      {
+        id: 3, name: 'HIV Screen Weak Reactive → repeat', status: 'active', cascadeGroup: 'HIV',
+        when: 'HIV_Screen == "Weak Reactive"',
+        whenSummary: [
+          { t:'var', v:'HIV_Screen' }, { t:'op', v:'==' }, { t:'str', v:'"Weak Reactive"' }
+        ],
+        actions: [
+          { type: 'order', test: 'HIV_Screen', priority: 'routine', reason: 'Equivocal — repeat in 2 weeks per national algorithm' },
+        ],
+        thenSummary: 'Repeat HIV Screen',
+        edited: '2026-04-15 by p.diallo',
+      },
+      {
+        id: 4, name: 'WBC critically high → manual differential', status: 'active',
+        when: 'isCriticallyHigh(WBC)',
+        whenSummary: [{ t:'pred', v:'isCriticallyHigh' }, { t:'paren', v:'(' }, { t:'var', v:'WBC' }, { t:'paren', v:')' }],
+        actions: [{ type: 'order', test: 'Diff', priority: 'routine', reason: 'WBC above critical high — manual review' }],
+        thenSummary: 'Order Manual WBC Differential',
+        edited: '2026-03-12 by m.kone',
+      },
+      {
+        id: 5, name: 'Urine dipstick positive → culture', status: 'active',
+        when: '(Nitrites == "Positive" OR Leuk IN ("++","+++"))',
+        whenSummary: [
+          { t:'paren', v:'(' }, { t:'var', v:'Nitrites' }, { t:'op', v:'==' }, { t:'str', v:'"Positive"' },
+          { t:'bool', v:'OR' }, { t:'var', v:'Leuk' }, { t:'bool', v:'IN' }, { t:'str', v:'("++","+++")' }, { t:'paren', v:')' }
+        ],
+        actions: [{ type: 'order', test: 'UC', reason: 'Dipstick suggests UTI — culture & sensitivity' }],
+        thenSummary: 'Order Urine Culture',
+        edited: '2026-02-28 by m.kone',
+      },
+      {
+        id: 6, name: 'Strep A positive → throat culture', status: 'disabled',
+        when: 'StrepA == "Positive" AND Age < 18',
+        whenSummary: [
+          { t:'var', v:'StrepA' }, { t:'op', v:'==' }, { t:'str', v:'"Positive"' },
+          { t:'bool', v:'AND' }, { t:'attr', v:'Age' }, { t:'op', v:'<' }, { t:'num', v:'18' }
+        ],
+        actions: [{ type: 'order', test: 'ThroatCx', reason: 'Pediatric — confirm with culture' }],
+        thenSummary: 'Order Throat Culture',
+        edited: '2025-12-10 by p.diallo',
+      },
+      {
+        id: 7, name: 'Critical glucose → alert + lactate', status: 'active',
+        when: 'isCritical(GLU)',
+        whenSummary: [{ t:'pred', v:'isCritical' }, { t:'paren', v:'(' }, { t:'var', v:'GLU' }, { t:'paren', v:')' }],
+        actions: [
+          { type: 'alert', alert: 'Critical Value Alert' },
+          { type: 'order', test: 'Lactate', priority: 'stat' }
+        ],
+        thenSummary: 'Critical alert + order STAT Lactate',
+        edited: '2026-04-05 by m.kone',
+      },
+      {
+        id: 8, name: 'Severe anemia → workup', status: 'active',
+        when: 'HGB < 7 AND Age > 18',
+        whenSummary: [{ t:'var', v:'HGB' }, { t:'op', v:'<' }, { t:'num', v:'7' }, { t:'bool', v:'AND' }, { t:'attr', v:'Age' }, { t:'op', v:'>' }, { t:'num', v:'18' }],
+        actions: [
+          { type: 'order', test: 'Retic' },
+          { type: 'panel', panel: 'Iron studies (Fe, TIBC, Ferritin, Transferrin)' }
+        ],
+        thenSummary: 'Order Reticulocyte + Iron panel',
+        edited: '2026-04-30 by m.kone',
+      },
+    ];
+
+    // Try to match a predicate call starting at index i.
+    // Returns { predId, testId, value, endIndex } or null.
+    function matchPredCall(tokens, i) {
+      let j = i;
+      if (tokens[j]?.kind !== 'pred') return null;
+      const predId = tokens[j].text; j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      if (!(tokens[j]?.kind === 'paren' && tokens[j].text === '(')) return null;
+      j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      if (tokens[j]?.kind !== 'var') return null;
+      const testId = tokens[j].text; j++;
+      while (tokens[j]?.kind === 'ws') j++;
+      let value = null;
+      if (tokens[j]?.kind === 'paren' && tokens[j].text === ',') {
+        j++;
+        while (tokens[j]?.kind === 'ws') j++;
+        if (tokens[j]?.kind === 'num' || tokens[j]?.kind === 'str') {
+          value = tokens[j].text.replace(/^"|"$/g, '');
+          if (tokens[j].kind === 'num') value = +value;
+          j++;
+          while (tokens[j]?.kind === 'ws') j++;
+        }
+      }
+      if (!(tokens[j]?.kind === 'paren' && tokens[j].text === ')')) return null;
+      return { predId, testId, value, endIndex: j + 1 };
+    }
+
+    function FormulaSummary({ text }) {
+      const tokens = tokenize(text);
+      const out = [];
+      let i = 0;
+      while (i < tokens.length) {
+        const m = matchPredCall(tokens, i);
+        if (m) {
+          const p = PREDICATES.find(p => p.id === m.predId);
+          const t = TEST_BY_ID[m.testId];
+          if (p) {
+            const suffix = p.valueInput
+              ? (m.value != null ? ` ${m.value}${t?.units ? ' ' + t.units : ''}` : ' …')
+              : '';
+            out.push(
+              <span key={i} className="phrase">
+                <strong>{m.testId}</strong> <em>{p.short}{suffix}</em>
+              </span>
+            );
+            i = m.endIndex;
+            continue;
+          }
+        }
+        const tok = tokens[i];
+        out.push(<span key={i} className={tok.kind === 'ws' ? '' : `tok-${tok.kind}`}>{tok.text}</span>);
+        i++;
+      }
+      return <span className="rule-summary">{out}</span>;
+    }
+
+    function RuleSummary({ when, thenSummary }) {
+      return (
+        <div className="rule-when-then">
+          <span className="label w">WHEN</span>
+          <FormulaSummary text={when} />
+          <span className="arrow">→</span>
+          <span className="label t">THEN</span>
+          <span className="then" style={{ color: '#0e6027' }}>{thenSummary}</span>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // SIMULATOR — see if rule fires given sample inputs
+    // ========================================================================
+    function TSHSimulator() {
+      const [tsh, setTsh] = useState(8.4);
+      const [ft4, setFt4] = useState(0.5);
+      const tshRange = TEST_BY_ID.TSH.refRange;
+      const ft4Threshold = 0.7;  // matches the specific-value cutoff in the default rule
+      const tshOutside = tsh < tshRange[0] || tsh > tshRange[1];
+      const ft4Low = ft4 < ft4Threshold;
+      const fires = tshOutside && ft4Low;
+      return (
+        <div>
+          <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+            Enter results for both tests. The rule mixes a catalog-based condition (TSH outside normal) with a specific-value condition (FT4 &lt; {ft4Threshold}).
+          </span>
+          <div className="sim-row">
+            <label>TSH</label>
+            <input type="number" step="0.1" value={tsh} onChange={e => setTsh(+e.target.value || 0)} />
+            <span style={{ flex: '0 0 60px', fontSize: 12, color: '#6f6f6f' }}>µIU/mL</span>
+          </div>
+          <div style={{ fontSize: 11, color: tshOutside ? '#a2191f' : '#0e6027', marginLeft: 160, marginTop: -4, marginBottom: 6 }}>
+            {tshOutside ? `↳ outside normal (catalog range ${tshRange[0]}–${tshRange[1]})` : `↳ normal (catalog range ${tshRange[0]}–${tshRange[1]})`}
+          </div>
+          <div className="sim-row">
+            <label>Free T4 (FT4)</label>
+            <input type="number" step="0.1" value={ft4} onChange={e => setFt4(+e.target.value || 0)} />
+            <span style={{ flex: '0 0 60px', fontSize: 12, color: '#6f6f6f' }}>ng/dL</span>
+          </div>
+          <div style={{ fontSize: 11, color: ft4Low ? '#a2191f' : '#0e6027', marginLeft: 160, marginTop: -4, marginBottom: 6 }}>
+            {ft4Low ? `↳ less than ${ft4Threshold} (specific-value condition)` : `↳ at or above ${ft4Threshold} (specific-value condition)`}
+          </div>
+          <div className={'sim-result ' + (fires ? 'fires' : 'idle')}>
+            <div className="head">{fires ? '✓ Rule fires' : '◯ Rule does not fire'}</div>
+            <div className="body">
+              {fires
+                ? <>
+                    Both conditions are true — <strong>TSH is outside the normal range</strong> AND <strong>Free T4 is less than {ft4Threshold}</strong>.
+                    <div className="action-line" style={{ marginTop: 6 }}>
+                      → <span className="action-tag order">Order Test</span> Thyroid antibody panel
+                    </div>
+                  </>
+                : <>
+                    <div style={{ marginBottom: 4 }}>TSH is outside normal: <strong>{tshOutside ? 'Yes' : 'No'}</strong></div>
+                    <div style={{ marginBottom: 4 }}>Free T4 is less than {ft4Threshold}: <strong>{ft4Low ? 'Yes' : 'No'}</strong></div>
+                    <div style={{ color: '#6f6f6f' }}>The rule needs both to be Yes to fire.</div>
+                  </>
+              }
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function HIVSimulator() {
+      const [result, setResult] = useState('Reactive');
+      const fires1 = result === 'Reactive';
+      const fires2 = result === 'Weak Reactive';
+      return (
+        <div>
+          <span className="compact-hint" style={{ display: 'block', marginBottom: 8 }}>
+            Pick a screen result. The simulator runs <strong>all</strong> rules in the HIV cascade to show which fires.
+          </span>
+          <div className="sim-row">
+            <label>HIV Screen result</label>
+            <select value={result} onChange={e => setResult(e.target.value)}>
+              <option>Reactive</option>
+              <option>Weak Reactive</option>
+              <option>Non-Reactive</option>
+            </select>
+            <span style={{ flex: '0 0 60px' }}></span>
+          </div>
+          <div className={'sim-result ' + (fires1 ? 'fires' : 'idle')}>
+            <div className="head">Rule #2 · Reactive → Confirmatory</div>
+            <div className="body">
+              {fires1
+                ? <>
+                    <div className="action-line">→ <span className="action-tag order">Order Test</span> HIV-1 Confirmatory (WB)</div>
+                    <div className="action-line">→ <span className="action-tag note">External Note</span> "Screening result reactive…"</div>
+                  </>
+                : '— not fired'}
+            </div>
+          </div>
+          <div className={'sim-result ' + (fires2 ? 'fires' : 'idle')}>
+            <div className="head">Rule #3 · Weak Reactive → Repeat Screen</div>
+            <div className="body">
+              {fires2
+                ? <div className="action-line">→ <span className="action-tag order">Order Test</span> HIV Screen (repeat)</div>
+                : '— not fired'}
+            </div>
+          </div>
+          {result === 'Non-Reactive' && (
+            <div className="sim-result idle">
+              <div className="head">No rules fire</div>
+              <div className="body">Non-reactive — no further testing. This is the expected terminal state for this cascade.</div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // ANALYZER PARAMETERS — attach to a few tests for the demo
+    // ========================================================================
+    // Inject analyzer parameters onto existing test catalog entries.
+    // In a real implementation these come from the Test Catalog editor sourced
+    // via the existing QC table linkage.
+    TESTS.find(t => t.id === 'WBC').analyzerParameters = [
+      { id: 'blasts',     name: 'Blasts suspected',           type: 'coded',   values: ['Yes','No'] },
+      { id: 'atyplymph',  name: 'Atypical lymphs suspected',  type: 'coded',   values: ['Yes','No'] },
+      { id: 'nRBC',       name: 'Nucleated RBC count',        type: 'numeric', units: '/100 WBC', refRange: [0, 0] },
+    ];
+    TESTS.find(t => t.id === 'GLU').analyzerParameters = [
+      { id: 'sampleHemolyzed', name: 'Sample hemolyzed flag', type: 'coded', values: ['Yes','No'] },
+      { id: 'sampleIcteric',   name: 'Sample icteric flag',   type: 'coded', values: ['Yes','No'] },
+    ];
+    // Rebuild TEST_BY_ID index in case anyone needs analyzer params from it
+    Object.assign(TEST_BY_ID, Object.fromEntries(TESTS.map(t => [t.id, t])));
+
+    function inputMeta(testId, paramId) {
+      const t = TEST_BY_ID[testId]; if (!t) return null;
+      if (paramId) return (t.analyzerParameters || []).find(p => p.id === paramId);
+      return t;
+    }
+
+    // ========================================================================
+    // UNIFIED INPUT PICKER — used for both condition inputs and action targets
+    // Modes:
+    //   'input'  — search test results + analyzer parameters (for conditions)
+    //   'target' — search test results + panels (for Order actions); sample filter
+    // ========================================================================
+    function UnifiedInputPicker({ value, onChange, mode, triggerSample, error }) {
+      const [open, setOpen] = useState(false);
+      const [q, setQ] = useState('');
+      const [scope, setScope] = useState('same'); // 'same' | 'any', only used in target mode
+      const triggerRef = React.useRef(null);
+
+      // Close on Escape; restore focus to trigger
+      React.useEffect(() => {
+        if (!open) return;
+        const onKey = (e) => {
+          if (e.key === 'Escape') {
+            setOpen(false);
+            triggerRef.current?.focus();
+          }
+        };
+        document.addEventListener('keydown', onKey);
+        return () => document.removeEventListener('keydown', onKey);
+      }, [open]);
+
+      // Sync default scope to trigger sample on first open
+      React.useEffect(() => {
+        if (open && mode === 'target') setScope('same');
+      }, [open, mode]);
+
+      // Build candidates
+      const candidates = [];
+      if (mode === 'input') {
+        TESTS.forEach(t => {
+          if (t.type === 'reflex') return; // reflex-only tests (orderable, not result-producing) excluded from conditions
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded · ' + t.values.length + ' values' : (t.units || 'numeric')}${t.sample ? ' · sample: ' + t.sample : ''}`,
+            sample: t.sample,
+          });
+          (t.analyzerParameters || []).forEach(p => {
+            candidates.push({
+              kind: 'param', testId: t.id, paramId: p.id,
+              humanName: p.name,
+              parentName: t.name,
+              techId: `${t.id}.${p.id}`,
+              meta: `${p.type === 'coded' ? 'coded · ' + p.values.join(' / ') : (p.units || 'numeric')}${p.refRange ? ' · range ' + p.refRange[0] + '–' + p.refRange[1] : ''}`,
+              sample: t.sample,
+            });
+          });
+        });
+      } else {
+        // target mode — tests (incl. orderable reflex) + panels
+        TESTS.forEach(t => {
+          candidates.push({
+            kind: 'result', testId: t.id,
+            humanName: t.name,
+            techId: t.id,
+            meta: `${t.loinc || 'no LOINC'} · ${t.values ? 'coded' : (t.units || t.type)}`,
+            sample: t.sample,
+          });
+        });
+        PANELS.forEach(p => {
+          candidates.push({
+            kind: 'panel', panelId: p.id,
+            humanName: p.name,
+            techId: p.id,
+            meta: `${p.tests.length} tests: ${p.tests.slice(0, 5).join(', ')}${p.tests.length > 5 ? ', …' : ''}`,
+            sample: p.sample,
+          });
+        });
+      }
+
+      const filterSample = (mode === 'target' && scope === 'same' && triggerSample) ? triggerSample : null;
+      const filtered = candidates.filter(c => {
+        if (filterSample && c.sample !== filterSample) return false;
+        return q === '' ||
+          (c.humanName + ' ' + (c.parentName || '') + ' ' + c.techId + ' ' + c.meta).toLowerCase().includes(q.toLowerCase());
+      });
+
+      const selected = value
+        ? (value.kind === 'panel'
+            ? PANELS.find(p => p.id === value.id)
+            : (value.paramId ? inputMeta(value.testId, value.paramId) : TEST_BY_ID[value.testId]))
+        : null;
+      const selectedKind = value?.kind || (value?.paramId ? 'param' : 'result');
+      const selectedTechId = value
+        ? (value.kind === 'panel' ? value.id
+           : value.paramId ? `${value.testId}.${value.paramId}` : value.testId)
+        : null;
+
+      const pick = (c) => {
+        if (c.kind === 'panel') onChange({ kind: 'panel', id: c.panelId });
+        else if (c.kind === 'param') onChange({ kind: 'result', testId: c.testId, paramId: c.paramId });
+        else onChange({ kind: 'result', testId: c.testId });
+        setQ(''); setOpen(false);
+        setTimeout(() => triggerRef.current?.focus(), 0);
+      };
+
+      // Split filtered by kind for sectioning
+      const tests   = filtered.filter(c => c.kind === 'result');
+      const params  = filtered.filter(c => c.kind === 'param');
+      const panels  = filtered.filter(c => c.kind === 'panel');
+
+      const tests_results_sectionTitle = mode === 'input' ? 'Test results' : 'Tests';
+
+      return (
+        <div className="ip-wrap">
+          <button ref={triggerRef} type="button"
+                  className={'ip-trigger' + (value ? '' : ' empty') + (error ? ' error' : '')}
+                  aria-haspopup="listbox" aria-expanded={open}
+                  onClick={() => setOpen(o => !o)}
+                  title={value ? `${selected?.name || selectedTechId} (${selectedTechId})` : 'Pick…'}>
+            {value && (
+              <span className={'ip-kind ' + selectedKind}>{selectedKind === 'param' ? 'param' : selectedKind === 'panel' ? 'panel' : 'result'}</span>
+            )}
+            <span className="ip-label">{selected?.name || (mode === 'input' ? 'Pick test or parameter…' : 'Pick test or panel…')}</span>
+            {value && <span className="ip-sub">{selectedTechId}</span>}
+            {value && (
+              <span className="clear-btn" role="button" aria-label="Clear selection"
+                    onClick={(e) => { e.stopPropagation(); onChange(null); }}>×</span>
+            )}
+            <span className="caret">{open ? '▴' : '▾'}</span>
+          </button>
+          {open && (
+            <>
+              <div style={{ position: 'fixed', inset: 0, zIndex: 50 }}
+                   onClick={() => setOpen(false)} aria-hidden="true" />
+              <div className="ip-pop" role="listbox">
+                <input type="text" className="ip-pop-search" autoFocus
+                       placeholder={mode === 'input'
+                         ? 'Search test name, parameter, LOINC, units…'
+                         : 'Search tests and panels…'}
+                       value={q} onChange={e => setQ(e.target.value)} />
+                {mode === 'target' && (
+                  <div className="ip-pop-scope">
+                    <label><input type="radio" checked={scope === 'same'} onChange={() => setScope('same')} />
+                      Same sample type{triggerSample ? ` (${triggerSample})` : ''} only</label>
+                    <label><input type="radio" checked={scope === 'any'} onChange={() => setScope('any')} />
+                      All sample types <span className="warn-pill">requires new collection</span></label>
+                  </div>
+                )}
+                {mode === 'target' && scope === 'any' && (
+                  <div className="ip-pop-warn">
+                    ⚠ Cross-sample reflex — firing this rule will trigger an order with a different sample type than the trigger. Lab will need to collect a new specimen.
+                  </div>
+                )}
+                <div className="ip-pop-list">
+                  {filtered.length === 0 && <div className="ip-pop-empty">No matches.</div>}
+                  {tests.length > 0 && (
+                    <>
+                      <div className="ip-section">{tests_results_sectionTitle} · {tests.length} matching</div>
+                      {tests.slice(0, 10).map((c, i) => (
+                        <button key={'r' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind result">{mode === 'input' ? 'result' : 'test'}</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name"><strong>{c.humanName}</strong></div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {params.length > 0 && (
+                    <>
+                      <div className="ip-section">Analyzer parameters · {params.length} matching</div>
+                      {params.slice(0, 10).map((c, i) => (
+                        <button key={'p' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind param">param</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name">
+                              <span style={{ color: '#6f6f6f' }}>{c.parentName} →</span> <strong>{c.humanName}</strong>
+                            </div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {panels.length > 0 && (
+                    <>
+                      <div className="ip-section">Panels · {panels.length} matching</div>
+                      {panels.slice(0, 8).map((c, i) => (
+                        <button key={'pa' + i} className="ip-item" onClick={() => pick(c)}>
+                          <span className="ip-kind panel">panel</span>
+                          <span className="ip-item-body">
+                            <div className="ip-item-name"><strong>{c.humanName}</strong></div>
+                            <div className="ip-item-meta">{c.techId} · {c.meta}</div>
+                          </span>
+                          {c.sample && <span className="sample-chip">{c.sample}</span>}
+                        </button>
+                      ))}
+                    </>
+                  )}
+                  {tests.length > 10 && (
+                    <div className="ip-pop-more">…and {tests.length - 10} more tests. Refine your search.</div>
+                  )}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // COMPOSE MODE — row-list view of a compound WHEN clause
+    // ========================================================================
+    function ComposeRowValueInput({ test, predDef, value, onChange }) {
+      if (!predDef || !predDef.valueInput) return null;
+      const inputStyle = { padding: '4px 8px', fontSize: 13, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#fff', minWidth: 80 };
+      if (predDef.valueInput === 'number') {
+        return (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <input type="number" step="any" placeholder="value"
+                   value={value ?? ''} onChange={e => onChange(e.target.value === '' ? null : +e.target.value)}
+                   style={inputStyle} />
+            {test.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{test.units}</span>}
+          </span>
+        );
+      }
+      if (predDef.valueInput === 'range') {
+        const v = value || [null, null];
+        return (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <input type="number" step="any" placeholder="low" value={v[0] ?? ''}
+                   onChange={e => onChange([e.target.value === '' ? null : +e.target.value, v[1]])}
+                   style={{ ...inputStyle, width: 70, minWidth: 70 }} />
+            <span style={{ fontSize: 11, color: '#525252' }}>and</span>
+            <input type="number" step="any" placeholder="high" value={v[1] ?? ''}
+                   onChange={e => onChange([v[0], e.target.value === '' ? null : +e.target.value])}
+                   style={{ ...inputStyle, width: 70, minWidth: 70 }} />
+            {test.units && <span style={{ fontSize: 11, color: '#6f6f6f' }}>{test.units}</span>}
+          </span>
+        );
+      }
+      if (predDef.valueInput === 'coded') {
+        return (
+          <select value={value ?? ''} onChange={e => onChange(e.target.value || null)} style={inputStyle}>
+            <option value="">— pick value —</option>
+            {test.values.map(v => <option key={v} value={v}>{v}</option>)}
+          </select>
+        );
+      }
+      if (predDef.valueInput === 'codedMulti') {
+        const selected = value || [];
+        return (
+          <span style={{ display: 'inline-flex', flexWrap: 'wrap', gap: 4, alignItems: 'center' }}>
+            {test.values.map(v => (
+              <label key={v} style={{ fontSize: 12, display: 'inline-flex', alignItems: 'center', gap: 3, cursor: 'pointer' }}>
+                <input type="checkbox"
+                       checked={selected.includes(v)}
+                       onChange={e => {
+                         const next = e.target.checked
+                           ? [...selected, v]
+                           : selected.filter(x => x !== v);
+                         onChange(next);
+                       }} />
+                {v}
+              </label>
+            ))}
+          </span>
+        );
+      }
+      return null;
+    }
+
+    function ComposeBuilder({ rows, joiners, onChange }) {
+      // rows: [{ input: { kind:'result', testId, paramId? } | null, pred, value }, ...]
+      const setRow = (i, patch) => onChange(rows.map((r, idx) => idx === i ? { ...r, ...patch } : r), joiners);
+      const setJoiner = (i, val) => onChange(rows, joiners.map((j, idx) => idx === i ? val : j));
+      const addRow = () => onChange([...rows, { input: null, pred: '', value: null }], [...joiners, 'AND']);
+      const removeRow = (i) => onChange(rows.filter((_, idx) => idx !== i), joiners.filter((_, idx) => idx !== i));
+      return (
+        <div className="compose-block">
+          {rows.map((r, i) => {
+            const meta = r.input ? inputMeta(r.input.testId, r.input.paramId) : null;
+            const predDef = r.pred ? PREDICATES.find(p => p.id === r.pred) : null;
+            return (
+              <div key={i} className="compose-row">
+                {i === 0
+                  ? <span className="joiner first">WHEN</span>
+                  : <select className="joiner" aria-label="Join with previous condition"
+                            value={joiners[i] || 'AND'} onChange={e => setJoiner(i, e.target.value)}>
+                      <option>AND</option><option>OR</option>
+                    </select>}
+                <UnifiedInputPicker
+                  mode="input"
+                  value={r.input}
+                  onChange={v => setRow(i, { input: v, pred: '', value: null })}
+                />
+                <div className="pred-pick">
+                  {meta ? (
+                    <>
+                      <select value={r.pred}
+                              aria-label="Question to ask about the input"
+                              onChange={e => setRow(i, { pred: e.target.value, value: null })}>
+                        <option value="">— pick a question —</option>
+                        {PREDICATE_GROUPS.map(g => {
+                          const groupPreds = PREDICATES.filter(p => p.group === g.id);
+                          return (
+                            <optgroup key={g.id} label={g.label}>
+                              {groupPreds.map(p => {
+                                const available = predicateAvailable(p, meta);
+                                const reason = REQUIREMENT_REASONS[p.requires] || 'compatible input';
+                                return (
+                                  <option key={p.id} value={p.id} disabled={!available}>
+                                    {p.label}{!available ? ` — needs ${reason}` : ''}
+                                  </option>
+                                );
+                              })}
+                            </optgroup>
+                          );
+                        })}
+                      </select>
+                      <ComposeRowValueInput test={meta} predDef={predDef} value={r.value}
+                                            onChange={v => setRow(i, { value: v })} />
+                    </>
+                  ) : (
+                    <span style={{ fontSize: 11, color: '#a8a8a8', fontStyle: 'italic' }}>
+                      Pick an input first to see questions you can ask
+                    </span>
+                  )}
+                </div>
+                <button className="delete" onClick={() => removeRow(i)} aria-label="Remove this condition">×</button>
+              </div>
+            );
+          })}
+          <button className="cds--btn cds--btn--ghost add-cta" onClick={addRow}
+                  aria-label="Add another condition">
+            <span className="plus">+</span>
+            <span>Add another condition</span>
+            <span className="hint">join with AND or OR</span>
+          </button>
+        </div>
+      );
+    }
+
+    // Compile compose-row state to a formula string
+    function rowsToFormula(rows, joiners) {
+      const parts = [];
+      rows.forEach((r, i) => {
+        if (i > 0) parts.push(joiners[i] || 'AND');
+        if (!(r.input && r.pred)) { parts.push('_'); return; }
+        const tid = r.input.paramId ? `${r.input.testId}.${r.input.paramId}` : r.input.testId;
+        const p = PREDICATES.find(p => p.id === r.pred);
+        if (p && p.valueInput) {
+          let v;
+          if (p.valueInput === 'range') v = `[${(r.value || [])[0] ?? '?'},${(r.value || [])[1] ?? '?'}]`;
+          else if (p.valueInput === 'codedMulti') v = `[${(r.value || []).map(x => '"' + x + '"').join(',')}]`;
+          else if (p.valueInput === 'coded') v = `"${r.value ?? ''}"`;
+          else v = r.value ?? '?';
+          parts.push(`${r.pred}(${tid}, ${v})`);
+        } else {
+          parts.push(`${r.pred}(${tid})`);
+        }
+      });
+      return parts.join(' ');
+    }
+
+    // ========================================================================
+    // TSH/FT4 COMPOUND EDITOR — demonstrates compound predicates
+    // ========================================================================
+    function TSHEditor() {
+      const [mode, setMode] = useState('compose');
+      const [showTechnical, setShowTechnical] = useState(false);
+      const [rows, setRows] = useState([
+        { input: { kind: 'result', testId: 'TSH' }, pred: 'isOutsideNormal',  value: null },
+        { input: { kind: 'result', testId: 'FT4' }, pred: 'lt',               value: 0.7 },
+      ]);
+      const [joiners, setJoiners] = useState([null, 'AND']);
+      const when = rowsToFormula(rows, joiners);
+      const setComposeState = (newRows, newJoiners) => {
+        setRows(newRows); setJoiners(newJoiners);
+      };
+      const setWhen = (v) => { /* formula-bar typed input — would parse back to rows in a real impl */ };
+      // Collect distinct tests referenced for the Predicate Index
+      const referencedTests = [...new Set(rows.map(r => r.input?.testId).filter(Boolean))];
+
+      const [triggerSample, setTriggerSample] = useState('Serum');
+      const [catalogOpen, setCatalogOpen] = useState(false);
+      const [simulatorOpen, setSimulatorOpen] = useState(true);
+      // Save states — for demo: idle | saving | error
+      const [saveState, setSaveState] = useState('idle');
+      const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+      const [actions, setActions] = useState([
+        { type: 'order', target: { kind: 'panel', id: 'PANEL_THYRAB' }, priority: 'routine', reason: 'TSH + FT4 both abnormal — reflex thyroid antibody workup' },
+        { type: 'note_ext', note: 'TSH and Free T4 are both outside the normal range. Thyroid antibody panel ordered automatically per lab reflex policy.' },
+      ]);
+      const updateAction = (i, a) => setActions(arr => arr.map((x, idx) => idx === i ? a : x));
+      const deleteAction = (i) => setActions(arr => arr.filter((_, idx) => idx !== i));
+      const addAction = () => setActions(arr => [...arr, { type: 'order', test: '' }]);
+
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Triggers on: TSH or FT4 (Serum)</span>
+                <span className="cds--tag cds--tag--teal">2 conditions (AND)</span>
+                <span className="cds--tag cds--tag--purple">{actions.length} action{actions.length !== 1 ? 's' : ''}</span>
+              </div>
+
+              <div className="editor-stack">
+
+                {/* TOP — Test catalog data (collapsible, default closed) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (catalogOpen ? '' : ' collapsed')}
+                          aria-expanded={catalogOpen}
+                          onClick={() => setCatalogOpen(o => !o)}>
+                    <span className="caret">{catalogOpen ? '▾' : '▸'}</span>
+                    <span className="col-title">Test catalog data</span>
+                    <span className="col-summary">
+                      {referencedTests.length > 0
+                        ? `${referencedTests.map(id => TEST_BY_ID[id]?.name || id).join(', ')} · ranges and thresholds defined in the catalog`
+                        : 'Pick a test in the rule to see its catalog metadata'}
+                    </span>
+                    <span className="pill gray">Reference</span>
+                  </button>
+                  {catalogOpen && (
+                    <div className="collapsible-body">
+                      <div className="compact-hint" style={{ marginBottom: 8 }}>
+                        What's defined in the Test Catalog for each test in this rule. Questions in
+                        the Compose picker are enabled based on this metadata — set ranges or
+                        thresholds here to unlock more questions.
+                      </div>
+                      <TestCatalogRef
+                        testIds={referencedTests.length > 0 ? referencedTests : ['TSH']} />
+                    </div>
+                  )}
+                </div>
+
+                {/* MIDDLE — Rule definition (full width) */}
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">WHEN / THEN</span> <span className="pill" style={{ background: '#cfeaff', color: '#0072c3' }}>Compound</span></h4>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', gap: '0.5rem' }}>
+                      <div style={{ flex: 2 }}>
+                        <label style={{ fontSize: 12, color: '#525252' }}>Rule name</label>
+                        <input type="text" defaultValue="Thyroid panel reflex — TSH + FT4 both abnormal"
+                               style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }} />
+                      </div>
+                      <div style={{ flex: 1 }}>
+                        <label style={{ fontSize: 12, color: '#525252' }}>Trigger sample</label>
+                        <select value={triggerSample} onChange={e => setTriggerSample(e.target.value)}
+                                style={{ width: '100%', padding: 6, border: 'none', borderBottom: '1px solid #8d8d8d', background: '#f4f4f4' }}>
+                          <option>Serum</option><option>Plasma</option><option>Whole Blood</option>
+                          <option>EDTA Tube</option><option>Urines</option>
+                          <option>Any sample type</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 6 }}>
+                      <div className="block-label when" style={{ marginBottom: 0 }}>WHEN</div>
+                      <div className="mode-tabs">
+                        <button className={mode === 'compose' ? 'active' : ''} onClick={() => setMode('compose')}>Build it</button>
+                        <button className={mode === 'formula' ? 'active' : ''} onClick={() => setMode('formula')}>Type it</button>
+                      </div>
+                      <span style={{ marginLeft: 'auto', fontSize: 11, color: '#6f6f6f' }}>
+                        Same rule. Both views save the same way.
+                      </span>
+                    </div>
+
+                    {/* Plain-English rule preview, always visible */}
+                    <div style={{
+                      background: '#f4f9ff', borderLeft: '3px solid #0f62fe',
+                      padding: '0.5rem 0.75rem', marginBottom: 8, fontSize: 14, color: '#161616'
+                    }}>
+                      <span style={{ fontSize: 10, color: '#0043ce', fontWeight: 700, letterSpacing: 0.5 }}>RULE READS AS</span>
+                      <div style={{ marginTop: 4 }}>
+                        Reflex the thyroid antibody panel when{' '}
+                        {rows.map((r, i) => (
+                          <React.Fragment key={i}>
+                            {i > 0 && <strong style={{ color: '#0043ce' }}> {joiners[i] || 'AND'} </strong>}
+                            <strong>{predicatePhrase(r.input, r.pred, r.value) || '…'}</strong>
+                          </React.Fragment>
+                        ))}.
+                      </div>
+                    </div>
+
+                    {mode === 'compose'
+                      ? <ComposeBuilder rows={rows} joiners={joiners} onChange={setComposeState} />
+                      : <ConditionBar value={when} onChange={setWhen} />}
+
+                    {/* Technical form — hidden by default */}
+                    <div style={{ marginTop: 6 }}>
+                      <button onClick={() => setShowTechnical(s => !s)}
+                              style={{ background: 'none', border: 'none', color: '#0f62fe', cursor: 'pointer', fontSize: 11, padding: 0 }}>
+                        {showTechnical ? '▾ Hide technical form' : '▸ Show technical form (for developers / DMN export)'}
+                      </button>
+                      {showTechnical && (
+                        <div style={{ marginTop: 6, background: '#f4f4f4', padding: '0.5rem 0.75rem', fontSize: 12 }}>
+                          <div style={{ fontSize: 10, color: '#525252', textTransform: 'uppercase', letterSpacing: 0.5, marginBottom: 4 }}>
+                            Stored AST (semantic form)
+                          </div>
+                          <code style={{ fontSize: 12 }}><FormulaSummary text={when} /></code>
+                          <div style={{ fontSize: 10, color: '#525252', textTransform: 'uppercase', letterSpacing: 0.5, marginTop: 8, marginBottom: 4 }}>
+                            Compiled (semantic predicates expand to numeric expressions; specific-value predicates stay as-is)
+                          </div>
+                          <code style={{ fontSize: 12, color: '#525252' }}>
+                            {(() => {
+                              const parts = rows.map(r => {
+                                const p = PREDICATES.find(p => p.id === r.pred);
+                                if (!p) return '_';
+                                const inp = r.input || {};
+                                const tid = inp.paramId ? `${inp.testId}.${inp.paramId}` : (inp.testId || '_');
+                                const meta = inp.testId ? (inp.paramId ? (TEST_BY_ID[inp.testId]?.analyzerParameters || []).find(x => x.id === inp.paramId) || {} : TEST_BY_ID[inp.testId] || {}) : {};
+                                if (p.valueInput) return p.desugar(tid, meta, r.value);
+                                return p.desugar(tid, meta);
+                              });
+                              const out = [];
+                              parts.forEach((p, i) => {
+                                if (i > 0) out.push(` ${joiners[i] || 'AND'} `);
+                                out.push(`(${p})`);
+                              });
+                              return out.join('');
+                            })()}
+                          </code>
+                          <div style={{ fontSize: 11, color: '#6f6f6f', marginTop: 6, fontStyle: 'italic' }}>
+                            The semantic form (top) is what's stored — when reference ranges change in the Test Catalog, the compiled form (bottom) updates automatically.
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="panel-section">
+                    <div style={{ display: 'flex', alignItems: 'center', marginBottom: 6 }}>
+                      <div className="block-label then" style={{ marginBottom: 0 }}>THEN do all of the following</div>
+                      <span style={{ marginLeft: 'auto', fontSize: 11, color: '#6f6f6f' }}>
+                        {actions.length} action{actions.length !== 1 ? 's' : ''}
+                      </span>
+                    </div>
+                    {actions.map((a, i) => (
+                      <ActionRow key={i} action={a} triggerSample={triggerSample}
+                                 onChange={(na) => updateAction(i, na)} onDelete={() => deleteAction(i)} />
+                    ))}
+                    <button className="add-cta" onClick={addAction}>
+                      <span className="plus">+</span>
+                      <span>Add another action</span>
+                      <span className="hint">Order test · Order panel · Note · Set priority · Send alert</span>
+                    </button>
+                  </div>
+                </div>
+
+                {/* BOTTOM — Simulator (collapsible, default open) */}
+                <div className="collapsible">
+                  <button type="button" className={'collapsible-head' + (simulatorOpen ? '' : ' collapsed')}
+                          aria-expanded={simulatorOpen}
+                          onClick={() => setSimulatorOpen(o => !o)}>
+                    <span className="caret">{simulatorOpen ? '▾' : '▸'}</span>
+                    <span className="col-title">Simulator</span>
+                    <span className="col-summary">
+                      Test the rule against hypothetical TSH and Free T4 inputs.
+                    </span>
+                    <span className="pill green">Sandbox</span>
+                  </button>
+                  {simulatorOpen && (
+                    <div className="collapsible-body">
+                      <TSHSimulator />
+                    </div>
+                  )}
+                </div>
+
+              </div>
+
+              {/* Save state visualizations — toggle via the demo buttons below */}
+              {saveState === 'error' && (
+                <div className="save-error" role="alert">
+                  <div className="title">⚠ Couldn't save this rule — please fix the issues below:</div>
+                  <ul>
+                    <li>Condition 2: predicate is incomplete (FT4 is less than … needs a numeric value)</li>
+                    <li>Cross-sample reflex requires an audit reason (action 1 orders a Whole Blood test from a Serum trigger).</li>
+                  </ul>
+                </div>
+              )}
+
+              <div className="footer-actions">
+                {/* Demo controls — let reviewers see all states */}
+                <span style={{ fontSize: 11, color: '#6f6f6f', alignSelf: 'center', marginRight: 'auto' }}>
+                  Demo:
+                  <button onClick={() => setSaveState('idle')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'idle' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>idle</button> ·
+                  <button onClick={() => setSaveState('saving')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'saving' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>saving</button> ·
+                  <button onClick={() => setSaveState('error')} style={{ marginLeft: 6, background: 'none', border: 'none', color: saveState === 'error' ? '#0f62fe' : '#525252', cursor: 'pointer', fontSize: 11 }}>save-failed</button>
+                </span>
+                <button className="cds--btn cds--btn--ghost" onClick={() => setShowDisableConfirm(true)}>Disable rule</button>
+                <button className="cds--btn cds--btn--ghost" disabled={saveState === 'saving'}>Cancel</button>
+                <button className="cds--btn cds--btn--primary" disabled={saveState === 'saving'}
+                        aria-busy={saveState === 'saving'}>
+                  {saveState === 'saving' ? 'Saving…' : 'Save changes'}
+                </button>
+              </div>
+            </div>
+
+            {showDisableConfirm && (
+              <div className="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="confirm-title"
+                   onClick={(e) => { if (e.target === e.currentTarget) setShowDisableConfirm(false); }}>
+                <div className="modal-panel">
+                  <div className="modal-head">
+                    <div className="modal-title" id="confirm-title">Disable this rule?</div>
+                  </div>
+                  <div className="modal-body">
+                    <p style={{ margin: 0 }}>
+                      <strong>Thyroid panel reflex — TSH abnormal + FT4 &lt; 0.7</strong> will stop firing immediately on save.
+                      Existing reflex orders already created by this rule are not affected.
+                    </p>
+                    <p style={{ marginTop: 12, fontSize: 12, color: '#525252' }}>
+                      The rule remains visible in the list as <em>Disabled</em>. You can re-enable it from the row's overflow menu at any time.
+                    </p>
+                  </div>
+                  <div className="modal-foot">
+                    <button className="cds--btn cds--btn--secondary" onClick={() => setShowDisableConfirm(false)}>Cancel</button>
+                    <button className="cds--btn cds--btn--danger" onClick={() => setShowDisableConfirm(false)}>Disable rule</button>
+                  </div>
+                </div>
+              </div>
+            )}
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // HIV CASCADE EDITOR — decision table mode
+    // ========================================================================
+    function HIVCascadeEditor() {
+      const [mode, setMode] = useState('table');
+      return (
+        <tr>
+          <td colSpan={6} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="expanded-tile">
+              <div className="badge-row">
+                <span className="cds--tag cds--tag--blue">Editing</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Trigger: HIV Screen (Whole Blood)</span>
+                <span className="cds--tag cds--tag--purple">Cascade · 2 rules</span>
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', marginBottom: '0.75rem' }}>
+                <span style={{ fontSize: 13, color: '#525252' }}>
+                  Two rules share <strong>HIV_Screen</strong> as their trigger. View as:
+                </span>
+                <div className="mode-toggle">
+                  <button className={mode === 'individual' ? 'active' : ''} onClick={() => setMode('individual')}>Individual rules</button>
+                  <button className={mode === 'table' ? 'active' : ''} onClick={() => setMode('table')}>Decision table</button>
+                </div>
+              </div>
+
+              {mode === 'table' && (
+                <div className="panel" style={{ padding: '1rem' }}>
+                  <h4>HIV Screen decision table <span className="pill">Compact view</span></h4>
+                  <p className="compact-hint" style={{ marginBottom: '0.75rem' }}>
+                    Each row is a rule. Authoring multiple rules with the same trigger as a table makes the cascade easier to read than three separate forms.
+                  </p>
+                  <table className="decision-table">
+                    <thead>
+                      <tr>
+                        <th style={{ width: 40 }}>#</th>
+                        <th className="col-header-when">When HIV_Screen equals…</th>
+                        <th className="col-header-then">Order test</th>
+                        <th className="col-header-then">Priority</th>
+                        <th className="col-header-then">External note</th>
+                        <th style={{ width: 40 }}></th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr>
+                        <td>1</td>
+                        <td className="dt-cell"><span className="tok-str">"Reactive"</span></td>
+                        <td className="dt-cell"><span className="tok-var">HIV1_Conf</span> <span style={{ color: '#6f6f6f' }}>(Confirmatory WB)</span></td>
+                        <td className="dt-cell">Routine</td>
+                        <td className="dt-cell" style={{ fontFamily: 'inherit', fontSize: 12 }}>
+                          "Reactive — confirm with WB per national algorithm"
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      <tr>
+                        <td>2</td>
+                        <td className="dt-cell"><span className="tok-str">"Weak Reactive"</span></td>
+                        <td className="dt-cell"><span className="tok-var">HIV_Screen</span> <span style={{ color: '#6f6f6f' }}>(repeat)</span></td>
+                        <td className="dt-cell">Routine</td>
+                        <td className="dt-cell" style={{ fontFamily: 'inherit', fontSize: 12 }}>
+                          "Equivocal — repeat in 2 weeks"
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      <tr style={{ background: '#fafafa' }}>
+                        <td>3</td>
+                        <td className="dt-cell"><span className="tok-str">"Non-Reactive"</span></td>
+                        <td colSpan={3} className="dt-cell" style={{ fontFamily: 'inherit', color: '#525252', fontStyle: 'italic' }}>
+                          (no actions — terminal state)
+                        </td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <button className="cds--btn cds--btn--ghost" style={{ marginTop: 8, fontSize: 12 }}>+ Add row</button>
+                </div>
+              )}
+
+              {mode === 'individual' && (
+                <div className="panel">
+                  <p className="compact-hint">Each rule renders in its own WHEN/THEN editor (like the TSH editor above). Switch back to <strong>Decision table</strong> for the compact view.</p>
+                </div>
+              )}
+
+              <div className="editor-grid" style={{ marginTop: '1rem' }}>
+                <div className="panel">
+                  <h4>Simulator <span className="pill green">Sandbox</span></h4>
+                  <HIVSimulator />
+                </div>
+                <div className="panel">
+                  <h4>Cascade preview <span className="pill gray">Read-only</span></h4>
+                  <div className="cascade" style={{ flexWrap: 'wrap' }}>
+                    <div className="node trigger">HIV Screen</div>
+                    <span className="arr">→</span>
+                    <div className="node action">HIV-1 Confirmatory (WB)</div>
+                    <span className="arr">↘</span>
+                  </div>
+                  <div className="cascade" style={{ marginTop: 4 }}>
+                    <div className="node trigger">HIV Screen</div>
+                    <span className="arr">→</span>
+                    <div className="node chain">HIV Screen (repeat)</div>
+                    <span style={{ fontSize: 11, color: '#6f6f6f', marginLeft: 8 }}>self-loop · capped at 1 retry</span>
+                  </div>
+
+                  <h4 style={{ fontSize: 13, margin: '1rem 0 0.5rem' }}>Conflicts</h4>
+                  <div className="conflict">
+                    ⚠ Rule #2 (Reactive) and Rule #3 (Weak Reactive) cannot both fire on the same result —
+                    HIV_Screen has a single coded value. No conflict.
+                  </div>
+                  <div style={{ marginTop: 6, fontSize: 11, color: '#0e6027' }}>
+                    ✓ Coverage check: all three coded values (Reactive, Weak Reactive, Non-Reactive) are handled.
+                  </div>
+                </div>
+              </div>
+
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--ghost">Run all simulations</button>
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // FORMULA LIBRARY (templates)
+    // ========================================================================
+    const LIBRARY = [
+      { name: 'HIV cascade (national algorithm)', shape: 'Screen → Confirmatory / Repeat / End', src: 'WHO 2019' },
+      { name: 'TB cascade (GeneXpert → DST)',     shape: 'GeneXpert+ → Drug Susceptibility',    src: 'WHO 2021' },
+      { name: 'Syphilis reverse algorithm',       shape: 'Treponemal+ → RPR + TPPA',            src: 'CDC 2015' },
+      { name: 'Hepatitis B reflex',               shape: 'HBsAg+ → HBeAg + HBV DNA',            src: 'AASLD' },
+      { name: 'Urine dipstick → culture',         shape: 'Nitrites/Leuk+ → C&S',                 src: 'standard' },
+      { name: 'Strep RADT → throat culture',      shape: 'RADT- and pediatric → culture',       src: 'IDSA' },
+      { name: 'CBC manual differential trigger',  shape: 'WBC>30k or atypical → manual diff',   src: 'CLSI H20-A2' },
+      { name: 'TSH reflex Free T4',               shape: 'TSH abnormal → FT4',                   src: 'ATA 2014' },
+      { name: 'Coombs+ → eluate + panel',         shape: 'DAT+ → eluate, ABO/Rh confirm',       src: 'AABB' },
+      { name: 'Severe anemia workup',             shape: 'Hgb<7 → Retic + Iron + B12/Folate',   src: 'standard' },
+      { name: 'Critical glucose alert',           shape: '<40 or >500 → alert + lactate',       src: 'CLSI C24-A3' },
+      { name: 'Newborn TSH reflex',               shape: 'NB TSH>20 → Day-7 repeat',            src: 'AAP 2006' },
+    ];
+
+    function LibraryDrawer({ onClose }) {
+      const [q, setQ] = useState('');
+      const filtered = LIBRARY.filter(t =>
+        (t.name + t.shape + t.src).toLowerCase().includes(q.toLowerCase())
+      );
+      return (
+        <div className="library-drawer">
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 8 }}>
+            <h4>Reflex algorithm library &nbsp;<span style={{ fontWeight: 400, fontSize: 11, color: '#6f6f6f' }}>{LIBRARY.length} entries · search by name, citation, or shape</span></h4>
+            <button onClick={onClose} style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#525252', fontSize: 16 }}>✕</button>
+          </div>
+          <input
+            className="library-search"
+            placeholder="Search algorithms (e.g. 'HIV', 'TSH', 'urine')…"
+            value={q} onChange={e => setQ(e.target.value)}
+          />
+          <div className="library-grid">
+            {filtered.map(tpl => (
+              <div key={tpl.name} className="library-card">
+                <div className="name">{tpl.name}</div>
+                <div className="shape">{tpl.shape}</div>
+                <div className="src">{tpl.src}</div>
+              </div>
+            ))}
+          </div>
+          <div style={{ marginTop: 8, fontSize: 11, color: '#6f6f6f' }}>
+            Picking an algorithm prefills the WHEN/THEN block(s) and adds the cascade as a single decision-table entry.
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      // TSH (1) + HIV cascade (2 — anchors the HIV group) both pre-expanded
+      const [expandedIds, setExpandedIds] = useState(new Set([1, 2]));
+      const toggleExpanded = (id) => setExpandedIds(s => {
+        const ns = new Set(s);
+        if (ns.has(id)) ns.delete(id); else ns.add(id);
+        return ns;
+      });
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [libraryOpen, setLibraryOpen] = useState(false);
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Reflex Test Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Reflex Test Rules
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> Reflex rules read as plain English clinical
+              questions: <em>"when TSH is outside the normal range AND Free T4 is less than
+              0.7, reflex the thyroid antibody panel."</em> Authors pick a test, then a
+              question about it. Three kinds of questions are available:
+              <strong>catalog-based</strong> (uses the test's reference / critical ranges —
+              "is outside normal", "is critically high"); <strong>specific-value</strong>
+              (you enter a number — "is at least 6.5", "is between 50 and 80"); and
+              <strong>coded value</strong> (pick from the test's possible values — "is
+              reactive", "is any of: ++, +++"). Conditions compose with AND / OR / NOT.
+              Multiple actions per rule. The technical form is hidden by default and
+              available behind a toggle for developers / DMN export.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search rules by name, trigger test, or action…" />
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Trigger sample: All ▾</span>
+              <span className="filter-pill">Cascade group: All ▾</span>
+            </div>
+            <div>
+              <button className={'browse-btn' + (libraryOpen ? ' open' : '')}
+                      onClick={() => setLibraryOpen(o => !o)}
+                      style={{ marginRight: 8 }}>
+                Browse algorithm library
+              </button>
+              <button className="cds--btn cds--btn--primary">+ New rule</button>
+            </div>
+          </div>
+
+          {libraryOpen && <LibraryDrawer onClose={() => setLibraryOpen(false)} />}
+
+          {/* Rule list */}
+          <div className="cds--data-table-container" style={{ background: '#fff', border: '1px solid #e0e0e0', borderTop: 'none' }}>
+            <table className="cds--data-table">
+              <thead>
+                <tr>
+                  <th style={{ width: 40 }}></th>
+                  <th style={{ width: 90 }}>Status</th>
+                  <th>Rule</th>
+                  <th style={{ width: 140 }}>Cascade</th>
+                  <th style={{ width: 180 }}>Last edited</th>
+                  <th style={{ width: 60 }}></th>
+                </tr>
+              </thead>
+              <tbody>
+                {RULES.map(rule => {
+                  const isExpanded = expandedIds.has(rule.id);
+                  return (
+                  <React.Fragment key={rule.id}>
+                    <tr style={{ background: isExpanded ? '#edf5ff' : 'transparent' }}>
+                      <td>
+                        <button
+                          onClick={() => toggleExpanded(rule.id)}
+                          style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe' }}>
+                          {isExpanded ? '▾' : '▸'}
+                        </button>
+                      </td>
+                      <td>
+                        {rule.status === 'active'
+                          ? <span className="cds--tag cds--tag--green">Active</span>
+                          : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                      </td>
+                      <td>
+                        <div className="rule-name">{rule.name}</div>
+                        <RuleSummary when={rule.when} thenSummary={rule.thenSummary} />
+                      </td>
+                      <td style={{ fontSize: 12 }}>
+                        {rule.cascadeGroup
+                          ? <span className="cds--tag cds--tag--purple">{rule.cascadeGroup}</span>
+                          : <span style={{ color: '#a8a8a8' }}>—</span>}
+                      </td>
+                      <td style={{ fontSize: 12, color: '#6f6f6f' }}>{rule.edited}</td>
+                      <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                    </tr>
+                    {isExpanded && rule.id === 1 && <TSHEditor />}
+                    {isExpanded && rule.id === 2 && <HIVCascadeEditor />}
+                    {isExpanded && rule.id === 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#fafafa', fontSize: 13, color: '#525252' }}>
+                          This rule shares the HIV cascade. Open <strong>rule #2</strong> above to edit the cascade as a decision table.
+                        </td>
+                      </tr>
+                    )}
+                    {isExpanded && rule.id !== 1 && rule.id !== 2 && rule.id !== 3 && (
+                      <tr>
+                        <td colSpan={6} style={{ padding: '1rem 2rem', background: '#f4f4f4', fontSize: 13, color: '#525252' }}>
+                          (Editor for <strong>{rule.name}</strong> would render in the same WHEN/THEN layout. Cascade groups would offer decision-table mode.)
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>What changed vs. today:</strong> WHEN/THEN structure replaces "Add Reflex Rule
+            Conditions / Perform the following actions" (clearer mental model, matches Drools,
+            Salesforce Flow, Zapier). Boolean formula bar replaces row-of-conditions + ANY/ALL dropdown —
+            supports coded results (HIV "Reactive"), numeric comparisons, patient attributes, and
+            properly nested AND/OR with parens. Structured action list replaces "free-form text with sample-type dropdown" —
+            picks from Order Test, Order Panel, Note (internal/external), Set Priority, Send Alert.
+            Decision-table mode added for cascades (HIV, TB, syphilis) so the cascade reads as a single
+            artifact instead of three separate forms. Simulator added on the right pane — paste a sample
+            result, see what fires. Cascade overlay shows downstream chains and self-loops. Conflict
+            detection runs on save. Algorithm library replaces "no templates" with WHO/CDC/IDSA-cited cascades.
+            Same Carbon shell as Calculated Values v2 — list view, inline expansion, two-pane editor.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1'; s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message +
+          '<pre style="font-size:11px;">' + (e.stack || '').split('\n').slice(0,6).join('\n') + '</pre>';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/mockup-viewer/public/designs/admin-config/test-rules-list-view-preview.html
+++ b/mockup-viewer/public/designs/admin-config/test-rules-list-view-preview.html
@@ -1,0 +1,938 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Test Rules — Unified List View — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem 4rem; max-width: 1480px; margin: 0 auto; }
+    .breadcrumb { font-size: 12px; color: #525252; margin: 0.5rem 0 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+
+    .brief-banner {
+      background: #edf5ff; border-left: 3px solid #0f62fe;
+      padding: 0.75rem 1rem; margin-bottom: 1rem; font-size: 13px; color: #161616;
+    }
+    .brief-banner strong { color: #0043ce; }
+
+    /* Token rendering */
+    .tok-var { color: #0043ce; font-weight: 600; }
+    .tok-fn { color: #491d8b; font-weight: 600; }
+    .tok-attr { color: #a2191f; font-weight: 600; }
+    .tok-op { color: #d12771; font-weight: 600; }
+    .tok-bool { color: #8a3ffc; font-weight: 700; }
+    .tok-num { color: #198038; font-weight: 600; }
+    .tok-str { color: #0e6027; }
+    .tok-paren { color: #525252; }
+    .tok-pred { color: #0072c3; font-weight: 600; }
+    .phrase {
+      display: inline-flex; align-items: baseline; gap: 4px;
+      background: #f4f9ff; padding: 2px 8px; border-radius: 4px;
+      font-family: 'IBM Plex Sans', sans-serif; font-size: 12px;
+      color: #161616; margin: 0 2px;
+    }
+    .phrase strong { font-weight: 600; color: #161616; }
+    .phrase em { color: #0072c3; font-style: normal; font-weight: 500; }
+
+    .summary {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px; margin-top: 4px;
+    }
+
+    /* Type chips */
+    .type-chip {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 11px; font-weight: 600; padding: 3px 8px; border-radius: 4px;
+      text-transform: uppercase; letter-spacing: 0.4px;
+    }
+    .type-chip.rule  { background: #d0e2ff; color: #0043ce; }
+    .type-chip.algo  { background: #e8daff; color: #491d8b; }
+    .type-chip.calc  { background: #defbe6; color: #0e6027; }
+    .type-chip.mcalc { background: #fff8e1; color: #b28600; }
+
+    /* Toolbar */
+    .toolbar {
+      display: flex; gap: 0.5rem; align-items: center; justify-content: space-between;
+      background: #fff; padding: 0.5rem 1rem; border: 1px solid #e0e0e0; border-bottom: none;
+    }
+    .toolbar-left { display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap; }
+    .search-input {
+      border: none; border-bottom: 1px solid #8d8d8d; padding: 6px 10px; width: 260px;
+      font-size: 14px; background: #f4f4f4;
+    }
+    .filter-pill {
+      background: #f4f4f4; padding: 4px 10px; font-size: 12px; border-radius: 999px;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .filter-pill.active { background: #d0e2ff; color: #0043ce; border-color: #4589ff; }
+
+    /* New button + menu */
+    .new-btn-wrap { position: relative; display: inline-block; }
+    .new-menu {
+      position: absolute; top: 100%; right: 0; margin-top: 4px;
+      background: #fff; border: 1px solid #c6c6c6;
+      min-width: 280px; z-index: 5;
+      box-shadow: 0 2px 12px rgba(0,0,0,0.08);
+    }
+    .new-menu .item {
+      padding: 10px 14px; cursor: pointer; display: flex; flex-direction: column; gap: 2px;
+      border-bottom: 1px solid #f4f4f4;
+    }
+    .new-menu .item:hover { background: #edf5ff; }
+    .new-menu .item:last-child { border-bottom: none; }
+    .new-menu .item-name { font-size: 13px; font-weight: 600; color: #161616; }
+    .new-menu .item-desc { font-size: 11px; color: #6f6f6f; }
+
+    /* Data table */
+    table.cds--data-table { width: 100%; background: #fff; border: 1px solid #e0e0e0; border-top: none; }
+    table.cds--data-table th { font-size: 12px; }
+    table.cds--data-table td { vertical-align: top; padding: 0.75rem 1rem; }
+    .rule-name { font-weight: 600; color: #161616; }
+
+    .when-then {
+      display: flex; align-items: center; gap: 0.5rem; margin-top: 4px;
+      flex-wrap: wrap;
+    }
+    .when-then .label {
+      font-size: 10px; padding: 2px 6px; border-radius: 999px; font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    .when-then .label.w { background: #fff8e1; color: #b28600; }
+    .when-then .label.t { background: #defbe6; color: #0e6027; }
+    .when-then .arrow { color: #525252; }
+    .summary-text {
+      font-family: 'IBM Plex Mono', monospace; font-size: 12px;
+    }
+
+    /* Tests involved column */
+    .test-chips { display: flex; gap: 4px; flex-wrap: wrap; }
+    .test-chip {
+      background: #f4f4f4; color: #161616;
+      padding: 2px 8px; border-radius: 4px; font-size: 11px;
+      font-family: 'IBM Plex Mono', monospace;
+      cursor: pointer; border: 1px solid #e0e0e0;
+    }
+    .test-chip.input  { border-color: #a2191f; color: #a2191f; }
+    .test-chip.output { border-color: #198038; color: #0e6027; }
+    .test-chip.both   { border-color: #0043ce; color: #0043ce; }
+    .test-chip:hover { background: #edf5ff; border-color: #0f62fe; color: #0f62fe; }
+
+    /* Open-in-editor link for algos / multi-step */
+    .open-editor-row {
+      background: #f4f4f4; padding: 1rem 1.5rem; border-top: 2px solid #491d8b;
+      display: flex; justify-content: space-between; align-items: center;
+    }
+    .open-editor-row.calc { border-color: #b28600; }
+    .open-editor-row .left { display: flex; flex-direction: column; gap: 4px; }
+    .open-editor-row .title { font-size: 14px; font-weight: 600; }
+    .open-editor-row .desc { font-size: 12px; color: #525252; }
+    .open-editor-row .right { display: flex; gap: 0.5rem; align-items: center; }
+
+    /* Inline rule editor (when simple rule is expanded) */
+    .inline-rule-editor {
+      background: #f4f4f4; padding: 1.25rem; border-top: 2px solid #0f62fe;
+    }
+    .inline-rule-editor .editor-grid {
+      display: grid; grid-template-columns: 1.2fr 1fr; gap: 1rem;
+    }
+    .panel {
+      background: #fff; padding: 1rem; border: 1px solid #e0e0e0;
+    }
+    .panel h4 {
+      margin: 0 0 0.75rem; font-size: 14px; font-weight: 600;
+      display: flex; align-items: center; gap: 0.5rem;
+    }
+    .panel h4 .pill {
+      background: #d0e2ff; color: #0043ce; font-size: 10px;
+      padding: 2px 8px; border-radius: 999px; font-weight: 500;
+    }
+    .field-row { display: flex; gap: 0.75rem; margin-bottom: 0.5rem; align-items: end; }
+    .field-row label { font-size: 12px; color: #525252; display: block; margin-bottom: 4px; }
+    .field-row input, .field-row select {
+      padding: 6px 10px; border: none; border-bottom: 1px solid #8d8d8d;
+      background: #f4f4f4; font-size: 13px; width: 100%;
+    }
+    .footer-actions {
+      display: flex; gap: 0.5rem; justify-content: flex-end; margin-top: 0.75rem;
+    }
+
+    /* Side panel — test catalog cross-reference */
+    .layout-grid {
+      display: grid; grid-template-columns: 1fr 320px; gap: 1rem;
+    }
+    .side-panel {
+      background: #fff; border: 1px solid #e0e0e0; padding: 1rem;
+      align-self: start; position: sticky; top: 1rem;
+    }
+    .side-panel h4 {
+      margin: 0 0 0.5rem; font-size: 13px; font-weight: 600;
+    }
+    .side-panel .test-card {
+      padding: 8px 10px; border: 1px solid #e0e0e0; margin-bottom: 6px;
+      font-size: 12px;
+    }
+    .side-panel .test-card .tname { font-weight: 600; color: #161616; }
+    .side-panel .test-card .tmeta {
+      font-size: 11px; color: #6f6f6f; font-family: 'IBM Plex Mono', monospace;
+    }
+    .side-panel .test-card .role {
+      font-size: 10px; padding: 1px 6px; border-radius: 3px;
+      margin-right: 4px;
+    }
+    .side-panel .test-card .role.input  { background: #fff1f1; color: #a2191f; }
+    .side-panel .test-card .role.output { background: #defbe6; color: #0e6027; }
+    .side-panel .test-card .role.intermediate { background: #d0e2ff; color: #0043ce; }
+    .catalog-link {
+      display: block; margin-top: 0.75rem; padding: 0.5rem; background: #edf5ff;
+      font-size: 12px; color: #0043ce; text-decoration: none; text-align: center;
+      border: 1px solid #4589ff;
+    }
+    .catalog-link:hover { background: #d0e2ff; }
+
+    .compact-hint { font-size: 11px; color: #6f6f6f; font-style: italic; }
+
+    /* Empty state */
+    .empty-state {
+      padding: 3rem 2rem; text-align: center;
+      background: #fff; border: 1px solid #e0e0e0; border-top: none;
+    }
+    .empty-state .icon { font-size: 32px; color: #8d8d8d; margin-bottom: 0.5rem; }
+    .empty-state .title { font-size: 16px; font-weight: 600; color: #161616; margin-bottom: 4px; }
+    .empty-state .desc { font-size: 13px; color: #525252; margin-bottom: 1rem; }
+
+    /* Batch action bar — shows when items are selected */
+    .batch-bar {
+      display: flex; align-items: center; gap: 0.5rem; justify-content: space-between;
+      background: #0043ce; color: #fff; padding: 0.5rem 1rem;
+      border: 1px solid #0043ce; border-bottom: none;
+    }
+    .batch-bar .count { font-size: 13px; font-weight: 600; }
+    .batch-bar .actions { display: flex; gap: 0.5rem; }
+    .batch-bar button {
+      background: rgba(255,255,255,0.15); border: 1px solid rgba(255,255,255,0.3); color: #fff;
+      padding: 4px 10px; font-size: 12px; cursor: pointer;
+    }
+    .batch-bar button:hover { background: rgba(255,255,255,0.25); }
+    .batch-bar button.danger { border-color: #fa4d56; }
+    .batch-bar .clear { background: none; border: none; color: #fff; cursor: pointer; padding: 4px; }
+
+    /* Counts row */
+    .count-row {
+      display: flex; gap: 1.5rem; margin-bottom: 0.75rem; font-size: 13px; color: #525252;
+    }
+    .count-row .c { display: flex; align-items: center; gap: 6px; }
+    .count-row .num {
+      font-weight: 600; font-size: 16px; color: #161616;
+    }
+  </style>
+</head>
+<body class="cds--white">
+  <div class="preview-banner">
+    Visual Preview — Test Rules unified list view &nbsp;|&nbsp; OpenELIS Design Mockup &nbsp;|&nbsp; Not a live application
+  </div>
+  <div id="boot-status" style="padding: 1rem 2rem; font-size: 13px; color: #525252; font-family: monospace;">
+    Loading… <span id="boot-detail">if this message persists, check the browser console for errors.</span>
+  </div>
+  <div class="preview-content" id="root"></div>
+
+  <script>
+    // Visible boot diagnostics so the page never silently dies on a CDN miss.
+    window.addEventListener('error', function (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1';
+        s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Error:</strong> ' + (e.message || 'unknown') +
+          (e.filename ? ' &nbsp; <em>' + e.filename + ':' + e.lineno + '</em>' : '');
+      }
+    });
+    function _checkDeps() {
+      var missing = [];
+      if (typeof React === 'undefined') missing.push('React');
+      if (typeof ReactDOM === 'undefined') missing.push('ReactDOM');
+      if (typeof Babel === 'undefined') missing.push('Babel');
+      var s = document.getElementById('boot-detail');
+      if (missing.length) {
+        s.textContent = 'Missing dependencies: ' + missing.join(', ') + '. Check the network tab for blocked CDNs (cdnjs.cloudflare.com, unpkg.com).';
+        s.style.color = '#a2191f';
+      } else {
+        s.textContent = 'Dependencies loaded. Mounting…';
+      }
+    }
+    window.addEventListener('load', _checkDeps);
+  </script>
+
+  <script type="text/babel">
+    const { useState } = React;
+
+    const KNOWN_TESTS = ['TSH','FT4','HIV_Screen','HIV_Conf','HIV_Tie','HIV_Status','TC','HDL','TRIG','LDL','SCr','Bili','INR','Na','MELD_Na','WBC','Diff','HGB','Retic','GLU','Lactate','Nitrites','Leuk','UC','StrepA','ThroatCx','CA','ALB','CorrCa','WT','HT','BMI','Trep','RPR','TPPA','Syph_Final','Sputum','GeneXpert','DST','TB_Final'];
+    const KEYWORDS = ['AND','OR','NOT','IN'];
+    const PREDICATES = ['isNormal','isOutsideNormal','isAboveNormal','isBelowNormal','isCritical','isCriticallyHigh','isCriticallyLow','isFlagged','changedSignificantly','isReactive','isPositive','isAnyOf'];
+    function tokenize(text) {
+      const re = /("[^"]*")|(\d+(?:\.\d+)?)|([A-Za-z_][A-Za-z0-9_]*)|(==|!=|>=|<=|>|<|=|\+|-|\*|\/)|([(),])|(\s+)|(.)/g;
+      const out = []; let m;
+      while ((m = re.exec(text)) !== null) {
+        if (m[1]) out.push({k:'str', t:m[1]});
+        else if (m[2]) out.push({k:'num', t:m[2]});
+        else if (m[3]) {
+          if (KEYWORDS.includes(m[3].toUpperCase())) out.push({k:'bool', t:m[3]});
+          else if (PREDICATES.includes(m[3])) out.push({k:'pred', t:m[3]});
+          else if (['min','max','log','ln','round','if','eq','pow'].includes(m[3])) out.push({k:'fn', t:m[3]});
+          else if (['Age','Sex','Sample'].includes(m[3])) out.push({k:'attr', t:m[3]});
+          else if (KNOWN_TESTS.includes(m[3])) out.push({k:'var', t:m[3]});
+          else out.push({k:'var', t:m[3]});
+        }
+        else if (m[4]) out.push({k:'op', t:m[4]});
+        else if (m[5]) out.push({k:'paren', t:m[5]});
+        else if (m[6]) out.push({k:'ws', t:m[6]});
+        else out.push({k:'other', t:m[7]});
+      }
+      return out;
+    }
+    const PREDICATE_SHORT = {
+      isNormal: 'is within normal',
+      isOutsideNormal: 'is outside normal',
+      isAboveNormal: 'is above normal',
+      isBelowNormal: 'is below normal',
+      isCritical: 'is critical',
+      isCriticallyHigh: 'is critically high',
+      isCriticallyLow: 'is critically low',
+      isFlagged: 'is flagged',
+      changedSignificantly: 'changed significantly',
+      isReactive: 'is reactive',
+      isPositive: 'is positive',
+      isAnyOf: 'is one of…',
+    };
+
+    function Tokenized({ text }) {
+      const tokens = tokenize(text);
+      const out = [];
+      let i = 0;
+      while (i < tokens.length) {
+        const t = tokens[i];
+        if (t.k === 'pred' &&
+            tokens[i+1] && tokens[i+1].k === 'paren' && tokens[i+1].t === '(' &&
+            tokens[i+2] && tokens[i+2].k === 'var' &&
+            tokens[i+3] && tokens[i+3].k === 'paren' && tokens[i+3].t === ')') {
+          const phrase = PREDICATE_SHORT[t.t];
+          const testId = tokens[i+2].t;
+          if (phrase) {
+            out.push(
+              <span key={i} className="phrase">
+                <strong>{testId}</strong> <em>{phrase}</em>
+              </span>
+            );
+            i += 4;
+            continue;
+          }
+        }
+        out.push(<span key={i} className={t.k === 'ws' ? '' : 'tok-' + t.k}>{t.t}</span>);
+        i++;
+      }
+      return <span className="summary-text">{out}</span>;
+    }
+
+    // ========================================================================
+    // UNIFIED RULES DATA — mix of types
+    // ========================================================================
+    const ITEMS = [
+      {
+        id: 1, type: 'rule', name: 'TSH abnormal → reflex Free T4',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isOutsideNormal(TSH)', then: 'Order Free T4' },
+        tests: [{ id: 'TSH', role: 'input' }, { id: 'FT4', role: 'output' }],
+        trigger: 'On TSH result',
+        edited: '2026-04-22 by m.kone',
+      },
+      {
+        id: 2, type: 'algo', name: 'HIV 3-test national algorithm',
+        status: 'active',
+        summary: { kind: 'algo', nodes: 3, ends: 4, paths: 'Screen → Confirm → Tiebreaker' },
+        tests: [
+          { id: 'HIV_Screen', role: 'input' }, { id: 'HIV_Conf', role: 'intermediate' },
+          { id: 'HIV_Tie', role: 'intermediate' }, { id: 'HIV_Status', role: 'output' }
+        ],
+        trigger: 'On HIV_Status order',
+        edited: '2026-04-30 by p.diallo',
+      },
+      {
+        id: 3, type: 'calc', name: 'LDL Cholesterol (Friedewald)',
+        status: 'active',
+        summary: { kind: 'formula', text: 'LDL = TC - HDL - TRIG / 5' },
+        tests: [{ id: 'TC', role: 'input' }, { id: 'HDL', role: 'input' }, { id: 'TRIG', role: 'input' }, { id: 'LDL', role: 'output' }],
+        trigger: 'On all inputs resulted',
+        edited: '2026-04-28 by p.diallo',
+      },
+      {
+        id: 12, type: 'calc', name: 'TB GenoType Resistance Interpretation', outputKind: 'coded',
+        status: 'active',
+        summary: { kind: 'formula', text: 'Decision table: 4 rules + Otherwise · maps band pattern + melting points to 6 categories' },
+        tests: [
+          { id: 'TB_GT', role: 'input' },
+          { id: 'TB_INTERP', role: 'output' }
+        ],
+        trigger: 'On TB_GT result',
+        edited: '2026-05-08 by m.kone',
+      },
+      {
+        id: 4, type: 'mcalc', name: 'MELD-Na (Liver allocation)',
+        status: 'active',
+        summary: { kind: 'mcalc', steps: 6, finalText: 'MELD_Na (capped 6–40)' },
+        tests: [
+          { id: 'SCr', role: 'input' }, { id: 'Bili', role: 'input' },
+          { id: 'INR', role: 'input' }, { id: 'Na', role: 'input' },
+          { id: 'MELD_Na', role: 'output' }
+        ],
+        trigger: 'On all inputs resulted',
+        edited: '2026-03-22 by p.diallo',
+      },
+      {
+        id: 5, type: 'rule', name: 'WBC critically high → manual differential',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isCriticallyHigh(WBC)', then: 'Order Manual Diff' },
+        tests: [{ id: 'WBC', role: 'input' }, { id: 'Diff', role: 'output' }],
+        trigger: 'On WBC result',
+        edited: '2026-03-12 by m.kone',
+      },
+      {
+        id: 6, type: 'calc', name: 'BMI', status: 'active',
+        summary: { kind: 'formula', text: 'BMI = WT / pow(HT, 2)' },
+        tests: [{ id: 'WT', role: 'input' }, { id: 'HT', role: 'input' }, { id: 'BMI', role: 'output' }],
+        trigger: 'On WT + HT resulted',
+        edited: '2026-04-12 by m.kone',
+      },
+      {
+        id: 7, type: 'rule', name: 'Urine dipstick positive → culture',
+        status: 'active',
+        summary: { kind: 'whenThen', when: '(Nitrites == "Positive" OR Leuk IN ("++","+++"))', then: 'Order Urine Culture' },
+        tests: [{ id: 'Nitrites', role: 'input' }, { id: 'Leuk', role: 'input' }, { id: 'UC', role: 'output' }],
+        trigger: 'On dipstick result',
+        edited: '2026-02-28 by m.kone',
+      },
+      {
+        id: 8, type: 'algo', name: 'TB cascade (GeneXpert → DST)',
+        status: 'disabled',
+        summary: { kind: 'algo', nodes: 4, ends: 6, paths: 'Sputum → GX → DST → 2nd-line' },
+        tests: [
+          { id: 'Sputum', role: 'input' }, { id: 'GeneXpert', role: 'intermediate' },
+          { id: 'DST', role: 'intermediate' }, { id: 'TB_Final', role: 'output' }
+        ],
+        trigger: 'On TB_Final order',
+        edited: '2026-01-04 by p.diallo',
+      },
+      {
+        id: 9, type: 'calc', name: 'Corrected Calcium', status: 'active',
+        summary: { kind: 'formula', text: 'CorrCa = CA + 0.8 * (4 - ALB)' },
+        tests: [{ id: 'CA', role: 'input' }, { id: 'ALB', role: 'input' }, { id: 'CorrCa', role: 'output' }],
+        trigger: 'On Ca + Alb resulted',
+        edited: '2026-04-21 by m.kone',
+      },
+      {
+        id: 10, type: 'rule', name: 'Critical glucose → alert + lactate',
+        status: 'active',
+        summary: { kind: 'whenThen', when: 'isCritical(GLU)', then: 'Critical Alert + STAT Lactate' },
+        tests: [{ id: 'GLU', role: 'input' }, { id: 'Lactate', role: 'output' }],
+        trigger: 'On GLU result',
+        edited: '2026-04-05 by m.kone',
+      },
+      {
+        id: 11, type: 'algo', name: 'Syphilis reverse algorithm',
+        status: 'active',
+        summary: { kind: 'algo', nodes: 3, ends: 4, paths: 'Treponemal → RPR → TPPA' },
+        tests: [
+          { id: 'Trep', role: 'input' }, { id: 'RPR', role: 'intermediate' },
+          { id: 'TPPA', role: 'intermediate' }, { id: 'Syph_Final', role: 'output' }
+        ],
+        trigger: 'On Syph_Final order',
+        edited: '2025-11-29 by p.diallo',
+      },
+    ];
+
+    // Counts
+    const COUNTS = ITEMS.reduce((acc, x) => {
+      acc[x.type] = (acc[x.type] || 0) + 1;
+      acc.total++;
+      if (x.status === 'active') acc.active++;
+      return acc;
+    }, { total: 0, active: 0 });
+
+    function TestChips({ tests }) {
+      return (
+        <div className="test-chips">
+          {tests.map(t => (
+            <span key={t.id} className={'test-chip ' + t.role} title={
+              t.role === 'input' ? 'Read by this rule' :
+              t.role === 'output' ? 'Written by this rule (test in catalog)' :
+              'Decision step in the algorithm'
+            }>
+              {t.id}
+            </span>
+          ))}
+        </div>
+      );
+    }
+
+    function ItemSummary({ item }) {
+      const s = item.summary;
+      if (s.kind === 'whenThen') {
+        return (
+          <div className="when-then">
+            <span className="label w">WHEN</span>
+            <Tokenized text={s.when} />
+            <span className="arrow">→</span>
+            <span className="label t">THEN</span>
+            <span style={{ color: '#0e6027', fontFamily: "'IBM Plex Mono', monospace", fontSize: 12 }}>{s.then}</span>
+          </div>
+        );
+      }
+      if (s.kind === 'formula') {
+        return <div className="summary"><Tokenized text={s.text} /></div>;
+      }
+      if (s.kind === 'algo') {
+        return (
+          <div className="summary" style={{ display: 'flex', gap: 12, alignItems: 'center', color: '#525252' }}>
+            <span><strong>{s.nodes}</strong> decision steps · <strong>{s.ends}</strong> end states</span>
+            <span style={{ color: '#491d8b', fontFamily: 'monospace' }}>{s.paths}</span>
+          </div>
+        );
+      }
+      if (s.kind === 'mcalc') {
+        return (
+          <div className="summary" style={{ color: '#525252' }}>
+            <strong>{s.steps}</strong> named intermediates → <span style={{ color: '#0e6027', fontFamily: 'monospace' }}>{s.finalText}</span>
+          </div>
+        );
+      }
+      return null;
+    }
+
+    function TypeChip({ type }) {
+      const labels = { rule: 'Rule', algo: 'Algorithm', calc: 'Calc', mcalc: 'Multi-step Calc' };
+      return <span className={'type-chip ' + type}>{labels[type]}</span>;
+    }
+
+    // ========================================================================
+    // INLINE RULE EDITOR (only for type='rule' — simple WHEN/THEN)
+    // ========================================================================
+    function InlineRuleEditor({ item }) {
+      const [when, setWhen] = useState(item.summary.when);
+      // Which dedicated preview corresponds to this item?
+      const dedicatedPreview = item.type === 'rule' ? 'reflex-tests-redesign-preview.html'
+        : (item.type === 'calc' && item.outputKind === 'coded') ? 'calc-decision-table-preview.html'
+        : 'calculated-values-redesign-v2-preview.html';
+      const editorName = item.type === 'rule' ? 'Reflex rule editor'
+        : (item.type === 'calc' && item.outputKind === 'coded') ? 'Coded Calculation editor (Decision Table)'
+        : 'Numeric Calculation editor (Formula bar)';
+      return (
+        <tr>
+          <td colSpan={7} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className="inline-rule-editor">
+              {/* Cross-preview navigation banner */}
+              <div style={{
+                background: '#edf5ff', border: '1px solid #4589ff', borderLeft: '3px solid #0f62fe',
+                padding: '0.5rem 0.75rem', marginBottom: 12, fontSize: 12, color: '#0043ce',
+                display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap'
+              }}>
+                <span style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: 0.5, fontWeight: 700 }}>
+                  Editor preview
+                </span>
+                <span style={{ color: '#525252' }}>
+                  This is the inline editor for a <strong>{item.type === 'rule' ? 'Reflex rule' : 'Calculation'}</strong>.
+                  See the full-width version with all states + interactivity:
+                </span>
+                <a href={dedicatedPreview}
+                   style={{ marginLeft: 'auto', background: '#0f62fe', color: '#fff', padding: '4px 12px',
+                            textDecoration: 'none', fontSize: 12, fontWeight: 600, borderRadius: 3 }}>
+                  Open {editorName} →
+                </a>
+              </div>
+              <div style={{ display: 'flex', gap: 8, marginBottom: 12 }}>
+                <span className="cds--tag cds--tag--blue">Editing inline</span>
+                <span className="cds--tag cds--tag--green">Active</span>
+                <span className="cds--tag cds--tag--warm-gray">Single decision point</span>
+              </div>
+
+              <div className="editor-grid">
+                <div className="panel">
+                  <h4>Rule definition <span className="pill">WHEN / THEN</span></h4>
+                  <div className="field-row">
+                    <div style={{ flex: 1 }}>
+                      <label>Name</label>
+                      <input type="text" defaultValue={item.name} />
+                    </div>
+                  </div>
+                  <div style={{ marginTop: 12 }}>
+                    <div style={{ fontSize: 10, fontWeight: 700, color: '#b28600', background: '#fff8e1', display: 'inline-block', padding: '3px 10px', borderRadius: 999, marginBottom: 6 }}>WHEN</div>
+                    <div style={{ background: '#fff', border: '1px solid #8d8d8d', padding: '8px 12px', fontFamily: 'IBM Plex Mono', fontSize: 14 }}>
+                      <Tokenized text={when} />
+                    </div>
+                    <div className="compact-hint" style={{ marginTop: 4 }}>
+                      Inline formula bar — same syntax as the algorithm decision tables.
+                    </div>
+                  </div>
+                  <div style={{ marginTop: 12 }}>
+                    <div style={{ fontSize: 10, fontWeight: 700, color: '#0e6027', background: '#defbe6', display: 'inline-block', padding: '3px 10px', borderRadius: 999, marginBottom: 6 }}>THEN</div>
+                    <div style={{ background: '#fff', border: '1px solid #e0e0e0', padding: '8px 12px', fontSize: 13 }}>
+                      <span style={{ background: '#d0e2ff', color: '#0043ce', padding: '2px 8px', borderRadius: 4, fontSize: 11, fontWeight: 600, marginRight: 6 }}>Order Test</span>
+                      {item.summary.then}
+                    </div>
+                  </div>
+                </div>
+                <div className="panel">
+                  <h4>Test catalog references <span className="pill" style={{ background: '#e8daff', color: '#491d8b' }}>FYI</span></h4>
+                  <div className="compact-hint" style={{ marginBottom: 8 }}>
+                    Every test this rule touches is a real entry in the Test Catalog. Click any chip to jump to its catalog page.
+                  </div>
+                  {item.tests.map(t => (
+                    <div key={t.id} style={{ padding: 6, borderBottom: '1px solid #f4f4f4', display: 'flex', justifyContent: 'space-between', fontSize: 12 }}>
+                      <span style={{ fontFamily: 'monospace', fontWeight: 600 }}>{t.id}</span>
+                      <span style={{ color: '#6f6f6f' }}>
+                        {t.role === 'input' ? 'Reads result' : t.role === 'output' ? 'Writes result' : 'Decision step'}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+              <div className="footer-actions">
+                <button className="cds--btn cds--btn--secondary">Cancel</button>
+                <button className="cds--btn cds--btn--primary">Save changes</button>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // OPEN-IN-EDITOR ROW (for algo / mcalc — full-page editors)
+    // ========================================================================
+    function OpenEditorRow({ item }) {
+      const isCalc = item.type === 'mcalc';
+      return (
+        <tr>
+          <td colSpan={7} style={{ padding: 0, background: '#f4f4f4' }}>
+            <div className={'open-editor-row' + (isCalc ? ' calc' : '')}>
+              <div className="left">
+                <div className="title">
+                  This is a {item.type === 'algo' ? 'multi-step algorithm' : 'multi-step calculation'} —
+                  it doesn't edit inline.
+                </div>
+                <div className="desc">
+                  {item.type === 'algo'
+                    ? `${item.summary.nodes} decision steps wired together with ${item.summary.ends} end states. The workflow editor takes over a full screen so the graph has room to breathe.`
+                    : `${item.summary.steps} named intermediate values feeding a final output. The multi-step editor shows the dependency graph plus each step's formula bar.`}
+                </div>
+                <div className="desc" style={{ marginTop: 4 }}>
+                  Tests touched: <TestChips tests={item.tests} />
+                </div>
+              </div>
+              <div className="right">
+                <span style={{ background: '#f1c21b', color: '#6b4a00', padding: '2px 8px', borderRadius: 3, fontSize: 10, fontWeight: 700, alignSelf: 'center', marginRight: 8 }}>PHASE 2</span>
+                <a href="algorithm-as-graph-preview.html"
+                   style={{ background: '#0f62fe', color: '#fff', padding: '6px 14px', textDecoration: 'none',
+                            fontSize: 12, fontWeight: 600, borderRadius: 3 }}>
+                  Open in {item.type === 'algo' ? 'Algorithm Editor' : 'Multi-step Editor'} →
+                </a>
+              </div>
+            </div>
+          </td>
+        </tr>
+      );
+    }
+
+    // ========================================================================
+    // SIDE PANEL — Test Catalog cross-reference for a selected item
+    // ========================================================================
+    function CatalogPanel({ item }) {
+      if (!item) {
+        return (
+          <div className="side-panel">
+            <h4>Test catalog references</h4>
+            <div className="compact-hint">
+              Click any rule, algorithm, or multi-step calc to see which tests it touches and how.
+            </div>
+          </div>
+        );
+      }
+      return (
+        <div className="side-panel">
+          <h4>Tests touched by "{item.name}"</h4>
+          <div className="compact-hint" style={{ marginBottom: 8 }}>
+            Every test below is a real entry in the Test Catalog. The rule is glue between them — it doesn't create new test types.
+          </div>
+          {item.tests.map(t => (
+            <div key={t.id} className="test-card">
+              <div className="tname">
+                <span className={'role ' + t.role}>{t.role}</span>
+                {t.id}
+              </div>
+              <div className="tmeta">
+                {t.role === 'input' && 'Rule reads this test\'s result'}
+                {t.role === 'output' && 'Rule writes a result back to this test'}
+                {t.role === 'intermediate' && 'Algorithm orders this test at a decision step'}
+              </div>
+            </div>
+          ))}
+          <a href="#" className="catalog-link">→ Open Test Catalog</a>
+          <h4 style={{ marginTop: 16 }}>Trigger mode</h4>
+          <div style={{ fontSize: 12, color: '#525252' }}>
+            <strong>{item.trigger}</strong>
+          </div>
+          <div className="compact-hint" style={{ marginTop: 4 }}>
+            {item.trigger.includes('order')
+              ? 'Provider orders the output test; the rule cascade runs underneath. Provider doesn\'t see the cascade.'
+              : 'Rule reads the trigger result and decides what (if anything) to order next.'}
+          </div>
+        </div>
+      );
+    }
+
+    // ========================================================================
+    // APP
+    // ========================================================================
+    function App() {
+      const [expandedId, setExpandedId] = useState(1);
+      const [newMenuOpen, setNewMenuOpen] = useState(false);
+      const [typeFilter, setTypeFilter] = useState('all');
+      const [briefOpen, setBriefOpen] = useState(true);
+      const [selectedIds, setSelectedIds] = useState(new Set());
+      const [demoEmpty, setDemoEmpty] = useState(false);  // For showcasing empty state
+
+      const selected = ITEMS.find(i => i.id === expandedId);
+      const filtered = demoEmpty ? [] : (typeFilter === 'all' ? ITEMS : ITEMS.filter(i => i.type === typeFilter));
+
+      const toggleSel = (id) => setSelectedIds(s => {
+        const ns = new Set(s); if (ns.has(id)) ns.delete(id); else ns.add(id); return ns;
+      });
+      const allSelected = filtered.length > 0 && filtered.every(i => selectedIds.has(i.id));
+      const toggleAll = () => {
+        if (allSelected) setSelectedIds(s => { const ns = new Set(s); filtered.forEach(i => ns.delete(i.id)); return ns; });
+        else setSelectedIds(s => { const ns = new Set(s); filtered.forEach(i => ns.add(i.id)); return ns; });
+      };
+      const clearSel = () => setSelectedIds(new Set());
+
+      return (
+        <div>
+          <div className="breadcrumb">
+            <a href="#">Home</a> / <a href="#">Admin Management</a> / <span>Test Rules</span>
+          </div>
+          <h1 style={{ fontSize: 28, fontWeight: 400, margin: '0.5rem 0 1rem' }}>
+            Test Rules <span style={{ fontSize: 12, color: '#6f6f6f', fontWeight: 400, marginLeft: 8 }}>rules · algorithms · multi-step calculations</span>
+          </h1>
+
+          {briefOpen && (
+            <div className="brief-banner">
+              <strong>Design brief:</strong> One page for everything that wires Test Catalog entries
+              together — simple rules (WHEN/THEN reflex or arithmetic calc), algorithms (multi-step
+              workflows like HIV 3-test), and multi-step calculations (MELD-Na). The list view shows
+              all three types with type-aware summaries. <strong>Predicates</strong> like{' '}
+              <span className="tok-pred">isOutsideNormal(TSH)</span>,{' '}
+              <span className="tok-pred">isCriticallyHigh(WBC)</span>, and{' '}
+              <span className="tok-pred">isCritical(GLU)</span> replace hardcoded numeric thresholds —
+              the actual range comes from the Test Catalog, so a range change updates every rule
+              automatically. Simple rules expand <em>inline</em>; algorithms and multi-step calcs
+              open in <em>dedicated full-screen editors</em>. Every rule type reads and writes
+              ordinary tests in the Test Catalog.
+              <button onClick={() => setBriefOpen(false)}
+                      style={{ float: 'right', background: 'none', border: 'none', cursor: 'pointer', color: '#525252' }}>✕</button>
+            </div>
+          )}
+
+          {/* Counts */}
+          <div className="count-row">
+            <div className="c"><span className="num">{COUNTS.total}</span> total</div>
+            <div className="c"><span className="num">{COUNTS.active}</span> active</div>
+            <div className="c"><TypeChip type="rule" /> <span className="num">{COUNTS.rule || 0}</span></div>
+            <div className="c"><TypeChip type="algo" /> <span className="num">{COUNTS.algo || 0}</span></div>
+            <div className="c"><TypeChip type="calc" /> <span className="num">{COUNTS.calc || 0}</span></div>
+            <div className="c"><TypeChip type="mcalc" /> <span className="num">{COUNTS.mcalc || 0}</span></div>
+          </div>
+
+          {/* Toolbar */}
+          <div className="toolbar">
+            <div className="toolbar-left">
+              <input className="search-input" placeholder="Search by name, test, or formula text…" />
+              <span className={'filter-pill' + (typeFilter === 'all' ? ' active' : '')} onClick={() => setTypeFilter('all')}>All types</span>
+              <span className={'filter-pill' + (typeFilter === 'rule' ? ' active' : '')} onClick={() => setTypeFilter('rule')}>Rules</span>
+              <span className={'filter-pill' + (typeFilter === 'algo' ? ' active' : '')} onClick={() => setTypeFilter('algo')}>Algorithms</span>
+              <span className={'filter-pill' + (typeFilter === 'calc' ? ' active' : '')} onClick={() => setTypeFilter('calc')}>Calcs</span>
+              <span className={'filter-pill' + (typeFilter === 'mcalc' ? ' active' : '')} onClick={() => setTypeFilter('mcalc')}>Multi-step</span>
+              <span className="filter-pill">Status: All ▾</span>
+              <span className="filter-pill">Trigger test ▾</span>
+            </div>
+            <div className="new-btn-wrap">
+              <button className="cds--btn cds--btn--primary" style={{ fontSize: 13 }}
+                      onClick={() => setNewMenuOpen(o => !o)}>+ New ▾</button>
+              {newMenuOpen && (
+                <div className="new-menu">
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="rule" /> &nbsp;Simple rule</div>
+                    <div className="item-desc">One condition → one or more actions. Inline editor. Use for TSH reflex, critical alerts, single-condition reflexes.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="algo" /> &nbsp;Algorithm</div>
+                    <div className="item-desc">Multiple decision steps wired together. Workflow editor. Use for HIV cascade, TB cascade, syphilis reverse algorithm.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="calc" /> &nbsp;Simple calculation</div>
+                    <div className="item-desc">One formula bar. Inline editor. Use for BMI, A:G ratio, anion gap.</div>
+                  </div>
+                  <div className="item" onClick={() => setNewMenuOpen(false)}>
+                    <div className="item-name"><TypeChip type="mcalc" /> &nbsp;Multi-step calculation</div>
+                    <div className="item-desc">Named intermediates feeding a final output. Multi-step editor. Use for MELD-Na, eGFR with caps, full CKD-EPI.</div>
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Batch action bar appears when items are selected */}
+          {selectedIds.size > 0 && (
+            <div className="batch-bar" role="region" aria-label="Bulk actions">
+              <span className="count">{selectedIds.size} selected</span>
+              <div className="actions">
+                <button>Enable</button>
+                <button>Disable</button>
+                <button>Export CSV</button>
+                <button className="danger">Delete…</button>
+              </div>
+              <button className="clear" aria-label="Clear selection" onClick={clearSel}>✕</button>
+            </div>
+          )}
+
+          {/* Empty state when there are no rules to show */}
+          {filtered.length === 0 ? (
+            <div className="empty-state">
+              <div className="icon">📋</div>
+              <div className="title">No rules yet</div>
+              <div className="desc">
+                {demoEmpty
+                  ? 'This is the empty state — the page when a fresh deployment has no rules configured.'
+                  : 'No rules match your filters. Try clearing them or change the search.'}
+              </div>
+              <button className="cds--btn cds--btn--primary">+ Create your first rule</button>
+              <div style={{ marginTop: 8 }}>
+                <button className="cds--btn cds--btn--ghost"
+                        onClick={() => setDemoEmpty(d => !d)}
+                        style={{ fontSize: 11 }}>
+                  {demoEmpty ? '← Restore demo rules' : 'Show empty state'}
+                </button>
+              </div>
+            </div>
+          ) : (
+          <div className="layout-grid">
+            <div>
+              <div style={{ marginBottom: 8 }}>
+                <button className="cds--btn cds--btn--ghost"
+                        onClick={() => setDemoEmpty(d => !d)}
+                        style={{ fontSize: 11 }}>
+                  {demoEmpty ? '← Restore demo rules' : 'Show empty state'}
+                </button>
+              </div>
+              <table className="cds--data-table">
+                <thead>
+                  <tr>
+                    <th style={{ width: 36 }}>
+                      <input type="checkbox" checked={allSelected} onChange={toggleAll}
+                             aria-label="Select all rules" />
+                    </th>
+                    <th style={{ width: 40 }}></th>
+                    <th style={{ width: 130 }}>Type</th>
+                    <th style={{ width: 80 }}>Status</th>
+                    <th>Name / summary</th>
+                    <th>Tests touched</th>
+                    <th style={{ width: 150 }}>Trigger</th>
+                    <th style={{ width: 60 }}></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.map(item => {
+                    const isExpanded = expandedId === item.id;
+                    const isSelected = selectedIds.has(item.id);
+                    return (
+                    <React.Fragment key={item.id}>
+                      <tr style={{ background: isSelected ? '#edf5ff' : (isExpanded ? '#edf5ff' : 'transparent') }}>
+                        <td onClick={e => e.stopPropagation()}>
+                          <input type="checkbox" checked={isSelected}
+                                 onChange={() => toggleSel(item.id)}
+                                 aria-label={`Select ${item.name}`} />
+                        </td>
+                        <td style={{ cursor: 'pointer' }} onClick={() => setExpandedId(isExpanded ? null : item.id)}>
+                          <button aria-expanded={isExpanded}
+                                  aria-label={isExpanded ? 'Collapse rule' : 'Expand rule'}
+                                  style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: 14, color: '#0f62fe', padding: '4px 8px' }}>
+                            {isExpanded ? '▾' : '▸'}
+                          </button>
+                        </td>
+                        <td><TypeChip type={item.type} /></td>
+                        <td>
+                          {item.status === 'active'
+                            ? <span className="cds--tag cds--tag--green">Active</span>
+                            : <span className="cds--tag cds--tag--gray">Disabled</span>}
+                        </td>
+                        <td>
+                          <div className="rule-name">{item.name}</div>
+                          <ItemSummary item={item} />
+                        </td>
+                        <td><TestChips tests={item.tests} /></td>
+                        <td style={{ fontSize: 12, color: '#525252' }}>{item.trigger}</td>
+                        <td><span style={{ cursor: 'pointer', color: '#525252' }}>⋮</span></td>
+                      </tr>
+                      {isExpanded && (item.type === 'rule' || item.type === 'calc') && <InlineRuleEditor item={item} />}
+                      {isExpanded && (item.type === 'algo' || item.type === 'mcalc') && <OpenEditorRow item={item} />}
+                    </React.Fragment>
+                    );
+                  })}
+                </tbody>
+              </table>
+              <p style={{ fontSize: 11, color: '#6f6f6f', marginTop: 6, fontStyle: 'italic' }}>
+                Select rows via the checkbox at left to reveal the batch action bar (Enable / Disable / Export / Delete).
+              </p>
+            </div>
+            <CatalogPanel item={selected} />
+          </div>
+          )}
+
+          <div style={{ marginTop: '1.5rem', fontSize: 12, color: '#525252', lineHeight: 1.6 }}>
+            <strong>Data-model recap:</strong> every test referenced by a rule — input, intermediate
+            decision step, or output — is a regular entry in the Test Catalog. A rule is glue between
+            existing catalog entries. <em>Algorithm</em> and <em>multi-step calculation</em> introduce
+            no new result types; they just write into ordinary tests. Reporting, validation, manual
+            override, and FHIR ServiceRequest / Observation interoperability all work without
+            modification. The Test Catalog itself gets a corresponding cross-reference:
+            each test card shows "Used by 2 rules, 1 algorithm" so you can navigate from either side.
+            <br/><br/>
+            <strong>Trigger modes:</strong> rules trigger on a result; algorithms can trigger either
+            on a result (legacy reflex pattern) or on an order of the final-output test (cascade is
+            invisible to the provider). The trigger mode is a top-level field on the algorithm — same
+            distinction that Beckman REMISOL and Roche cobas IT use for cascades.
+          </div>
+        </div>
+      );
+    }
+
+    try {
+      ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+      var s = document.getElementById('boot-status');
+      if (s) s.style.display = 'none';
+    } catch (e) {
+      var s = document.getElementById('boot-status');
+      if (s) {
+        s.style.background = '#fff1f1';
+        s.style.color = '#a2191f';
+        s.style.borderLeft = '3px solid #da1e28';
+        s.innerHTML = '<strong>Render error:</strong> ' + e.message + '<pre style="font-size:11px;">' + (e.stack || '').split('\n').slice(0,6).join('\n') + '</pre>';
+      }
+    }
+  </script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -271,6 +271,19 @@ export const MOCKUP_REGISTRY = [
     githubIssue: 101,
     tags: ['admin', 'roadmap', 'planning', 'phase-5'],
   },
+  {
+    name: 'Test Rules Authoring Redesign — MVP',
+    category: 'admin-config',
+    component: null,
+    description: 'Unified replacement for the legacy Reflex Tests Management and Calculated Value Tests Management admin pages — one route at /admin/testRules. List view mixes Rules + Calculations + Algorithms + Multi-step calcs. Inline row expansion for simple rule authoring; dedicated full-width editors for Reflex (WHEN/THEN compose + formula bar), Numeric Calc (formula bar + live preview + flowchart), and Coded Calc (decision table, e.g. TB GenoType interpretation). Algorithm-as-graph canvas is Phase 2 reference. All five previews are cross-linked — open the list view and click through. FRS: 43 numbered FRs, full AST data model, 29 acceptance criteria, ~100 i18n keys.',
+    specPath: 'designs/admin-config/test-rules-mvp-frs.md',
+    htmlUrl: 'designs/admin-config/test-rules-list-view-preview.html',
+    added: '2026-05-12',
+    status: 'draft',
+    githubIssue: null,
+    jira: [],
+    tags: ['admin', 'test-rules', 'reflex', 'calculated-values', 'decision-table', 'formula-bar', 'analyzer-parameters', 'predicate-vocabulary', 'MVP', 'global'],
+  },
 
   // ─── Analyzer Integration ───
   {


### PR DESCRIPTION
Registers unified /admin/testRules page replacing legacy Reflex Tests Management and Calculated Value Tests Management admin pages.

One gallery entry (list view as canonical). Five cross-linked HTML previews all in designs/admin-config/ so relative hrefs are preserved:
  - test-rules-list-view-preview.html  (entry point, 12 sample rows)
  - reflex-tests-redesign-preview.html  (WHEN/THEN compose + formula bar)
  - calculated-values-redesign-v2-preview.html  (numeric calc, formula bar)
  - calc-decision-table-preview.html  (coded calc, TB GenoType example)
  - algorithm-as-graph-preview.html  (Phase 2 DMN canvas reference)

FRS: 43 FRs, full AST data model, 29 acceptance criteria, ~100 i18n keys.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
