### PR TITLE
feat(mockups): OGC-775 expanded-uncertainty + OGC-777 trap-detail fields

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -2663,3 +2663,55 @@
     - global
   added: "2026-05-27"
   status: draft
+
+- id: results-entry-expanded-uncertainty
+  type: both
+  path: designs/results-validation/results-entry-expanded-uncertainty.jsx
+  spec: designs/results-validation/results-entry-expanded-uncertainty.md
+  preview: designs/results-validation/results-entry-expanded-uncertainty.html
+  category: results-validation
+  description: >
+    Results Entry screen enhancement for OGC-775 (S-15a MVP). Adds an optional
+    U (k=2) numeric column to the results table for ISO 17025 §7.8.3.1(c)
+    expanded measurement uncertainty capture. Backward-compatible — labs without
+    uncertainty leave the cell blank. The LHU v2.0 conditional U column reads
+    this value when populated. MVP scope only.
+  links:
+    jira: ["OGC-775", "OGC-552", "OGC-527"]
+    gallery: https://digi-uw.github.io/openelis-work/#/results-validation/results-entry-expanded-uncertainty
+    preview: https://digi-uw.github.io/openelis-work/designs/results-validation/results-entry-expanded-uncertainty.html
+  tags:
+    - results-entry
+    - iso-17025
+    - measurement-uncertainty
+    - lhu-v2
+  added: "2026-05-28"
+  status: draft
+
+- id: collection-lot-trap-details
+  type: both
+  path: designs/vector-surveillance/collection-lot-trap-details.jsx
+  spec: designs/vector-surveillance/collection-lot-trap-details.md
+  preview: designs/vector-surveillance/collection-lot-trap-details.html
+  category: vector-surveillance
+  description: >
+    V-02 Vector Collection Workflow form enhancement for OGC-777 (V-05a STRETCH).
+    Adds a "Trap Configuration" section to the existing CollectionLot edit form
+    with four new optional fields: lure, deployment_start, deployment_end,
+    storage_temperature_c. WHO entomological surveillance reproducibility
+    requirements. Backward-compatible — existing CollectionLots remain valid
+    with NULL values. LHU Mode A footnote auto-degrades when fields are null.
+    STRETCH: partner labs do not yet capture this granularity.
+  links:
+    jira: ["OGC-777", "OGC-552", "OGC-527"]
+    gallery: https://digi-uw.github.io/openelis-work/#/vector-surveillance/collection-lot-trap-details
+    preview: https://digi-uw.github.io/openelis-work/designs/vector-surveillance/collection-lot-trap-details.html
+  tags:
+    - vector
+    - collection-lot
+    - trap-configuration
+    - WHO
+    - lhu-v2
+    - stretch
+  added: "2026-05-28"
+  status: draft

