### PR TITLE
fix: Lock → Locked icon (Carbon icons-react doesn't export Lock)

### DIFF
--- a/designs/sample-collection/pre-analytical-eligibility-gate.jsx
+++ b/designs/sample-collection/pre-analytical-eligibility-gate.jsx
@@ -48,7 +48,7 @@ import {
   Warning,
   Add,
   TrashCan,
-  Lock,
+  Locked,
   ArrowRight,
   Renew,
   Download,
@@ -489,7 +489,7 @@ function Screen1EligibilityAssessment() {
                             {severityTag(c.severity)}
                             {c.autoComputed && (
                               <>
-                                <Tag kind="gray" size="sm" renderIcon={Lock}>
+                                <Tag kind="gray" size="sm" renderIcon={Locked}>
                                   {t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}
                                 </Tag>
                                 {c.sourceData && (
@@ -1678,7 +1678,7 @@ function Screen6VectorVariant() {
                           {severityTag(c.severity)}
                           {c.autoComputed && (
                               <>
-                                <Tag kind="gray" size="sm" renderIcon={Lock}>{t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}</Tag>
+                                <Tag kind="gray" size="sm" renderIcon={Locked}>{t('label.eligibility.criterionAutoComputed', 'Auto-evaluated')}</Tag>
                                 {c.sourceData && (
                                   <Button kind="ghost" size="sm"
                                     onClick={() => toggleVectorSource(c.id)}


### PR DESCRIPTION
pre-analytical-eligibility-gate.jsx (merged in #88) imported Lock from @carbon/icons-react, but the exported name is Locked. Tests pass in jsdom because it doesn't strictly check tree-shaking, but Rollup's production build fails. This broke main's deploy since #88 merged — the gallery has not updated since.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