--- a/designs/results-validation/results-entry-expanded-uncertainty.html
+++ b/designs/results-validation/results-entry-expanded-uncertainty.html
@@ -1,0 +1,429 @@
+<!--
+  Results Entry — Expanded Uncertainty (U) Capture
+  Source ticket: OGC-775 (S-15a MVP)
+  Parent epic: OGC-527
+  Consumed by: OGC-552 (S-06 LHU v2.0 conditional U column)
+  Spec: results-entry-expanded-uncertainty.md
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Results Entry — Expanded Uncertainty (U) — OGC-775 mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --gray100: #161616;
+    --gray70:  #525252;
+    --gray50:  #8d8d8d;
+    --gray30:  #c6c6c6;
+    --gray20:  #e0e0e0;
+    --gray10:  #f4f4f4;
+    --blue60:  #0f62fe;
+    --blue10:  #edf5ff;
+    --green60: #198038;
+    --green10: #defbe6;
+    --orange60:#a56eff;
+    --red60:   #da1e28;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+    background: var(--gray10);
+    color: var(--gray100);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 1.5rem 2rem;
+  }
+  /* Breadcrumb */
+  nav.breadcrumb {
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+  }
+  nav.breadcrumb a {
+    color: var(--blue60);
+    text-decoration: none;
+  }
+  nav.breadcrumb a:hover { text-decoration: underline; }
+  nav.breadcrumb .sep { color: var(--gray50); margin: 0 0.5rem; }
+  nav.breadcrumb .current { color: var(--gray70); }
+
+  /* Header card */
+  .card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .card .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .card h1 {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 0.5rem;
+    color: var(--gray100);
+  }
+  .card .subtitle {
+    color: var(--gray70);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+  .card .timestamps {
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--gray70);
+  }
+  .card .timestamps div { margin-bottom: 0.25rem; }
+
+  /* Banner */
+  .banner {
+    background: var(--blue10);
+    border-left: 4px solid var(--blue60);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.875rem;
+  }
+  .banner strong { color: var(--blue60); }
+
+  /* Table */
+  .table-shell {
+    background: white;
+    border: 1px solid var(--gray20);
+    margin-bottom: 1.25rem;
+  }
+  .table-header {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--gray20);
+  }
+  .table-header h2 {
+    font-size: 1.125rem;
+    font-weight: 400;
+    margin: 0 0 0.25rem;
+  }
+  .table-header .desc {
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    margin: 0;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+  table th, table td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--gray20);
+    vertical-align: middle;
+  }
+  table th {
+    background: var(--gray10);
+    font-weight: 600;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    text-transform: none;
+  }
+  table th.numeric, table td.numeric {
+    text-align: left; /* keep left-aligned per Carbon convention */
+    font-variant-numeric: tabular-nums;
+  }
+  table tbody tr:hover {
+    background: var(--gray10);
+  }
+  /* The NEW column gets a subtle highlight in the mockup so the dev can spot it */
+  .u-col {
+    background: rgba(15, 98, 254, 0.04);
+  }
+  th.u-col {
+    background: rgba(15, 98, 254, 0.10);
+  }
+  .new-pill {
+    display: inline-block;
+    margin-left: 0.375rem;
+    padding: 0.0625rem 0.375rem;
+    background: var(--blue60);
+    color: white;
+    border-radius: 2px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    vertical-align: 0.0625rem;
+  }
+  .asterisk {
+    color: var(--blue60);
+    font-weight: 600;
+    margin-left: 0.125rem;
+  }
+  .method-cell {
+    font-size: 0.8125rem;
+    color: var(--gray70);
+  }
+  .empty-cell {
+    color: var(--gray50);
+    font-style: normal;
+  }
+  .na-cell {
+    color: var(--gray70);
+  }
+  .u-prefix {
+    color: var(--gray70);
+    margin-right: 0.125rem;
+  }
+  /* Tag */
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+  .tag.green {
+    background: var(--green10);
+    color: var(--green60);
+  }
+  /* Actions */
+  .actions {
+    white-space: nowrap;
+  }
+  .btn-ghost {
+    background: transparent;
+    border: 0;
+    padding: 0.375rem 0.5rem;
+    color: var(--gray100);
+    cursor: pointer;
+    font-size: 0.8125rem;
+    border-radius: 2px;
+  }
+  .btn-ghost:hover {
+    background: var(--gray20);
+  }
+  .icon-btn {
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 2px;
+    color: var(--gray70);
+  }
+  .icon-btn:hover {
+    background: var(--gray20);
+    color: var(--gray100);
+  }
+
+  /* Legend */
+  .legend {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1rem 1.25rem;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+  }
+  .legend strong { color: var(--gray100); }
+
+  /* Editing row affordance (illustrative — one row is shown mid-edit) */
+  tr.editing {
+    background: #fffbe6;
+  }
+  tr.editing .u-col {
+    background: #fff3a0;
+  }
+  .u-input {
+    width: 5.5rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--gray50);
+    border-radius: 2px;
+    font: inherit;
+    font-variant-numeric: tabular-nums;
+    background: white;
+  }
+  .u-input:focus {
+    outline: 2px solid var(--blue60);
+    outline-offset: -2px;
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb" aria-label="page navigation">
+    <a href="#">Home</a>
+    <span class="sep">/</span>
+    <a href="#">Results</a>
+    <span class="sep">/</span>
+    <span class="current">Order LHU-2026-0042/R</span>
+  </nav>
+
+  <!-- Header card -->
+  <div class="card">
+    <div class="row">
+      <div>
+        <h1>Results Entry &mdash; LHU-2026-0042/R</h1>
+        <p class="subtitle">PT. Unggulrejo Wasono &middot; Air Limbah (Wastewater)</p>
+      </div>
+      <div class="timestamps">
+        <div>Received: 2026-03-08</div>
+        <div>Tested: 2026-03-12 &rarr; 2026-03-15</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mockup-only banner (not part of production UI) -->
+  <div class="banner">
+    <strong>OGC-775 mockup callout (not in production UI):</strong>
+    the only change to this screen is the new <strong>U (k=2)</strong> column right of <strong>Result</strong>. Optional, numeric, blank by default. Backward-compatible &mdash; rows with no U entered render as empty cells (see <em>Fenol Total</em>, <em>TSS</em>, and <em>Krom Total</em> rows). The system does not auto-detect "uncertainty doesn't apply here" &mdash; the lab simply leaves the cell blank. The LHU template (OGC-552) can render its own &mdash; on the report face for below-LOD rows; that's a presentation concern, not an entry concern. One row (<em>BOD5</em>) is shown mid-edit to illustrate the input affordance.
+  </div>
+
+  <!-- Results table -->
+  <div class="table-shell">
+    <div class="table-header">
+      <h2>Results</h2>
+      <p class="desc">Validated test results for this order. Edit a row to enter or update U (k=2).</p>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Test</th>
+          <th class="numeric">Result</th>
+          <th class="numeric u-col">U (k=2)<span class="new-pill">New</span></th>
+          <th>Unit</th>
+          <th>Reference Range</th>
+          <th>Method</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- BOD5 — editing -->
+        <tr class="editing">
+          <td>BOD5</td>
+          <td class="numeric">11.2</td>
+          <td class="numeric u-col">
+            <input type="number" min="0" step="0.001" value="1.8" class="u-input" aria-label="Expanded uncertainty for BOD5">
+          </td>
+          <td>mg/L</td>
+          <td>&le; 60</td>
+          <td class="method-cell">SNI 6989.72-2009</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="btn-ghost" style="background:var(--blue60);color:white;">Save</button>
+            <button class="btn-ghost">Cancel</button>
+          </td>
+        </tr>
+        <!-- COD -->
+        <tr>
+          <td>COD</td>
+          <td class="numeric">21.5</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>3.2</td>
+          <td>mg/L</td>
+          <td>&le; 150</td>
+          <td class="method-cell">SNI 6989.2-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- pH -->
+        <tr>
+          <td>pH</td>
+          <td class="numeric">6.7</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>0.1</td>
+          <td>&mdash;</td>
+          <td>6.0&ndash;9.0</td>
+          <td class="method-cell">SNI 6989.11-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Amonia Total -->
+        <tr>
+          <td>Amonia Total (NH<sub>3</sub> as N)</td>
+          <td class="numeric">0.255</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>0.038</td>
+          <td>mg/L</td>
+          <td>&le; 8.0</td>
+          <td class="method-cell">SNI 06-6989.30-2005</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Fenol Total — below LOD -->
+        <tr>
+          <td>Fenol Total</td>
+          <td class="numeric">&lt;0.0033</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 0.5</td>
+          <td class="method-cell">SNI 06-6989.21-2004</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- TSS — U blank (backward-compat default) -->
+        <tr>
+          <td>TSS</td>
+          <td class="numeric">14</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 50</td>
+          <td class="method-cell">In House</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Krom Total — below LOD -->
+        <tr>
+          <td>Krom Total (Cr)</td>
+          <td class="numeric">&lt;0.0095</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 1</td>
+          <td class="method-cell">SNI 6989.84-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Legend -->
+  <div class="legend">
+    <div><strong>U (k=2):</strong> Expanded measurement uncertainty at coverage factor k = 2 (~95% coverage). Optional &mdash; leave blank if not applicable or not computed for this method.</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/designs/results-validation/results-entry-expanded-uncertainty.jsx
+++ b/designs/results-validation/results-entry-expanded-uncertainty.jsx
@@ -1,0 +1,398 @@
+/**
+ * Results Entry — Expanded Uncertainty (U) Capture
+ *
+ * Source ticket: OGC-775 — S-15a Result Expanded Uncertainty Capture (MVP)
+ *   https://uwdigi.atlassian.net/browse/OGC-775
+ * Parent epic: OGC-527
+ * Consumed by: OGC-552 (S-06 LHU v2.0 conditional U column)
+ * Spec: results-entry-expanded-uncertainty.md (this directory)
+ *
+ * What's new in this mockup:
+ *   - Inline "U (k=2)" column added right of "Result" in the existing Results
+ *     Entry table. Optional. Backward compatible — empty cell = lab did not
+ *     enter U (most rows in non-accredited deployments).
+ *
+ * Scope reminders:
+ *   - MVP only — no tooltip, no admin toggle, no method-level prefill,
+ *     no placeholder text. Per OGC-775 "Out of scope". File S-15a v2 if
+ *     evidence later shows the UX scaffolding is needed.
+ *   - Coverage factor is hidden in MVP; always k=2. Per-row override is v2.
+ *
+ * Carbon React conventions: DataTable, NumberInput, Button, Tag.
+ * IBM Plex Sans, Carbon design tokens (gray100 / gray70 / gray20 / blue60).
+ */
+
+import React, { useState } from "react";
+import {
+  DataTable,
+  Table,
+  TableHead,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableCell,
+  TableContainer,
+  NumberInput,
+  Button,
+  Tag,
+  Stack,
+  Layer,
+  Breadcrumb,
+  BreadcrumbItem,
+  OverflowMenu,
+  OverflowMenuItem,
+} from "@carbon/react";
+import { Edit, OverflowMenuVertical } from "@carbon/icons-react";
+
+// ============================================================================
+// Example data — Order LHU-2026-0042 / PT. Unggulrejo Wasono wastewater
+//
+// Same example values as Environmental LHU v2.0 FRS §6.2 so the mockup
+// tells a coherent story end-to-end: the values entered here are what
+// the LHU's conditional U column will render.
+// ============================================================================
+
+const SAMPLE_INFO = {
+  orderNumber: "LHU-2026-0042/R",
+  customer: "PT. Unggulrejo Wasono",
+  matrix: "Air Limbah (Wastewater)",
+  receivedDate: "2026-03-08",
+  testDate: "2026-03-12 → 2026-03-15",
+};
+
+const INITIAL_RESULTS = [
+  {
+    id: "r-1",
+    test: "BOD5",
+    result: "11.2",
+    expandedUncertainty: "1.8",
+    coverageFactor: 2.0,
+    unit: "mg/L",
+    referenceRange: "≤ 60",
+    method: "SNI 6989.72-2009",
+    status: "Released",
+  },
+  {
+    id: "r-2",
+    test: "COD",
+    result: "21.5",
+    expandedUncertainty: "3.2",
+    coverageFactor: 2.0,
+    unit: "mg/L",
+    referenceRange: "≤ 150",
+    method: "SNI 6989.2-2019",
+    status: "Released",
+  },
+  {
+    id: "r-3",
+    test: "pH",
+    result: "6.7",
+    expandedUncertainty: "0.1",
+    coverageFactor: 2.0,
+    unit: "—",
+    referenceRange: "6.0–9.0",
+    method: "SNI 6989.11-2019",
+    status: "Released",
+  },
+  {
+    id: "r-4",
+    test: "Amonia Total (NH3 as N)",
+    result: "0.255",
+    expandedUncertainty: "0.038",
+    coverageFactor: 2.0,
+    unit: "mg/L",
+    referenceRange: "≤ 8.0",
+    method: "SNI 06-6989.30-2005",
+    status: "Released",
+  },
+  {
+    id: "r-5",
+    test: "Fenol Total",
+    result: "<0.0033",
+    expandedUncertainty: null, // below LOD — lab leaves blank
+    coverageFactor: null,
+    unit: "mg/L",
+    referenceRange: "≤ 0.5",
+    method: "SNI 06-6989.21-2004",
+    status: "Released",
+  },
+  {
+    id: "r-6",
+    test: "TSS",
+    result: "14",
+    // U left blank — backward-compat default for labs that haven't computed U
+    // for this in-house method
+    expandedUncertainty: null,
+    coverageFactor: null,
+    unit: "mg/L",
+    referenceRange: "≤ 50",
+    method: "In House",
+    status: "Released",
+  },
+  {
+    id: "r-7",
+    test: "Krom Total (Cr)",
+    result: "<0.0095",
+    expandedUncertainty: null, // below LOD — lab leaves blank
+    coverageFactor: null,
+    unit: "mg/L",
+    referenceRange: "≤ 1",
+    method: "SNI 6989.84-2019",
+    status: "Released",
+  },
+];
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Format an expanded-uncertainty value for display.
+ *  - null / undefined / empty → empty string (lab did not enter U, or U doesn't
+ *    apply to this row — either way the cell stays blank)
+ *  - otherwise → "± <value>"
+ *
+ * The system does not infer whether U applies to a given row. The lab decides
+ * by entering a value (numeric) or leaving it blank. No "—" or "N/A" sentinel
+ * is rendered in Results Entry; that's an LHU rendering concern (the LHU
+ * template can choose to render "—" on the report face when it detects a
+ * `<`-prefixed result value with a null U).
+ */
+function formatU(value) {
+  if (value === null || value === undefined || value === "") return "";
+  const num = Number(value);
+  if (Number.isNaN(num)) return value;
+  return `± ${value}`;
+}
+
+// ============================================================================
+// Main mockup component
+// ============================================================================
+
+export default function ResultsEntryExpandedUncertaintyMockup() {
+  const [results, setResults] = useState(INITIAL_RESULTS);
+  const [editingId, setEditingId] = useState(null);
+
+  const headers = [
+    { key: "test", header: "Test" },
+    { key: "result", header: "Result" },
+    { key: "uncertainty", header: "U (k=2)" }, // ← NEW column
+    { key: "unit", header: "Unit" },
+    { key: "referenceRange", header: "Reference Range" },
+    { key: "method", header: "Method" },
+    { key: "status", header: "Status" },
+    { key: "actions", header: "" },
+  ];
+
+  function handleUChange(id, raw) {
+    setResults((prev) =>
+      prev.map((r) =>
+        r.id === id
+          ? {
+              ...r,
+              expandedUncertainty: raw === "" ? null : raw,
+              // coverage factor stays 2.0 in MVP; hidden field
+              coverageFactor: raw === "" ? null : 2.0,
+            }
+          : r,
+      ),
+    );
+  }
+
+  return (
+    <Layer className="results-entry-uncertainty-mockup" style={{ padding: "1.5rem 2rem", background: "#f4f4f4", minHeight: "100vh" }}>
+      <Stack gap={5}>
+        {/* Breadcrumb */}
+        <Breadcrumb noTrailingSlash aria-label="page navigation">
+          <BreadcrumbItem href="#">Home</BreadcrumbItem>
+          <BreadcrumbItem href="#">Results</BreadcrumbItem>
+          <BreadcrumbItem isCurrentPage>Order {SAMPLE_INFO.orderNumber}</BreadcrumbItem>
+        </Breadcrumb>
+
+        {/* Header card with sample context */}
+        <Layer level={1} style={{ background: "white", padding: "1.25rem 1.5rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1.5rem" }}>
+            <div>
+              <h1 style={{ fontSize: "1.5rem", fontWeight: 400, color: "var(--cds-text-primary, #161616)", margin: 0 }}>
+                Results Entry &mdash; {SAMPLE_INFO.orderNumber}
+              </h1>
+              <p style={{ marginTop: "0.5rem", color: "var(--cds-text-secondary, #525252)", fontSize: "0.875rem" }}>
+                {SAMPLE_INFO.customer} &middot; {SAMPLE_INFO.matrix}
+              </p>
+            </div>
+            <div style={{ textAlign: "right", fontSize: "0.75rem", color: "var(--cds-text-helper, #6f6f6f)" }}>
+              <div>Received: {SAMPLE_INFO.receivedDate}</div>
+              <div>Tested: {SAMPLE_INFO.testDate}</div>
+            </div>
+          </div>
+        </Layer>
+
+        {/* What's new banner (mockup-only annotation; not part of the production UI) */}
+        <Layer level={1} style={{ background: "#edf5ff", borderLeft: "4px solid var(--cds-link-primary, #0f62fe)", padding: "0.875rem 1.25rem" }}>
+          <div style={{ display: "flex", gap: "0.75rem", alignItems: "flex-start" }}>
+            <div style={{ flex: 1, fontSize: "0.875rem", color: "var(--cds-text-primary, #161616)" }}>
+              <strong>OGC-775 mockup callout (not in production UI):</strong>{" "}
+              the only change to this screen is the new <strong>U (k=2)</strong> column right of <strong>Result</strong>. Optional, numeric, blank by default. Backward-compatible &mdash; rows with no U entered render as empty cells (see Fenol Total, TSS, and Krom Total rows). The system does not auto-detect "uncertainty doesn't apply here" &mdash; the lab simply leaves the cell blank. The LHU template (OGC-552) can render its own &mdash; (em dash) on the report face for below-LOD rows; that's a presentation concern, not an entry concern.
+            </div>
+          </div>
+        </Layer>
+
+        {/* Results table */}
+        <DataTable rows={results.map((r) => ({ ...r, id: r.id }))} headers={headers}>
+          {({ getHeaderProps, getRowProps, getTableProps, getTableContainerProps }) => (
+            <TableContainer
+              title="Results"
+              description="Validated test results for this order. Edit a row to enter or update U (k=2)."
+              {...getTableContainerProps()}
+            >
+              <Table {...getTableProps()} size="md">
+                <TableHead>
+                  <TableRow>
+                    {headers.map((header) => (
+                      <TableHeader
+                        key={header.key}
+                        {...getHeaderProps({ header })}
+                        // Highlight the new column subtly in the mockup banner is fine;
+                        // production header has no special styling
+                      >
+                        {header.header}
+                        {header.key === "uncertainty" && (
+                          <span
+                            style={{ marginLeft: "0.375rem", fontSize: "0.6875rem", color: "var(--cds-link-primary, #0f62fe)", fontWeight: 600 }}
+                            aria-hidden
+                            title="New for v2 — see callout above"
+                          >
+                            NEW
+                          </span>
+                        )}
+                      </TableHeader>
+                    ))}
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {results.map((row) => {
+                    const isEditing = editingId === row.id;
+                    return (
+                      <TableRow key={row.id} {...getRowProps({ row })}>
+                        {/* Test */}
+                        <TableCell>
+                          <span>{row.test}</span>
+                        </TableCell>
+
+                        {/* Result */}
+                        <TableCell>
+                          <span style={{ fontVariantNumeric: "tabular-nums" }}>{row.result}</span>
+                        </TableCell>
+
+                        {/* U (k=2) — NEW for OGC-775. Empty by default. Lab fills in
+                            when it applies; leaves blank otherwise (below-LOD,
+                            qualitative, or U-not-computed-by-this-method). */}
+                        <TableCell>
+                          {isEditing ? (
+                            <NumberInput
+                              id={`u-${row.id}`}
+                              label=""
+                              hideLabel
+                              hideSteppers
+                              min={0}
+                              step={0.001}
+                              value={row.expandedUncertainty ?? ""}
+                              onChange={(_, { value }) => handleUChange(row.id, value)}
+                              size="sm"
+                              invalidText="Uncertainty must be a non-negative number."
+                              invalid={row.expandedUncertainty != null && Number(row.expandedUncertainty) < 0}
+                            />
+                          ) : (
+                            <span style={{ fontVariantNumeric: "tabular-nums", color: row.expandedUncertainty ? "var(--cds-text-primary, #161616)" : "var(--cds-text-placeholder, #a8a8a8)" }}>
+                              {row.expandedUncertainty ? formatU(row.expandedUncertainty) : ""}
+                            </span>
+                          )}
+                        </TableCell>
+
+                        {/* Unit */}
+                        <TableCell>
+                          <span style={{ color: "var(--cds-text-secondary, #525252)" }}>{row.unit}</span>
+                        </TableCell>
+
+                        {/* Reference Range */}
+                        <TableCell>{row.referenceRange}</TableCell>
+
+                        {/* Method */}
+                        <TableCell>
+                          <span style={{ fontSize: "0.8125rem", color: "var(--cds-text-helper, #6f6f6f)" }}>{row.method}</span>
+                        </TableCell>
+
+                        {/* Status */}
+                        <TableCell>
+                          <Tag type={row.status === "Released" ? "green" : "gray"} size="sm">
+                            {row.status}
+                          </Tag>
+                        </TableCell>
+
+                        {/* Actions */}
+                        <TableCell style={{ width: "8rem" }}>
+                          {isEditing ? (
+                            <>
+                              <Button
+                                kind="primary"
+                                size="sm"
+                                onClick={() => setEditingId(null)}
+                              >
+                                Save
+                              </Button>
+                              <Button
+                                kind="ghost"
+                                size="sm"
+                                onClick={() => setEditingId(null)}
+                                style={{ marginLeft: "0.25rem" }}
+                              >
+                                Cancel
+                              </Button>
+                            </>
+                          ) : (
+                            <>
+                              <Button
+                                kind="ghost"
+                                size="sm"
+                                renderIcon={Edit}
+                                onClick={() => setEditingId(row.id)}
+                                iconDescription="Edit row"
+                                hasIconOnly
+                              />
+                              <OverflowMenu
+                                size="sm"
+                                aria-label="more actions"
+                                renderIcon={OverflowMenuVertical}
+                                flipped
+                              >
+                                <OverflowMenuItem itemText="View audit trail" />
+                                <OverflowMenuItem itemText="View method details" />
+                                <OverflowMenuItem itemText="Mark as overridden" />
+                              </OverflowMenu>
+                            </>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          )}
+        </DataTable>
+
+        {/* Footer / legend */}
+        <Layer level={1} style={{ background: "white", padding: "1rem 1.25rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)", fontSize: "0.8125rem", color: "var(--cds-text-secondary, #525252)" }}>
+          <div style={{ display: "flex", gap: "2rem", flexWrap: "wrap" }}>
+            <div>
+              <strong>U (k=2):</strong>
+              <span style={{ marginLeft: "0.5rem" }}>
+                Expanded measurement uncertainty at coverage factor k = 2 (~95% coverage). Optional — leave blank if not applicable or not computed for this method.
+              </span>
+            </div>
+          </div>
+        </Layer>
+      </Stack>
+    </Layer>
+  );
+}

--- a/designs/results-validation/results-entry-expanded-uncertainty.md
+++ b/designs/results-validation/results-entry-expanded-uncertainty.md
@@ -1,0 +1,144 @@
+# Results Entry — Expanded Uncertainty (U) Capture
+
+**Source ticket:** [OGC-775](https://uwdigi.atlassian.net/browse/OGC-775) — S-15a Result Expanded Uncertainty Capture — MVP (ISO 17025 §7.8.3.1(c))
+**Parent epic:** [OGC-527](https://uwdigi.atlassian.net/browse/OGC-527)
+**Consumed by:** [OGC-552](https://uwdigi.atlassian.net/browse/OGC-552) — S-06 LHU v2.0 conditional U column on the result table
+**Distinct from:** OGC-603 (S-03b — per-sample sampling uncertainty %, ISO 17025 §7.6)
+
+---
+
+## Overview
+
+A small, MVP-scoped extension to the existing **Results Entry** screen: each result row gains an optional numeric input for **expanded measurement uncertainty (U)** with a fixed coverage factor `k=2` (95% coverage interval). The field is purely additive — labs that don't track U leave the cell blank and nothing changes for them. KAN-accredited labs (Indonesian Labkesmas BBLKM, EU/US environmental labs) start populating U immediately.
+
+The Vector / Environmental LHU v2.0 has a conditional U column on its result table that renders only when *any* result on the report has `expanded_uncertainty` populated, and auto-hides when none do. This mockup shows the upstream capture surface that feeds that LHU column.
+
+## Scope (MVP)
+
+* **In scope:** inline `U (k=2)` column on the existing Results Entry table; numeric input; backward-compatible NULL handling.
+* **Out of scope** (deferred to S-15a v2 if pursued):
+  * Tooltip / inline help text explaining U and k
+  * Admin toggle `results.uncertainty.enabled` to hide the field from non-accredited deployments
+  * Method-level prefill from `Method.validated_uncertainty` (depends on OGC-750 capturing validated_uncertainty first)
+  * "Don't know? Leave blank" placeholder text + explicit no-validation-error-on-blank affordance
+  * Field label refinement (compact vs. expanded label by context)
+  * Per-row coverage-factor override (always k=2 in MVP)
+
+## Why this is intentionally thin
+
+The MVP gives KAN-accredited labs an immediate place to enter the U value they've already computed via method validation. Non-accredited labs leave it blank and see no change in behaviour. UX scaffolding for non-accredited users (tooltips, admin gating, prefill) lands as a v2 only when we have evidence of how the field is actually used in practice — not now on speculation.
+
+---
+
+## Layout
+
+Single change to the existing Results Entry results table: insert a new column **U (k=2)** immediately after the **Result** column. All other columns unchanged.
+
+```
+| Test               | Result   | U (k=2)  | Unit   | Reference Range | Status   | Actions      |
+| ------------------ | -------- | -------- | ------ | --------------- | -------- | ------------ |
+| BOD5               | 11.2     | ±1.8     | mg/L   | ≤ 60            | Released | Edit | ⋯     |
+| COD                | 21.5     | ±3.2     | mg/L   | ≤ 150           | Released | Edit | ⋯     |
+| pH                 | 6.7      | ±0.1     | —      | 6.0–9.0         | Released | Edit | ⋯     |
+| Amonia Total       | 0.255    | ±0.038   | mg/L   | ≤ 8.0           | Released | Edit | ⋯     |
+| Fenol Total        | <0.0033  |          | mg/L   | ≤ 0.5           | Released | Edit | ⋯     |
+| TSS                | 14       |          | mg/L   | ≤ 50            | Released | Edit | ⋯     |
+```
+
+Notes on rendering:
+
+* `±` prefix on the U value is a display convention — the stored value is a positive decimal; the prefix is added at render time
+* **Empty cell = either backward-compatible default (lab did not enter U) or U does not apply to this row.** The system does not infer whether U applies — the lab decides by entering a value or leaving it blank. No `—` em dash or `N/A` sentinel in Results Entry; that's an LHU rendering concern.
+* For below-LOD results (e.g., `<0.0033`) and qualitative results, the lab simply leaves U blank. The Test Catalog doesn't know which results are below-LOD (that's analyzer/method-dependent), so the entry form doesn't auto-detect or display anything special — it just stays empty.
+* The LHU template (OGC-552) renders `—` on the report face when it detects a `<`-prefixed result value with a blank U; that's a presentation-layer choice and lives entirely in the LHU rendering, not in the entry surface.
+* No tooltip in MVP. Field label is `U (k=2)` — labs that know what it means recognize it immediately; labs that don't leave it blank without ambiguity
+
+## Field spec
+
+| Field | Type | Required | Notes |
+| --- | --- | --- | --- |
+| `expanded_uncertainty` | DECIMAL (precision matches result) | No | Stored as positive decimal; render with `±` prefix |
+| `coverage_factor` | DECIMAL | No (default `2.0`) | Hidden in MVP — always k=2. Visible per-row override is v2. |
+
+Input UX:
+
+* Numeric input field; same width as the Result column input
+* Accepts decimal values; rejects negatives and non-numeric input via standard Carbon NumberInput validation
+* No placeholder text (per MVP scope decision)
+* No tooltip (per MVP scope decision)
+* Tab order: after Result, before Reference Range (Reference Range is usually read-only display, so tab order may skip directly to the Status / Actions cell depending on the row's edit state)
+
+## Data model
+
+Per [OGC-775](https://uwdigi.atlassian.net/browse/OGC-775) AC:
+
+* `result.expanded_uncertainty` — `DECIMAL`, nullable
+* `result.coverage_factor` — `DECIMAL`, default `2.0`
+
+API serializes both fields on `Result` GET / POST / PATCH. Backward compatible: existing results without U continue to render and behave normally.
+
+## Validation rules
+
+* If `expanded_uncertainty` is provided, it must be `≥ 0` (no negative uncertainty)
+* If `expanded_uncertainty` is provided and the result is qualitative or `<LOD`, the system does NOT block on save — the lab may have a valid reason to enter a value (e.g., LOD as the uncertainty). The UI doesn't second-guess.
+* `coverage_factor` is hidden in MVP; the default `2.0` is applied at save time
+* No cross-field validation between result value and U in MVP — the LHU rendering layer decides whether to use the uncertainty in compliance evaluation (per the decision rule on the report; see OGC-552 AC-552-B for the hardcoded BINARY_ACCEPTANCE statement)
+
+## i18n keys (new for this story)
+
+Keys live under `results.uncertainty.*`:
+
+| Key | EN |
+| --- | --- |
+| `results.uncertainty.column.label` | U (k=2) |
+| `results.uncertainty.column.header.tooltip` | (omitted in MVP — added in v2 if needed) |
+| `results.uncertainty.value.prefix` | ± |
+| `results.uncertainty.empty.placeholder` | (none — blank cell) |
+| `results.uncertainty.validation.negative` | Uncertainty must be a non-negative number. |
+
+Backwards: no existing i18n keys are repurposed; this is a clean additive set.
+
+## States (mockup illustrates the first only per MVP scope)
+
+1. **Default / populated row** (in scope) — result + U both filled, k=2 implicit. Most common KAN-accredited-lab case.
+2. **U left blank** (in scope as a row variant) — result filled, U cell empty. Backward-compatible default, AND also the convention for below-LOD / qualitative results (lab just leaves it blank; no special marker).
+3. **Validation error** (deferred) — U entered as negative or non-numeric. Standard Carbon NumberInput error state.
+
+## Acceptance Criteria check (mockup → OGC-775)
+
+| OGC-775 AC | Mockup demonstrates |
+| --- | --- |
+| Schema: `result.expanded_uncertainty` + `result.coverage_factor` | Documented in §"Data model" |
+| Results Entry UI: optional U (k=2) field next to result | Shown in the layout table |
+| API serializes both fields | Documented |
+| Backward compat: existing results without U render normally | Shown via the TSS row + the below-LOD rows (Fenol Total, Krom Total) — all empty U cells |
+| i18n keys under `results.uncertainty.*` | Documented in §"i18n keys" |
+
+### Out of Results Entry — kept on the LHU rendering side
+
+Things that are NOT in the Results Entry mockup but are still part of the broader v2.0 work:
+
+* **KAN accreditation indicators on Results Entry** — explicitly not surfaced. Accreditation is an LHU-rendering concern (asterisk on parameter name, `/R` suffix on report number). The analyst entering a result doesn't need to see it; the LHU template renders it from `ComplianceThreshold.parameter_kan_accredited` at report-assembly time.
+* **`—` em dash for "uncertainty not applicable"** — not in entry. The LHU template can render `—` based on detecting a `<`-prefixed result value with a null U at report-generation time. Live in the LHU template, not on the entry surface.
+
+## Out of scope reminders (NOT in this mockup)
+
+These are documented in OGC-775's "Out of scope" section and are NOT depicted here:
+
+* Tooltip / inline help
+* Admin enabled-toggle
+* Method-level prefill
+* Placeholder text or "Don't know?" affordance
+* Field label refinement by context
+* Per-row coverage-factor override
+
+If any of these turn out to matter once labs start using the MVP, file an S-15a v2 follow-up story.
+
+## References
+
+* [OGC-775](https://uwdigi.atlassian.net/browse/OGC-775) — this story's parent ticket
+* [OGC-552](https://uwdigi.atlassian.net/browse/OGC-552) — consumes the field via the LHU v2.0 conditional U column
+* `environmental-lhu.md` v2.0 §6.1 / §6.5 — LHU U column rendering rules
+* ISO/IEC 17025:2017 §7.8.3.1(c) — uncertainty reporting requirement
+* JCGM 100:2008 (GUM) — Guide to the Expression of Uncertainty in Measurement, foundational reference
+* LHU v2.0 upstream gap analysis (2026-05-26) — `lhu-v2-upstream-gap-analysis-2026-05-26.md`

--- a/designs/vector-surveillance/collection-lot-trap-details.html
+++ b/designs/vector-surveillance/collection-lot-trap-details.html
@@ -1,0 +1,406 @@
+<!--
+  Vector Collection Workflow — Trap Detail Fields
+  Source ticket: OGC-777 (V-05a STRETCH)
+  Parent epic: OGC-527
+  Host screen: V-02 Vector Collection Workflow (OGC-581)
+  Consumed by: OGC-552 (S-06 LHU v2.0 Mode A "Penjebakan / Trap details" footnote)
+  Spec: collection-lot-trap-details.md
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Collection Lot — Trap Details — OGC-777 mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --gray100: #161616;
+    --gray70:  #525252;
+    --gray50:  #8d8d8d;
+    --gray30:  #c6c6c6;
+    --gray20:  #e0e0e0;
+    --gray10:  #f4f4f4;
+    --blue60:  #0f62fe;
+    --blue10:  #edf5ff;
+    --green60: #198038;
+    --green10: #defbe6;
+    --yellow30:#fdd13a;
+    --yellow10:#fcf4d6;
+    --red60:   #da1e28;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+    background: var(--gray10);
+    color: var(--gray100);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 1.5rem 2rem;
+  }
+  /* Breadcrumb */
+  nav.breadcrumb {
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+  }
+  nav.breadcrumb a {
+    color: var(--blue60);
+    text-decoration: none;
+  }
+  nav.breadcrumb a:hover { text-decoration: underline; }
+  nav.breadcrumb .sep { color: var(--gray50); margin: 0 0.5rem; }
+  nav.breadcrumb .current { color: var(--gray70); }
+
+  /* Generic card */
+  .card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .card .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .card h1 {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 0.5rem;
+    color: var(--gray100);
+  }
+  .card .subtitle {
+    color: var(--gray70);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+  .card .timestamps {
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--gray70);
+  }
+  .card .timestamps div { margin-bottom: 0.25rem; }
+
+  /* Banner */
+  .banner {
+    background: var(--blue10);
+    border-left: 4px solid var(--blue60);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.875rem;
+  }
+  .banner strong { color: var(--blue60); }
+  .banner em { font-style: italic; color: var(--gray70); }
+
+  /* Collapsed existing-section bars (mockup affordance only) */
+  .ellipsis-bar {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    color: var(--gray50);
+    font-size: 0.8125rem;
+    font-style: italic;
+  }
+
+  /* The Trap Configuration section card */
+  .section-card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.5rem 1.75rem;
+    margin-bottom: 1.25rem;
+  }
+  .section-card h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+    padding-bottom: 0.625rem;
+    border-bottom: 2px solid var(--gray20);
+    color: var(--gray100);
+  }
+
+  .grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+  }
+  .field label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--gray70);
+    margin-bottom: 0.25rem;
+  }
+  .field .required {
+    color: var(--red60);
+    font-weight: 600;
+    margin-left: 0.125rem;
+  }
+  .new-pill {
+    display: inline-block;
+    margin-left: 0.375rem;
+    padding: 0.0625rem 0.375rem;
+    background: var(--blue60);
+    color: white;
+    border-radius: 2px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    vertical-align: 0.0625rem;
+  }
+
+  /* Inputs */
+  .input,
+  .select,
+  .date,
+  .time {
+    background: white;
+    border: 1px solid transparent;
+    border-bottom: 1px solid var(--gray70);
+    font: inherit;
+    font-size: 0.875rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0;
+    width: 100%;
+  }
+  .input:focus,
+  .select:focus,
+  .date:focus,
+  .time:focus {
+    outline: 2px solid var(--blue60);
+    outline-offset: -2px;
+  }
+  .input-with-suffix {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--gray70);
+    background: white;
+  }
+  .input-with-suffix input {
+    border: 0;
+    background: transparent;
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+  .input-with-suffix input:focus { outline: none; }
+  .input-with-suffix .suffix {
+    padding: 0.5rem 0.75rem;
+    color: var(--gray70);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .helper {
+    font-size: 0.75rem;
+    color: var(--gray70);
+    margin-top: 0.25rem;
+  }
+
+  /* Datetime composite (date + time + period) */
+  .datetime {
+    display: grid;
+    grid-template-columns: 1fr 4.5rem 4rem;
+    gap: 0.5rem;
+    align-items: end;
+  }
+
+  /* Section-level helper line */
+  .section-helper {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--gray20);
+    margin-top: 0.5rem;
+  }
+  .section-helper .icon {
+    flex-shrink: 0;
+    margin-top: 0.0625rem;
+    color: var(--blue60);
+    font-size: 1rem;
+    line-height: 1;
+  }
+  .section-helper strong { color: var(--gray100); }
+
+  /* Action bar */
+  .actions {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1rem 1.25rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+  .btn {
+    padding: 0.625rem 1.25rem;
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+  .btn.ghost {
+    background: transparent;
+    color: var(--gray100);
+  }
+  .btn.ghost:hover { background: var(--gray20); }
+  .btn.secondary {
+    background: white;
+    color: var(--gray100);
+    border: 1px solid var(--gray100);
+  }
+  .btn.secondary:hover { background: var(--gray20); }
+  .btn.primary {
+    background: var(--blue60);
+    color: white;
+  }
+  .btn.primary:hover { background: #0353e9; }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb" aria-label="page navigation">
+    <a href="#">Home</a>
+    <span class="sep">/</span>
+    <a href="#">Vector</a>
+    <span class="sep">/</span>
+    <a href="#">Collection</a>
+    <span class="sep">/</span>
+    <span class="current">CL-2026-0117</span>
+  </nav>
+
+  <!-- Header card -->
+  <div class="card">
+    <div class="row">
+      <div>
+        <h1>Edit Collection Lot &mdash; CL-2026-0117</h1>
+        <p class="subtitle">Kel. Mampang Prapatan, Kec. Mampang Prapatan, Kota Jakarta Selatan</p>
+      </div>
+      <div class="timestamps">
+        <div>Collector: Dr. Budi Santoso</div>
+        <div>Created: 2026-01-13</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mockup-only banner -->
+  <div class="banner">
+    <strong>OGC-777 mockup callout (not in production UI):</strong>
+    the change to this screen is the new <strong>Trap Configuration</strong> section grouping the existing <em>Trap Type</em> field with four new optional fields &mdash; <strong>Lure</strong>, <strong>Deployment Start</strong>, <strong>Deployment End</strong>, and <strong>Storage Temperature</strong>. Other sections of the CollectionLot form (Sample Info, Site, Specimens, Notes) are unchanged. All four new fields are optional &mdash; backward-compatible default is blank.
+  </div>
+
+  <!-- Collapsed existing sections above -->
+  <div class="ellipsis-bar">
+    &uarr; Sample Info &middot; Site &middot; Collector sections (existing &mdash; not shown in this mockup) &uarr;
+  </div>
+
+  <!-- THE NEW SECTION — Trap Configuration -->
+  <div class="section-card">
+    <h2>Trap Configuration</h2>
+
+    <!-- Row 1: Trap Type (existing) + Lure (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label for="trap-type">Trap Type<span class="required">*</span></label>
+        <select id="trap-type" class="select">
+          <option value="BG_SENTINEL" selected>BG-Sentinel</option>
+          <option value="CDC_BOTTLE">CDC bottle trap</option>
+          <option value="GRAVID">Gravid trap</option>
+          <option value="OVITRAP">Ovitrap</option>
+          <option value="LIGHT_TRAP">Light trap</option>
+          <option value="HUMAN_LANDING_CATCH">Human Landing Catch</option>
+          <option value="DIPPER">Dipper</option>
+          <option value="PIPETTE">Pipette</option>
+          <option value="OTHER">Other</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="lure">Lure<span class="new-pill">New</span></label>
+        <input id="lure" type="text" class="input" value="BG-Lure" placeholder="e.g., BG-Lure, CO&#8322;, octenol" aria-label="Lure (free text)">
+        <div class="helper">Free text &mdash; whatever the lab used.</div>
+      </div>
+    </div>
+
+    <!-- Row 2: Deployment Start (NEW) + Deployment End (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label>Deployment Start<span class="new-pill">New</span></label>
+        <div class="datetime">
+          <input type="date" class="date" value="2026-01-13" aria-label="Deployment start date">
+          <input type="time" class="time" value="06:00" aria-label="Deployment start time">
+          <select class="select" aria-label="Deployment start AM/PM">
+            <option value="AM" selected>AM</option>
+            <option value="PM">PM</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Deployment End<span class="new-pill">New</span></label>
+        <div class="datetime">
+          <input type="date" class="date" value="2026-01-15" aria-label="Deployment end date">
+          <input type="time" class="time" value="06:00" aria-label="Deployment end time">
+          <select class="select" aria-label="Deployment end AM/PM">
+            <option value="AM" selected>AM</option>
+            <option value="PM">PM</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <!-- Row 3: Storage Temperature (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label for="storage-temp">Storage Temperature<span class="new-pill">New</span></label>
+        <div class="input-with-suffix">
+          <input id="storage-temp" type="number" step="0.1" value="-20.0" aria-label="Storage temperature">
+          <span class="suffix">&deg;C</span>
+        </div>
+        <div class="helper">Negative values allowed for frozen storage (-20 &deg;C, -80 &deg;C are common).</div>
+      </div>
+      <div></div>
+    </div>
+
+    <!-- Section-level helper -->
+    <div class="section-helper">
+      <span class="icon" aria-hidden="true">&#9432;</span>
+      <span>
+        All trap-configuration fields except <strong>Trap Type</strong> are optional. The LHU Mode A footnote renders these when populated; absent fields are silently omitted.
+      </span>
+    </div>
+  </div>
+
+  <!-- Collapsed existing sections below -->
+  <div class="ellipsis-bar">
+    &darr; Specimens table &middot; Notes section (existing &mdash; not shown in this mockup) &darr;
+  </div>
+
+  <!-- Action bar -->
+  <div class="actions">
+    <button class="btn ghost">Cancel</button>
+    <button class="btn secondary">Save Draft</button>
+    <button class="btn primary">Save</button>
+  </div>
+
+</div>
+</body>
+</html>

--- a/designs/vector-surveillance/collection-lot-trap-details.jsx
+++ b/designs/vector-surveillance/collection-lot-trap-details.jsx
@@ -1,0 +1,359 @@
+/**
+ * Vector Collection Workflow — Trap Detail Fields
+ *
+ * Source ticket: OGC-777 — V-05a VectorSpecimen Trap-Detail Fields (STRETCH)
+ *   https://uwdigi.atlassian.net/browse/OGC-777
+ * Parent epic: OGC-527
+ * Host screen: V-02 Vector Collection Workflow (OGC-581, ✅ Done)
+ * Consumed by: OGC-552 (S-06 LHU v2.0 Mode A "Penjebakan / Trap details" footnote)
+ * Spec: collection-lot-trap-details.md (this directory)
+ *
+ * What's new in this mockup:
+ *   - New "Trap Configuration" section on the existing CollectionLot edit form,
+ *     adding four optional fields: lure, deployment_start, deployment_end,
+ *     storage_temperature_c. trap_type (existing) is grouped into this section
+ *     so all trap-config fields cluster visually.
+ *
+ * Scope reminders (per OGC-777):
+ *   - STRETCH ticket. Partner labs report they don't yet capture this data.
+ *     Schema + UI ready; fields stay NULL until lab practice catches up.
+ *   - All four new fields are optional. Trap Type remains required (existing).
+ *   - lure is FREE TEXT (not coded / not enum / not reference data). It's
+ *     stored and displayed on the LHU footnote, never used for filtering or
+ *     evaluation, so admin reference data is unnecessary overhead. (Decision
+ *     made 2026-05-28 after the original ENUM-based scope.)
+ *   - No per-field tooltips. One section-level helper line.
+ *   - Soft warning if deployment_end < deployment_start; no hard block.
+ *
+ * Carbon React conventions: Form, Stack, Dropdown, TextInput, DatePicker,
+ * TimePicker, NumberInput, InlineNotification, Layer.
+ * IBM Plex Sans, Carbon design tokens.
+ */
+
+import React, { useState } from "react";
+import {
+  Form,
+  FormGroup,
+  Stack,
+  Dropdown,
+  DatePicker,
+  DatePickerInput,
+  TimePicker,
+  TimePickerSelect,
+  SelectItem,
+  NumberInput,
+  Button,
+  InlineNotification,
+  Layer,
+  Breadcrumb,
+  BreadcrumbItem,
+  TextInput,
+  TextArea,
+} from "@carbon/react";
+import { Information } from "@carbon/icons-react";
+
+// ============================================================================
+// Example data — CollectionLot CL-2026-0117 from a hypothetical
+// BBLKM Jakarta Aedes aegypti trap deployment in Kel. Mampang Prapatan.
+// Same data the LHU v2.0 Mode A example uses, so end-to-end traceability
+// holds: values entered here populate the LHU §5A Mode A footnote
+// "Penjebakan / Trap details" + "Rantai dingin / Cold chain" lines.
+// ============================================================================
+
+const TRAP_TYPE_OPTIONS = [
+  { id: "BG_SENTINEL", label: "BG-Sentinel" },
+  { id: "CDC_BOTTLE", label: "CDC bottle trap" },
+  { id: "GRAVID", label: "Gravid trap" },
+  { id: "OVITRAP", label: "Ovitrap" },
+  { id: "LIGHT_TRAP", label: "Light trap" },
+  { id: "HUMAN_LANDING_CATCH", label: "Human Landing Catch" },
+  { id: "DIPPER", label: "Dipper" },
+  { id: "PIPETTE", label: "Pipette" },
+  { id: "OTHER", label: "Other" },
+];
+
+const INITIAL_LOT = {
+  // Existing CollectionLot fields (shown above the Trap Configuration section
+  // — collapsed in this mockup since they're not what this ticket changes)
+  collectionLotNumber: "CL-2026-0117",
+  site: "Kel. Mampang Prapatan, Kec. Mampang Prapatan, Kota Jakarta Selatan",
+  collector: "Dr. Budi Santoso",
+
+  // Trap Configuration — the focus of this mockup
+  trapType: { id: "BG_SENTINEL", label: "BG-Sentinel" }, // EXISTING, required
+  lure: "BG-Lure",                                        // NEW, optional, FREE TEXT
+  deploymentStartDate: "2026-01-13",                     // NEW, optional
+  deploymentStartTime: "06:00",                           // NEW, optional
+  deploymentStartPeriod: "AM",
+  deploymentEndDate: "2026-01-15",                       // NEW, optional
+  deploymentEndTime: "06:00",                             // NEW, optional
+  deploymentEndPeriod: "AM",
+  storageTemperatureC: -20.0,                             // NEW, optional
+
+  // Existing fields below the section (Specimens table, Notes) — not shown in mockup
+  notes: "",
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function combineDateTime(date, time, period) {
+  if (!date || !time) return null;
+  // Treat as a display-only string in this mockup; the real form persists ISO 8601
+  return `${date} ${time} ${period}`;
+}
+
+function isDeploymentWindowInverted(lot) {
+  const start = combineDateTime(lot.deploymentStartDate, lot.deploymentStartTime, lot.deploymentStartPeriod);
+  const end = combineDateTime(lot.deploymentEndDate, lot.deploymentEndTime, lot.deploymentEndPeriod);
+  if (!start || !end) return false;
+  // Naive string compare works for the mockup's ISO-like format; real impl uses Date
+  return end < start;
+}
+
+// ============================================================================
+// Main mockup component
+// ============================================================================
+
+export default function CollectionLotTrapDetailsMockup() {
+  const [lot, setLot] = useState(INITIAL_LOT);
+  const windowInverted = isDeploymentWindowInverted(lot);
+
+  function update(field, value) {
+    setLot((prev) => ({ ...prev, [field]: value }));
+  }
+
+  return (
+    <Layer style={{ padding: "1.5rem 2rem", background: "#f4f4f4", minHeight: "100vh" }}>
+      <Stack gap={5}>
+        {/* Breadcrumb */}
+        <Breadcrumb noTrailingSlash aria-label="page navigation">
+          <BreadcrumbItem href="#">Home</BreadcrumbItem>
+          <BreadcrumbItem href="#">Vector</BreadcrumbItem>
+          <BreadcrumbItem href="#">Collection</BreadcrumbItem>
+          <BreadcrumbItem isCurrentPage>{lot.collectionLotNumber}</BreadcrumbItem>
+        </Breadcrumb>
+
+        {/* Header card — minimal context */}
+        <Layer level={1} style={{ background: "white", padding: "1.25rem 1.5rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)" }}>
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: "1.5rem" }}>
+            <div>
+              <h1 style={{ fontSize: "1.5rem", fontWeight: 400, color: "var(--cds-text-primary, #161616)", margin: 0 }}>
+                Edit Collection Lot &mdash; {lot.collectionLotNumber}
+              </h1>
+              <p style={{ marginTop: "0.5rem", color: "var(--cds-text-secondary, #525252)", fontSize: "0.875rem" }}>
+                {lot.site}
+              </p>
+            </div>
+            <div style={{ textAlign: "right", fontSize: "0.75rem", color: "var(--cds-text-helper, #6f6f6f)" }}>
+              <div>Collector: {lot.collector}</div>
+              <div>Created: 2026-01-13</div>
+            </div>
+          </div>
+        </Layer>
+
+        {/* What's new banner (mockup-only annotation) */}
+        <Layer level={1} style={{ background: "#edf5ff", borderLeft: "4px solid var(--cds-link-primary, #0f62fe)", padding: "0.875rem 1.25rem" }}>
+          <div style={{ fontSize: "0.875rem", color: "var(--cds-text-primary, #161616)" }}>
+            <strong>OGC-777 mockup callout (not in production UI):</strong> the change to this screen is the new <strong>Trap Configuration</strong> section grouping the existing <em>Trap Type</em> field with four new optional fields &mdash; <strong>Lure</strong>, <strong>Deployment Start</strong>, <strong>Deployment End</strong>, and <strong>Storage Temperature</strong>. Other sections of the CollectionLot form (Sample Info, Site, Specimens, Notes) are unchanged. All four new fields are optional &mdash; backward-compatible default is blank.
+          </div>
+        </Layer>
+
+        {/* Existing sections collapsed to a placeholder bar in the mockup */}
+        <Layer level={1} style={{ background: "white", padding: "0.875rem 1.25rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)", color: "var(--cds-text-helper, #6f6f6f)", fontSize: "0.8125rem", fontStyle: "italic" }}>
+          &uarr; Sample Info &middot; Site &middot; Collector sections (existing &mdash; not shown in this mockup) &uarr;
+        </Layer>
+
+        {/* THE NEW SECTION — Trap Configuration */}
+        <Layer level={1} style={{ background: "white", padding: "1.5rem 1.75rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)" }}>
+          <h2 style={{ fontSize: "1.125rem", fontWeight: 600, color: "var(--cds-text-primary, #161616)", margin: "0 0 1.25rem", borderBottom: "2px solid var(--cds-border-subtle, #e0e0e0)", paddingBottom: "0.625rem" }}>
+            Trap Configuration
+          </h2>
+
+          <Form>
+            <Stack gap={6}>
+              {/* Row 1: Trap Type (existing) + Lure (NEW) */}
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem" }}>
+                <Dropdown
+                  id="trap-type"
+                  titleText={
+                    <span>
+                      Trap Type <span style={{ color: "var(--cds-support-error, #da1e28)" }}>*</span>
+                    </span>
+                  }
+                  label="Select a trap type"
+                  items={TRAP_TYPE_OPTIONS}
+                  itemToString={(item) => (item ? item.label : "")}
+                  selectedItem={lot.trapType}
+                  onChange={({ selectedItem }) => update("trapType", selectedItem)}
+                />
+
+                <TextInput
+                  id="lure"
+                  labelText={
+                    <span>
+                      Lure
+                      <span style={{ marginLeft: "0.375rem", fontSize: "0.6875rem", color: "var(--cds-link-primary, #0f62fe)", fontWeight: 600 }}>
+                        NEW
+                      </span>
+                    </span>
+                  }
+                  placeholder="e.g., BG-Lure, CO₂, octenol"
+                  helperText="Free text — whatever the lab used."
+                  value={lot.lure ?? ""}
+                  onChange={(e) => update("lure", e.target.value)}
+                />
+              </div>
+
+              {/* Row 2: Deployment Start (NEW) + Deployment End (NEW) */}
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem" }}>
+                <FormGroup
+                  legendText={
+                    <span>
+                      Deployment Start
+                      <span style={{ marginLeft: "0.375rem", fontSize: "0.6875rem", color: "var(--cds-link-primary, #0f62fe)", fontWeight: 600 }}>
+                        NEW
+                      </span>
+                    </span>
+                  }
+                >
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 6rem", gap: "0.75rem", alignItems: "end" }}>
+                    <DatePicker
+                      datePickerType="single"
+                      value={lot.deploymentStartDate}
+                      onChange={(dates) =>
+                        update("deploymentStartDate", dates[0] ? dates[0].toISOString().slice(0, 10) : "")
+                      }
+                    >
+                      <DatePickerInput
+                        id="deployment-start-date"
+                        labelText=""
+                        placeholder="yyyy-mm-dd"
+                        size="md"
+                      />
+                    </DatePicker>
+                    <TimePicker
+                      id="deployment-start-time"
+                      labelText=""
+                      value={lot.deploymentStartTime}
+                      onChange={(e) => update("deploymentStartTime", e.target.value)}
+                      size="md"
+                    >
+                      <TimePickerSelect
+                        id="deployment-start-period"
+                        labelText=""
+                        value={lot.deploymentStartPeriod}
+                        onChange={(e) => update("deploymentStartPeriod", e.target.value)}
+                      >
+                        <SelectItem value="AM" text="AM" />
+                        <SelectItem value="PM" text="PM" />
+                      </TimePickerSelect>
+                    </TimePicker>
+                  </div>
+                </FormGroup>
+
+                <FormGroup
+                  legendText={
+                    <span>
+                      Deployment End
+                      <span style={{ marginLeft: "0.375rem", fontSize: "0.6875rem", color: "var(--cds-link-primary, #0f62fe)", fontWeight: 600 }}>
+                        NEW
+                      </span>
+                    </span>
+                  }
+                >
+                  <div style={{ display: "grid", gridTemplateColumns: "1fr 6rem", gap: "0.75rem", alignItems: "end" }}>
+                    <DatePicker
+                      datePickerType="single"
+                      value={lot.deploymentEndDate}
+                      onChange={(dates) =>
+                        update("deploymentEndDate", dates[0] ? dates[0].toISOString().slice(0, 10) : "")
+                      }
+                    >
+                      <DatePickerInput
+                        id="deployment-end-date"
+                        labelText=""
+                        placeholder="yyyy-mm-dd"
+                        size="md"
+                      />
+                    </DatePicker>
+                    <TimePicker
+                      id="deployment-end-time"
+                      labelText=""
+                      value={lot.deploymentEndTime}
+                      onChange={(e) => update("deploymentEndTime", e.target.value)}
+                      size="md"
+                    >
+                      <TimePickerSelect
+                        id="deployment-end-period"
+                        labelText=""
+                        value={lot.deploymentEndPeriod}
+                        onChange={(e) => update("deploymentEndPeriod", e.target.value)}
+                      >
+                        <SelectItem value="AM" text="AM" />
+                        <SelectItem value="PM" text="PM" />
+                      </TimePickerSelect>
+                    </TimePicker>
+                  </div>
+                </FormGroup>
+              </div>
+
+              {/* Row 3: Storage Temperature (NEW) */}
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "1.5rem" }}>
+                <NumberInput
+                  id="storage-temperature"
+                  label={
+                    <span>
+                      Storage Temperature
+                      <span style={{ marginLeft: "0.375rem", fontSize: "0.6875rem", color: "var(--cds-link-primary, #0f62fe)", fontWeight: 600 }}>
+                        NEW
+                      </span>
+                    </span>
+                  }
+                  helperText="°C (negative values allowed for frozen storage)"
+                  step={0.1}
+                  value={lot.storageTemperatureC ?? ""}
+                  onChange={(_, { value }) => update("storageTemperatureC", value === "" ? null : Number(value))}
+                />
+                {/* Empty column for layout symmetry */}
+                <div />
+              </div>
+
+              {/* Soft warning if deployment window inverted */}
+              {windowInverted && (
+                <InlineNotification
+                  kind="warning"
+                  title="Deployment window check"
+                  subtitle="Deployment end is before deployment start. Confirm before saving."
+                  hideCloseButton
+                  lowContrast
+                />
+              )}
+
+              {/* Section-level helper */}
+              <div style={{ display: "flex", gap: "0.5rem", alignItems: "flex-start", fontSize: "0.8125rem", color: "var(--cds-text-helper, #6f6f6f)", paddingTop: "0.5rem", borderTop: "1px dashed var(--cds-border-subtle, #e0e0e0)" }}>
+                <Information size={16} style={{ flexShrink: 0, marginTop: "0.125rem" }} />
+                <span>
+                  All trap-configuration fields except <strong>Trap Type</strong> are optional. The LHU Mode A footnote renders these when populated; absent fields are silently omitted.
+                </span>
+              </div>
+            </Stack>
+          </Form>
+        </Layer>
+
+        {/* Existing sections below collapsed */}
+        <Layer level={1} style={{ background: "white", padding: "0.875rem 1.25rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)", color: "var(--cds-text-helper, #6f6f6f)", fontSize: "0.8125rem", fontStyle: "italic" }}>
+          &darr; Specimens table &middot; Notes section (existing &mdash; not shown in this mockup) &darr;
+        </Layer>
+
+        {/* Action bar */}
+        <Layer level={1} style={{ background: "white", padding: "1rem 1.25rem", border: "1px solid var(--cds-border-subtle, #e0e0e0)", display: "flex", justifyContent: "flex-end", gap: "0.5rem" }}>
+          <Button kind="ghost">Cancel</Button>
+          <Button kind="secondary">Save Draft</Button>
+          <Button kind="primary">Save</Button>
+        </Layer>
+      </Stack>
+    </Layer>
+  );
+}

--- a/designs/vector-surveillance/collection-lot-trap-details.md
+++ b/designs/vector-surveillance/collection-lot-trap-details.md
@@ -1,0 +1,152 @@
+# Vector Collection Workflow — Trap Detail Fields
+
+**Source ticket:** [OGC-777](https://uwdigi.atlassian.net/browse/OGC-777) — V-05a VectorSpecimen Trap-Detail Fields (STRETCH)
+**Parent epic:** [OGC-527](https://uwdigi.atlassian.net/browse/OGC-527)
+**Host screen:** V-02 Vector Collection Workflow ([OGC-581](https://uwdigi.atlassian.net/browse/OGC-581), already ✅ Done)
+**Consumed by:** [OGC-552](https://uwdigi.atlassian.net/browse/OGC-552) — S-06 LHU v2.0 Mode A "Penjebakan / Trap details" footnote + Sample Info block
+
+---
+
+## Overview
+
+A small enhancement to the existing **CollectionLot** edit form (V-02 / OGC-581): four new optional fields capturing trap-deployment specifics required by WHO entomological surveillance protocols. None of the fields are required; labs without this granularity continue to use the form exactly as today. The LHU Mode A footnote auto-degrades when the fields are null.
+
+The four new fields:
+
+| Field | Type | Why |
+| --- | --- | --- |
+| `lure` | TEXT (free-form) | Trap attractant; noted for reproducibility per WHO. Free text rather than coded — lure isn't used for filtering or evaluation, just displayed in the LHU footnote, so admin reference data is unnecessary overhead. Labs write what they used (e.g., "BG-Lure", "CO₂", "octenol", "custom blend X"). |
+| `deployment_start` | DATETIME | When the trap was set; combined with deployment_end gives true trap-nights for collection-density math |
+| `deployment_end` | DATETIME | When the trap was retrieved |
+| `storage_temperature_c` | DECIMAL (°C) | Chain-of-custody for downstream PCR; cold-chain breach affects RNA integrity |
+
+## Status: stretch / sprint 955 buffer
+
+Partner labs we've talked to report they don't yet capture this granularity in their day-to-day workflow. The story is queued as a "ready when labs are" upgrade — schema + UI land, fields stay null until lab practice catches up. LHU v2.0 Mode A footnote already accommodates this with auto-degrade behavior.
+
+Reagan to confirm whether any deployment is actually asking for the fields — if yes, story moves out of stretch.
+
+## Scope
+
+* **In scope:** four new fields added to the existing CollectionLot edit form; reference data seed for the `lure` enum; backward-compatible NULL handling; LHU Mode A footnote consumes the populated values.
+* **Out of scope:** no separate screen; no list view filtering by these fields (Vector Surveillance Reporting / OGC-585 may add filters later); no automated validation that deployment_end > deployment_start beyond a soft warning; no temperature-breach alerting (cold-chain integration would be a separate epic).
+
+## Layout
+
+The CollectionLot edit form gains one new sub-section **"Trap Configuration"** that groups the existing `trap_type` field with the four new ones. Other form sections (Sample, Site, Collector, Notes) are unchanged.
+
+```
+[Existing CollectionLot form sections above — Sample Info, Site, Collector, etc.]
+
+╔══════════════════════════════════════════════════════════════════╗
+║  Trap Configuration                                              ║
+║  ──────────────────────────────────────────────────────────────  ║
+║                                                                  ║
+║  Trap Type *                       Lure                          ║
+║  [BG-Sentinel             ▼]       [BG-Lure              ]       ║
+║                                    e.g., BG-Lure, CO₂, octenol   ║
+║                                                                  ║
+║  Deployment Start                  Deployment End                ║
+║  [2026-01-13]  [06:00 AM]         [2026-01-15]  [06:00 AM]       ║
+║                                                                  ║
+║  Storage Temperature                                             ║
+║  [-20.0]  °C                                                     ║
+║                                                                  ║
+║  ⓘ All trap-configuration fields except Trap Type are optional.  ║
+║    LHU Mode A footnote renders these when populated; absent      ║
+║    fields are silently omitted.                                  ║
+║                                                                  ║
+╚══════════════════════════════════════════════════════════════════╝
+
+[Existing CollectionLot form sections below — Specimens table, Notes, etc.]
+```
+
+Notes on rendering:
+
+* The five fields are grouped under one section header **"Trap Configuration"** so they cluster visually and are easy to skip if the lab doesn't capture them. Section title — no expansion/collapse in MVP (keeps the form simple).
+* **Trap Type stays required** (existing OGC-581 behavior). The four new fields are optional.
+* `Deployment Start / End` use a paired date + time input rather than a single DateTime picker — matches the OE convention for "when did this happen" timestamps where seconds rarely matter.
+* `Storage Temperature` is a NumberInput with `°C` suffix; accepts negative values (specimens stored at -20°C, -80°C are common).
+* The small `ⓘ` helper line at the bottom of the section is the only piece of guidance in MVP — no per-field tooltips. The LHU side does the inferring (renders the trap-detail footnote line only when any of the four fields is populated).
+
+## Field spec
+
+| Field | Component | Required | Default | Validation |
+| --- | --- | --- | --- | --- |
+| `trap_type` | Dropdown | Yes | (existing default) | (existing — from V-01 reference data via OGC-555) |
+| `lure` | TextInput (free-form) | No | NULL | None. Helper text suggests common values (BG-Lure, CO₂, octenol). |
+| `deployment_start` | DatePicker + TimePicker | No | NULL | Must be valid datetime; soft warning if `> deployment_end` |
+| `deployment_end` | DatePicker + TimePicker | No | NULL | Must be valid datetime; soft warning if `< deployment_start` |
+| `storage_temperature_c` | NumberInput (°C) | No | NULL | Decimal; accepts negative; sensible range -80 to +40 (soft warning outside) |
+
+**Why lure is free text, not coded:**
+
+`trap_type` is admin-managed reference data because it's used for filtering, aggregation, and decision-making (V-04 surveillance dashboards filter by trap type; MIR is computed per trap type). `lure` has none of those uses — it lives in one footnote line on the LHU. Building an admin entity (reference table + CRUD UI + permissions + i18n + tests) for a field that's just stored and displayed would be disproportionate. The principle: code it if you use it for logic; free-text it if you just store and display.
+
+Cross-field rule:
+
+* If `deployment_start` is populated, `deployment_end` should also be populated (and vice-versa). Soft warning (Carbon `InlineNotification` of kind `warning`) on save — not blocking.
+
+## Data model (per OGC-777 AC, amended 2026-05-28)
+
+* `collection_lot.lure` (TEXT, nullable, free-form)
+* `collection_lot.deployment_start` (DATETIME, nullable)
+* `collection_lot.deployment_end` (DATETIME, nullable)
+* `collection_lot.storage_temperature_c` (DECIMAL, nullable)
+
+API serializes all four on `CollectionLot` GET / POST / PATCH. Backward compatible: existing CollectionLot records default to NULL.
+
+No V-01 reference data extension needed (the original AC called for a `lure` enum table seed; that's dropped per the free-text decision).
+
+## i18n keys (new for this story)
+
+| Key | EN |
+| --- | --- |
+| `vector.collectionLot.section.trapConfiguration` | Trap Configuration |
+| `vector.collectionLot.lure` | Lure |
+| `vector.collectionLot.lure.placeholder` | e.g., BG-Lure, CO₂, octenol |
+| `vector.collectionLot.deploymentStart` | Deployment Start |
+| `vector.collectionLot.deploymentEnd` | Deployment End |
+| `vector.collectionLot.storageTemperatureC` | Storage Temperature |
+| `vector.collectionLot.storageTemperatureC.unit` | °C |
+| `vector.collectionLot.trapConfig.help` | All trap-configuration fields except Trap Type are optional. The LHU Mode A footnote renders these when populated; absent fields are silently omitted. |
+| `vector.collectionLot.deploymentWindow.warning` | Deployment end is before deployment start. Confirm before saving. |
+
+## States (mockup illustrates the first only per MVP scope)
+
+1. **Default / fully populated** (in scope) — all four new fields filled. The KAN-accredited surveillance case that OGC-777 unlocks.
+2. **All four fields blank** (in scope as the backward-compat default) — section renders with empty inputs; LHU Mode A footnote auto-omits the trap-details line.
+3. **Partial population** (deferred) — e.g., only lure entered, deployment dates blank. Allowed; saves cleanly.
+4. **Cross-field warning** (deferred) — deployment_end < deployment_start. InlineNotification kind=warning on save.
+
+## Acceptance Criteria check (mockup → OGC-777)
+
+| OGC-777 AC | Mockup demonstrates |
+| --- | --- |
+| Schema extend `collection_lot` with 4 new fields | Documented in §"Data model" |
+| V-02 form: 4 fields added to CollectionLot edit form; all optional | Shown in §"Layout" |
+| V-01 reference data extends `lure` enum table seed | Documented |
+| API serializes all 4 fields | Documented |
+| Backward compatible (existing LotCollections default NULL) | Documented |
+| LHU Mode A footnote skips trap-detail line when all 4 are null | Inherits from LHU v2.0 §6.4 auto-degrade rule |
+| i18n keys | Documented |
+
+## Out of scope reminders (NOT in this mockup)
+
+These are documented in OGC-777's "Out of scope" section and are NOT depicted here:
+
+* Per-field tooltips or inline help (only the section-level ⓘ helper)
+* Expand/collapse on the Trap Configuration section
+* Hard validation that deployment_end > deployment_start (soft warning only)
+* Temperature-breach alerting / cold-chain integration
+* List-view filtering by trap details (defer to V-04 surveillance reporting)
+
+## References
+
+* [OGC-777](https://uwdigi.atlassian.net/browse/OGC-777) — this story
+* [OGC-555](https://uwdigi.atlassian.net/browse/OGC-555) — V-01 reference data (host for `lure` enum extension)
+* [OGC-581](https://uwdigi.atlassian.net/browse/OGC-581) — V-02 Vector Collection Workflow (host form)
+* [OGC-552](https://uwdigi.atlassian.net/browse/OGC-552) — S-06 LHU v2.0 Mode A consumer
+* `vector-lhu.md` v2.0 §5A + §6.4 — LHU Mode A trap-details footnote rendering
+* WHO 2021 *Operational Manual on Aedes Surveillance* — reproducibility requirements for trap reporting
+* LHU v2.0 upstream gap analysis (2026-05-26)

--- a/mockup-viewer/public/designs/results-validation/results-entry-expanded-uncertainty.html
+++ b/mockup-viewer/public/designs/results-validation/results-entry-expanded-uncertainty.html
@@ -1,0 +1,429 @@
+<!--
+  Results Entry — Expanded Uncertainty (U) Capture
+  Source ticket: OGC-775 (S-15a MVP)
+  Parent epic: OGC-527
+  Consumed by: OGC-552 (S-06 LHU v2.0 conditional U column)
+  Spec: results-entry-expanded-uncertainty.md
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Results Entry — Expanded Uncertainty (U) — OGC-775 mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --gray100: #161616;
+    --gray70:  #525252;
+    --gray50:  #8d8d8d;
+    --gray30:  #c6c6c6;
+    --gray20:  #e0e0e0;
+    --gray10:  #f4f4f4;
+    --blue60:  #0f62fe;
+    --blue10:  #edf5ff;
+    --green60: #198038;
+    --green10: #defbe6;
+    --orange60:#a56eff;
+    --red60:   #da1e28;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+    background: var(--gray10);
+    color: var(--gray100);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 1.5rem 2rem;
+  }
+  /* Breadcrumb */
+  nav.breadcrumb {
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+  }
+  nav.breadcrumb a {
+    color: var(--blue60);
+    text-decoration: none;
+  }
+  nav.breadcrumb a:hover { text-decoration: underline; }
+  nav.breadcrumb .sep { color: var(--gray50); margin: 0 0.5rem; }
+  nav.breadcrumb .current { color: var(--gray70); }
+
+  /* Header card */
+  .card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .card .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .card h1 {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 0.5rem;
+    color: var(--gray100);
+  }
+  .card .subtitle {
+    color: var(--gray70);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+  .card .timestamps {
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--gray70);
+  }
+  .card .timestamps div { margin-bottom: 0.25rem; }
+
+  /* Banner */
+  .banner {
+    background: var(--blue10);
+    border-left: 4px solid var(--blue60);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.875rem;
+  }
+  .banner strong { color: var(--blue60); }
+
+  /* Table */
+  .table-shell {
+    background: white;
+    border: 1px solid var(--gray20);
+    margin-bottom: 1.25rem;
+  }
+  .table-header {
+    padding: 1rem 1.25rem;
+    border-bottom: 1px solid var(--gray20);
+  }
+  .table-header h2 {
+    font-size: 1.125rem;
+    font-weight: 400;
+    margin: 0 0 0.25rem;
+  }
+  .table-header .desc {
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    margin: 0;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.875rem;
+  }
+  table th, table td {
+    text-align: left;
+    padding: 0.75rem 1rem;
+    border-bottom: 1px solid var(--gray20);
+    vertical-align: middle;
+  }
+  table th {
+    background: var(--gray10);
+    font-weight: 600;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    text-transform: none;
+  }
+  table th.numeric, table td.numeric {
+    text-align: left; /* keep left-aligned per Carbon convention */
+    font-variant-numeric: tabular-nums;
+  }
+  table tbody tr:hover {
+    background: var(--gray10);
+  }
+  /* The NEW column gets a subtle highlight in the mockup so the dev can spot it */
+  .u-col {
+    background: rgba(15, 98, 254, 0.04);
+  }
+  th.u-col {
+    background: rgba(15, 98, 254, 0.10);
+  }
+  .new-pill {
+    display: inline-block;
+    margin-left: 0.375rem;
+    padding: 0.0625rem 0.375rem;
+    background: var(--blue60);
+    color: white;
+    border-radius: 2px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    vertical-align: 0.0625rem;
+  }
+  .asterisk {
+    color: var(--blue60);
+    font-weight: 600;
+    margin-left: 0.125rem;
+  }
+  .method-cell {
+    font-size: 0.8125rem;
+    color: var(--gray70);
+  }
+  .empty-cell {
+    color: var(--gray50);
+    font-style: normal;
+  }
+  .na-cell {
+    color: var(--gray70);
+  }
+  .u-prefix {
+    color: var(--gray70);
+    margin-right: 0.125rem;
+  }
+  /* Tag */
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.125rem 0.5rem;
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 500;
+  }
+  .tag.green {
+    background: var(--green10);
+    color: var(--green60);
+  }
+  /* Actions */
+  .actions {
+    white-space: nowrap;
+  }
+  .btn-ghost {
+    background: transparent;
+    border: 0;
+    padding: 0.375rem 0.5rem;
+    color: var(--gray100);
+    cursor: pointer;
+    font-size: 0.8125rem;
+    border-radius: 2px;
+  }
+  .btn-ghost:hover {
+    background: var(--gray20);
+  }
+  .icon-btn {
+    width: 2rem;
+    height: 2rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    border-radius: 2px;
+    color: var(--gray70);
+  }
+  .icon-btn:hover {
+    background: var(--gray20);
+    color: var(--gray100);
+  }
+
+  /* Legend */
+  .legend {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1rem 1.25rem;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    display: flex;
+    gap: 2rem;
+    flex-wrap: wrap;
+  }
+  .legend strong { color: var(--gray100); }
+
+  /* Editing row affordance (illustrative — one row is shown mid-edit) */
+  tr.editing {
+    background: #fffbe6;
+  }
+  tr.editing .u-col {
+    background: #fff3a0;
+  }
+  .u-input {
+    width: 5.5rem;
+    padding: 0.375rem 0.5rem;
+    border: 1px solid var(--gray50);
+    border-radius: 2px;
+    font: inherit;
+    font-variant-numeric: tabular-nums;
+    background: white;
+  }
+  .u-input:focus {
+    outline: 2px solid var(--blue60);
+    outline-offset: -2px;
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb" aria-label="page navigation">
+    <a href="#">Home</a>
+    <span class="sep">/</span>
+    <a href="#">Results</a>
+    <span class="sep">/</span>
+    <span class="current">Order LHU-2026-0042/R</span>
+  </nav>
+
+  <!-- Header card -->
+  <div class="card">
+    <div class="row">
+      <div>
+        <h1>Results Entry &mdash; LHU-2026-0042/R</h1>
+        <p class="subtitle">PT. Unggulrejo Wasono &middot; Air Limbah (Wastewater)</p>
+      </div>
+      <div class="timestamps">
+        <div>Received: 2026-03-08</div>
+        <div>Tested: 2026-03-12 &rarr; 2026-03-15</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mockup-only banner (not part of production UI) -->
+  <div class="banner">
+    <strong>OGC-775 mockup callout (not in production UI):</strong>
+    the only change to this screen is the new <strong>U (k=2)</strong> column right of <strong>Result</strong>. Optional, numeric, blank by default. Backward-compatible &mdash; rows with no U entered render as empty cells (see <em>Fenol Total</em>, <em>TSS</em>, and <em>Krom Total</em> rows). The system does not auto-detect "uncertainty doesn't apply here" &mdash; the lab simply leaves the cell blank. The LHU template (OGC-552) can render its own &mdash; on the report face for below-LOD rows; that's a presentation concern, not an entry concern. One row (<em>BOD5</em>) is shown mid-edit to illustrate the input affordance.
+  </div>
+
+  <!-- Results table -->
+  <div class="table-shell">
+    <div class="table-header">
+      <h2>Results</h2>
+      <p class="desc">Validated test results for this order. Edit a row to enter or update U (k=2).</p>
+    </div>
+    <table>
+      <thead>
+        <tr>
+          <th>Test</th>
+          <th class="numeric">Result</th>
+          <th class="numeric u-col">U (k=2)<span class="new-pill">New</span></th>
+          <th>Unit</th>
+          <th>Reference Range</th>
+          <th>Method</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- BOD5 — editing -->
+        <tr class="editing">
+          <td>BOD5</td>
+          <td class="numeric">11.2</td>
+          <td class="numeric u-col">
+            <input type="number" min="0" step="0.001" value="1.8" class="u-input" aria-label="Expanded uncertainty for BOD5">
+          </td>
+          <td>mg/L</td>
+          <td>&le; 60</td>
+          <td class="method-cell">SNI 6989.72-2009</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="btn-ghost" style="background:var(--blue60);color:white;">Save</button>
+            <button class="btn-ghost">Cancel</button>
+          </td>
+        </tr>
+        <!-- COD -->
+        <tr>
+          <td>COD</td>
+          <td class="numeric">21.5</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>3.2</td>
+          <td>mg/L</td>
+          <td>&le; 150</td>
+          <td class="method-cell">SNI 6989.2-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- pH -->
+        <tr>
+          <td>pH</td>
+          <td class="numeric">6.7</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>0.1</td>
+          <td>&mdash;</td>
+          <td>6.0&ndash;9.0</td>
+          <td class="method-cell">SNI 6989.11-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Amonia Total -->
+        <tr>
+          <td>Amonia Total (NH<sub>3</sub> as N)</td>
+          <td class="numeric">0.255</td>
+          <td class="numeric u-col"><span class="u-prefix">&plusmn;</span>0.038</td>
+          <td>mg/L</td>
+          <td>&le; 8.0</td>
+          <td class="method-cell">SNI 06-6989.30-2005</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Fenol Total — below LOD -->
+        <tr>
+          <td>Fenol Total</td>
+          <td class="numeric">&lt;0.0033</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 0.5</td>
+          <td class="method-cell">SNI 06-6989.21-2004</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- TSS — U blank (backward-compat default) -->
+        <tr>
+          <td>TSS</td>
+          <td class="numeric">14</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 50</td>
+          <td class="method-cell">In House</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+        <!-- Krom Total — below LOD -->
+        <tr>
+          <td>Krom Total (Cr)</td>
+          <td class="numeric">&lt;0.0095</td>
+          <td class="numeric u-col empty-cell">&nbsp;</td>
+          <td>mg/L</td>
+          <td>&le; 1</td>
+          <td class="method-cell">SNI 6989.84-2019</td>
+          <td><span class="tag green">Released</span></td>
+          <td class="actions">
+            <button class="icon-btn" aria-label="Edit row">&#9998;</button>
+            <button class="icon-btn" aria-label="More">&vellip;</button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- Legend -->
+  <div class="legend">
+    <div><strong>U (k=2):</strong> Expanded measurement uncertainty at coverage factor k = 2 (~95% coverage). Optional &mdash; leave blank if not applicable or not computed for this method.</div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/mockup-viewer/public/designs/vector-surveillance/collection-lot-trap-details.html
+++ b/mockup-viewer/public/designs/vector-surveillance/collection-lot-trap-details.html
@@ -1,0 +1,406 @@
+<!--
+  Vector Collection Workflow — Trap Detail Fields
+  Source ticket: OGC-777 (V-05a STRETCH)
+  Parent epic: OGC-527
+  Host screen: V-02 Vector Collection Workflow (OGC-581)
+  Consumed by: OGC-552 (S-06 LHU v2.0 Mode A "Penjebakan / Trap details" footnote)
+  Spec: collection-lot-trap-details.md
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Collection Lot — Trap Details — OGC-777 mockup</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --gray100: #161616;
+    --gray70:  #525252;
+    --gray50:  #8d8d8d;
+    --gray30:  #c6c6c6;
+    --gray20:  #e0e0e0;
+    --gray10:  #f4f4f4;
+    --blue60:  #0f62fe;
+    --blue10:  #edf5ff;
+    --green60: #198038;
+    --green10: #defbe6;
+    --yellow30:#fdd13a;
+    --yellow10:#fcf4d6;
+    --red60:   #da1e28;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    font-family: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+    background: var(--gray10);
+    color: var(--gray100);
+    font-size: 14px;
+    line-height: 1.4;
+  }
+  .page {
+    max-width: 1280px;
+    margin: 0 auto;
+    padding: 1.5rem 2rem;
+  }
+  /* Breadcrumb */
+  nav.breadcrumb {
+    margin-bottom: 1.25rem;
+    font-size: 0.8125rem;
+  }
+  nav.breadcrumb a {
+    color: var(--blue60);
+    text-decoration: none;
+  }
+  nav.breadcrumb a:hover { text-decoration: underline; }
+  nav.breadcrumb .sep { color: var(--gray50); margin: 0 0.5rem; }
+  nav.breadcrumb .current { color: var(--gray70); }
+
+  /* Generic card */
+  .card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1.25rem;
+  }
+  .card .row {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+  }
+  .card h1 {
+    font-size: 1.5rem;
+    font-weight: 400;
+    margin: 0 0 0.5rem;
+    color: var(--gray100);
+  }
+  .card .subtitle {
+    color: var(--gray70);
+    font-size: 0.875rem;
+    margin: 0;
+  }
+  .card .timestamps {
+    text-align: right;
+    font-size: 0.75rem;
+    color: var(--gray70);
+  }
+  .card .timestamps div { margin-bottom: 0.25rem; }
+
+  /* Banner */
+  .banner {
+    background: var(--blue10);
+    border-left: 4px solid var(--blue60);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    font-size: 0.875rem;
+  }
+  .banner strong { color: var(--blue60); }
+  .banner em { font-style: italic; color: var(--gray70); }
+
+  /* Collapsed existing-section bars (mockup affordance only) */
+  .ellipsis-bar {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 0.875rem 1.25rem;
+    margin-bottom: 1.25rem;
+    color: var(--gray50);
+    font-size: 0.8125rem;
+    font-style: italic;
+  }
+
+  /* The Trap Configuration section card */
+  .section-card {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1.5rem 1.75rem;
+    margin-bottom: 1.25rem;
+  }
+  .section-card h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 1.25rem;
+    padding-bottom: 0.625rem;
+    border-bottom: 2px solid var(--gray20);
+    color: var(--gray100);
+  }
+
+  .grid-2 {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+  }
+  .field label {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--gray70);
+    margin-bottom: 0.25rem;
+  }
+  .field .required {
+    color: var(--red60);
+    font-weight: 600;
+    margin-left: 0.125rem;
+  }
+  .new-pill {
+    display: inline-block;
+    margin-left: 0.375rem;
+    padding: 0.0625rem 0.375rem;
+    background: var(--blue60);
+    color: white;
+    border-radius: 2px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
+    vertical-align: 0.0625rem;
+  }
+
+  /* Inputs */
+  .input,
+  .select,
+  .date,
+  .time {
+    background: white;
+    border: 1px solid transparent;
+    border-bottom: 1px solid var(--gray70);
+    font: inherit;
+    font-size: 0.875rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0;
+    width: 100%;
+  }
+  .input:focus,
+  .select:focus,
+  .date:focus,
+  .time:focus {
+    outline: 2px solid var(--blue60);
+    outline-offset: -2px;
+  }
+  .input-with-suffix {
+    display: flex;
+    align-items: center;
+    border-bottom: 1px solid var(--gray70);
+    background: white;
+  }
+  .input-with-suffix input {
+    border: 0;
+    background: transparent;
+    flex: 1;
+    padding: 0.5rem 0.75rem;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+  .input-with-suffix input:focus { outline: none; }
+  .input-with-suffix .suffix {
+    padding: 0.5rem 0.75rem;
+    color: var(--gray70);
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+  .helper {
+    font-size: 0.75rem;
+    color: var(--gray70);
+    margin-top: 0.25rem;
+  }
+
+  /* Datetime composite (date + time + period) */
+  .datetime {
+    display: grid;
+    grid-template-columns: 1fr 4.5rem 4rem;
+    gap: 0.5rem;
+    align-items: end;
+  }
+
+  /* Section-level helper line */
+  .section-helper {
+    display: flex;
+    gap: 0.5rem;
+    align-items: flex-start;
+    font-size: 0.8125rem;
+    color: var(--gray70);
+    padding-top: 0.75rem;
+    border-top: 1px dashed var(--gray20);
+    margin-top: 0.5rem;
+  }
+  .section-helper .icon {
+    flex-shrink: 0;
+    margin-top: 0.0625rem;
+    color: var(--blue60);
+    font-size: 1rem;
+    line-height: 1;
+  }
+  .section-helper strong { color: var(--gray100); }
+
+  /* Action bar */
+  .actions {
+    background: white;
+    border: 1px solid var(--gray20);
+    padding: 1rem 1.25rem;
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+  .btn {
+    padding: 0.625rem 1.25rem;
+    border: 0;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+  .btn.ghost {
+    background: transparent;
+    color: var(--gray100);
+  }
+  .btn.ghost:hover { background: var(--gray20); }
+  .btn.secondary {
+    background: white;
+    color: var(--gray100);
+    border: 1px solid var(--gray100);
+  }
+  .btn.secondary:hover { background: var(--gray20); }
+  .btn.primary {
+    background: var(--blue60);
+    color: white;
+  }
+  .btn.primary:hover { background: #0353e9; }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <!-- Breadcrumb -->
+  <nav class="breadcrumb" aria-label="page navigation">
+    <a href="#">Home</a>
+    <span class="sep">/</span>
+    <a href="#">Vector</a>
+    <span class="sep">/</span>
+    <a href="#">Collection</a>
+    <span class="sep">/</span>
+    <span class="current">CL-2026-0117</span>
+  </nav>
+
+  <!-- Header card -->
+  <div class="card">
+    <div class="row">
+      <div>
+        <h1>Edit Collection Lot &mdash; CL-2026-0117</h1>
+        <p class="subtitle">Kel. Mampang Prapatan, Kec. Mampang Prapatan, Kota Jakarta Selatan</p>
+      </div>
+      <div class="timestamps">
+        <div>Collector: Dr. Budi Santoso</div>
+        <div>Created: 2026-01-13</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Mockup-only banner -->
+  <div class="banner">
+    <strong>OGC-777 mockup callout (not in production UI):</strong>
+    the change to this screen is the new <strong>Trap Configuration</strong> section grouping the existing <em>Trap Type</em> field with four new optional fields &mdash; <strong>Lure</strong>, <strong>Deployment Start</strong>, <strong>Deployment End</strong>, and <strong>Storage Temperature</strong>. Other sections of the CollectionLot form (Sample Info, Site, Specimens, Notes) are unchanged. All four new fields are optional &mdash; backward-compatible default is blank.
+  </div>
+
+  <!-- Collapsed existing sections above -->
+  <div class="ellipsis-bar">
+    &uarr; Sample Info &middot; Site &middot; Collector sections (existing &mdash; not shown in this mockup) &uarr;
+  </div>
+
+  <!-- THE NEW SECTION — Trap Configuration -->
+  <div class="section-card">
+    <h2>Trap Configuration</h2>
+
+    <!-- Row 1: Trap Type (existing) + Lure (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label for="trap-type">Trap Type<span class="required">*</span></label>
+        <select id="trap-type" class="select">
+          <option value="BG_SENTINEL" selected>BG-Sentinel</option>
+          <option value="CDC_BOTTLE">CDC bottle trap</option>
+          <option value="GRAVID">Gravid trap</option>
+          <option value="OVITRAP">Ovitrap</option>
+          <option value="LIGHT_TRAP">Light trap</option>
+          <option value="HUMAN_LANDING_CATCH">Human Landing Catch</option>
+          <option value="DIPPER">Dipper</option>
+          <option value="PIPETTE">Pipette</option>
+          <option value="OTHER">Other</option>
+        </select>
+      </div>
+
+      <div class="field">
+        <label for="lure">Lure<span class="new-pill">New</span></label>
+        <input id="lure" type="text" class="input" value="BG-Lure" placeholder="e.g., BG-Lure, CO&#8322;, octenol" aria-label="Lure (free text)">
+        <div class="helper">Free text &mdash; whatever the lab used.</div>
+      </div>
+    </div>
+
+    <!-- Row 2: Deployment Start (NEW) + Deployment End (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label>Deployment Start<span class="new-pill">New</span></label>
+        <div class="datetime">
+          <input type="date" class="date" value="2026-01-13" aria-label="Deployment start date">
+          <input type="time" class="time" value="06:00" aria-label="Deployment start time">
+          <select class="select" aria-label="Deployment start AM/PM">
+            <option value="AM" selected>AM</option>
+            <option value="PM">PM</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Deployment End<span class="new-pill">New</span></label>
+        <div class="datetime">
+          <input type="date" class="date" value="2026-01-15" aria-label="Deployment end date">
+          <input type="time" class="time" value="06:00" aria-label="Deployment end time">
+          <select class="select" aria-label="Deployment end AM/PM">
+            <option value="AM" selected>AM</option>
+            <option value="PM">PM</option>
+          </select>
+        </div>
+      </div>
+    </div>
+
+    <!-- Row 3: Storage Temperature (NEW) -->
+    <div class="grid-2">
+      <div class="field">
+        <label for="storage-temp">Storage Temperature<span class="new-pill">New</span></label>
+        <div class="input-with-suffix">
+          <input id="storage-temp" type="number" step="0.1" value="-20.0" aria-label="Storage temperature">
+          <span class="suffix">&deg;C</span>
+        </div>
+        <div class="helper">Negative values allowed for frozen storage (-20 &deg;C, -80 &deg;C are common).</div>
+      </div>
+      <div></div>
+    </div>
+
+    <!-- Section-level helper -->
+    <div class="section-helper">
+      <span class="icon" aria-hidden="true">&#9432;</span>
+      <span>
+        All trap-configuration fields except <strong>Trap Type</strong> are optional. The LHU Mode A footnote renders these when populated; absent fields are silently omitted.
+      </span>
+    </div>
+  </div>
+
+  <!-- Collapsed existing sections below -->
+  <div class="ellipsis-bar">
+    &darr; Specimens table &middot; Notes section (existing &mdash; not shown in this mockup) &darr;
+  </div>
+
+  <!-- Action bar -->
+  <div class="actions">
+    <button class="btn ghost">Cancel</button>
+    <button class="btn secondary">Save Draft</button>
+    <button class="btn primary">Save</button>
+  </div>
+
+</div>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -1136,6 +1136,16 @@ export const MOCKUP_REGISTRY = [
     tags: ['compliance', 'evaluation', 'environmental', 'vector', 'results', 'thresholds'],
   },
   {
+    name: 'Results Entry — Expanded Uncertainty (U) Capture',
+    category: 'results-validation',
+    component: React.lazy(() => import('@designs/results-validation/results-entry-expanded-uncertainty.jsx')),
+    description: 'Results Entry screen enhancement (OGC-775, S-15a MVP) — adds an optional U (k=2) numeric column to the results table for ISO 17025 §7.8.3.1(c) expanded measurement uncertainty capture. Backward-compatible: labs without uncertainty leave the cell blank. The LHU v2.0 (OGC-552) conditional U column reads this value when populated. MVP scope only — no tooltips, admin toggle, or method-level prefill; those land in S-15a v2 if needed.',
+    specPath: 'designs/results-validation/results-entry-expanded-uncertainty.md',
+    htmlUrl: 'designs/results-validation/results-entry-expanded-uncertainty.html',
+    added: '2026-05-28',
+    status: 'draft',
+  },
+  {
     name: 'Reusable Categorical Vocabulary',
     category: 'vector-surveillance',
     component: null,
@@ -1173,6 +1183,16 @@ export const MOCKUP_REGISTRY = [
     status: 'draft',
     relatedTo: ['Laporan Hasil — Compliance Report'],
     tags: ['report', 'vector-surveillance', 'laporan-hasil', 'LHU', 'pdf', 'certificate', 'Indonesia', 'SILNAS', 'KAN', 'mosquito', 'entomology'],
+  },
+  {
+    name: 'Collection Lot — Trap Details',
+    category: 'vector-surveillance',
+    component: React.lazy(() => import('@designs/vector-surveillance/collection-lot-trap-details.jsx')),
+    description: 'V-02 Vector Collection Workflow form enhancement (OGC-777, V-05a STRETCH) — adds a "Trap Configuration" section to the existing CollectionLot edit form with four new optional fields: lure, deployment_start, deployment_end, storage_temperature_c. WHO entomological surveillance reproducibility requirements. Backward-compatible: existing CollectionLots remain valid with NULL values. LHU Mode A footnote auto-degrades when fields are null. STRETCH: partner labs do not yet capture this granularity.',
+    specPath: 'designs/vector-surveillance/collection-lot-trap-details.md',
+    htmlUrl: 'designs/vector-surveillance/collection-lot-trap-details.html',
+    added: '2026-05-28',
+    status: 'draft',
   },
   {
     name: 'Laporan Hasil — Compliance Report',


### PR DESCRIPTION
Two small, focused mockups landing follow-up to the S-06 LHU v2.0 work (parent: OGC-552 / OGC-527).

OGC-775 (S-15a MVP) — Results Entry expanded uncertainty (U) capture:
- New inline "U (k=2)" column right of "Result" in the Results Entry table.
- Optional numeric input. Backward-compatible: labs without uncertainty leave blank; below-LOD and qualitative rows also stay blank (the LHU template handles "—" rendering on the report face, not the entry surface).
- KAN accreditation asterisk intentionally not surfaced on Results Entry (LHU-rendering concern only).
- MVP scope per OGC-775; no tooltip / admin gate / method-prefill (S-15a v2 if evidence later justifies).
- Files: designs/results-validation/results-entry-expanded-uncertainty.{md,jsx,html}

OGC-777 (V-05a STRETCH) — CollectionLot trap-detail fields:
- New "Trap Configuration" section on the existing CollectionLot edit form groups the existing trap_type field with four new optional fields: lure (free text), deployment_start, deployment_end, storage_temperature_c.
- lure was simplified from ENUM + V-01 reference data extension to plain free text (2026-05-28 decision) since it's display-only on the LHU footnote and not used for any filtering/aggregation/evaluation. See OGC-777 comments for rationale.
- Soft warning (no hard block) when deployment_end < deployment_start.
- Files: designs/vector-surveillance/collection-lot-trap-details.{md,jsx,html}

Both mockups: App.jsx MOCKUP_REGISTRY entries added; MANIFEST.yaml entries added; mockup-viewer/public/ HTML copies for local dev serving; all 231 tests pass.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
