### PR TITLE
feat(sample-collection): add Reference Lab Results design (OGC-796)

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -2715,3 +2715,39 @@
     - stretch
   added: "2026-05-28"
   status: draft
+
+- id: reference-lab-results
+  type: both
+  path: designs/sample-collection/reference-lab-results.jsx
+  spec: designs/sample-collection/reference-lab-results.md
+  preview: designs/sample-collection/reference-lab-results.html
+  category: sample-collection
+  description: >
+    New SideNav item under Sample Shipment at /SampleShipment/reference-lab-results.
+    Tracks the data lifecycle of every referred sample after physical shipment:
+    Outstanding, Returned-needs-action, and History views. Migrates ReferralStatus
+    enum to FHIR Task states (draft/requested/received/in-progress/completed plus
+    cancelled/rejected). Adds visible two-line "Enter result" button for manual
+    posting from non-OpenELIS reference labs. Accept = reception (peer already
+    validated); Reject = terminal close + clinician notification via OGC-589 +
+    Alerts feature trigger. Box.Reconciled gate prevents closing a Box until all
+    contained referrals are terminal. Companion docs in the same folder:
+    -dev-primer.md (narrative walkthrough), -breakdown.md (1 Epic + 14 stories
+    across 3 sprints), -brainstorm.md (problem framing + locked decisions),
+    -analyze-report.md (/analyze quality scan). Supersedes the state-model
+    scope of OGC-624 (Inter-Lab Transfer).
+  links:
+    jira: ["OGC-796", "OGC-797", "OGC-798", "OGC-799", "OGC-800", "OGC-801", "OGC-802", "OGC-803", "OGC-804", "OGC-805", "OGC-806", "OGC-807", "OGC-808", "OGC-809", "OGC-810"]
+    gallery: https://digi-uw.github.io/openelis-work/#/sample-collection/reference-lab-results
+    preview: https://digi-uw.github.io/openelis-work/designs/sample-collection/reference-lab-results.html
+  tags:
+    - referral
+    - reference-lab
+    - FHIR
+    - sample-shipment
+    - reconciliation
+    - inter-lab
+    - madagascar
+    - global
+  added: "2026-05-28"
+  status: draft

--- a/designs/sample-collection/reference-lab-results-analyze-report.md
+++ b/designs/sample-collection/reference-lab-results-analyze-report.md
@@ -1,0 +1,82 @@
+# /analyze Quality Report — Reference Lab Results
+
+**Date:** 2026-05-28
+**Artifacts reviewed:**
+- `referral-redesign-brainstorm.md`
+- `referral-redesign-frs.md`
+- `referral-redesign-mockup.jsx`
+- `referral-redesign-preview.html`
+
+---
+
+## Summary
+
+Overall quality is solid for a first-pass FRS+mockup+preview bundle. The state model, IA placement, and Box-system integration are coherent. The Lab Context section is plain-English and ~90-second readable. No constitution MUSTs are violated. **Three CRITICAL i18n gaps** in the mockup need fixing before `/breakdown`. **One MEDIUM** finding on the spec needs a one-paragraph clarification (FHIR DiagnosticReport-vs-Result rendering). Everything else is LOW polish.
+
+---
+
+## Findings
+
+| ID | Pass | Location | Issue | Severity | Fix |
+|---|---|---|---|---|---|
+| F-01 | A (i18n) | mockup.jsx · `TableContainer title="Outstanding referrals" description="…"` (and equivalents in ReturnedTable, HistoryTable) | Table titles and descriptions hardcoded in JSX, not in Localization table | **CRITICAL** | Wrap as `t('referral.table.outstanding.title', 'Outstanding referrals')` etc. Add 6 keys to §7 |
+| F-02 | A (i18n) | mockup.jsx · ExpandPanel sub-headings ("Status detail", "Outcome detail", "Result") | Hardcoded strings | **CRITICAL** | Wrap each + add keys |
+| F-03 | A (i18n) | mockup.jsx · OverflowMenuItem text ("Reject…", "Open in Result Entry"), button text ("Accept", "Accept to Analysis") | Hardcoded strings | **CRITICAL** | Wrap + verify already-listed keys in §7 cover them |
+| F-04 | A (i18n) | FRS §7 Localization table | Missing keys: 6 table titles/descriptions, 3 expand-panel sub-headings, 2 OverflowMenuItem labels, 5 result-card labels ("Reference range:", "Test", "Value", "Units", "Notes") | HIGH | Add 16 keys |
+| F-05 | G (invented data) | FRS §4.6 result-card display fields (`results[].range`, `results[].flag`, `results[].notes`) | These come from inbound FHIR `DiagnosticReport.Observation` resources, not the existing OpenELIS `Result` entity. Spec doesn't clarify the data source for the rendering — is this a transient view of DiagnosticReport JSON, or do we persist these fields somewhere before Accept? | MEDIUM | Add §4.6.1 "Returned-result data source: rendered directly from `DiagnosticReport.Observation` resources stored in the FHIR persistence layer; not persisted to a separate table. The Accept action persists into the standard `Result` entity by mapping Observation → Result." |
+| F-06 | N (Lab Context) | FRS §1.1 | "FHIR" used without first-use expansion | LOW | "FHIR (Fast Healthcare Interoperability Resources)" on first use |
+| F-07 | C (Carbon fidelity) | mockup.jsx · MetricTile component | Uses raw `<button>` with inline `borderLeft` instead of Carbon `Tile`. Justified — Carbon `Tile` doesn't have a thick-left-border variant; the deployed Sample Shipment dashboard uses the same custom pattern. Document the deviation. | LOW | Add comment block in JSX noting the lifted pattern from `/SampleShipment/dashboard` |
+| F-08 | C (Carbon fidelity) | mockup.jsx · FilterChip component | Carbon `ChipSet` is not used (custom button group instead). Justified — Carbon `ChipSet` API is filter-pill style and works fine, but the lift target is to keep visual consistency with the empty/filter-chip patterns in the deployed app. Acceptable as long as accessibility (Tab navigation, ARIA `role="tablist"` NO — that would imply tabs; use `role="radiogroup"` with `aria-checked` per chip) is documented. | LOW | Add ARIA attributes to FilterChip in mockup; document in FRS NFR-2 |
+| F-09 | E (coverage) | FR-INT-001 (Box-to-Referral back link section on Box detail page) | Not shown in mockup. Reasonable since the mockup is for the new Reference Lab Results page, and the back link lives on the existing Sample Shipment Box detail. Flag as a separate story in `/breakdown`. | LOW | No change — capture as a separate dependency story |
+| F-10 | E (coverage) | FR-OE-001 (Order Entry Step 3 hook) | Not shown in mockup. Lives on the OGC-605 Order Entry wizard, not this surface. | LOW | No change — capture as dependency on OGC-605 |
+| F-11 | E (coverage) | FR-INT-002 (Reconciliation gate on Box state) | Not shown in mockup. Lives on the existing Box state-transition UI. | LOW | No change — capture as a small dependency story |
+| F-12 | B (Carbon fidelity) | mockup.jsx · expand panel "Mark Lost" button | Uses `kind="ghost"` with `renderIcon={WarningAlt}`. The deployed Sample Shipment doesn't have a "Mark Lost" precedent to reference. Pattern is fine but worth a screenshot review once built. | LOW | No change |
+| F-13 | K (audit) | FRS §8.2 | `REFERRAL_LOST_REVERSED` listed but no UI surface in this FRS to invoke it (admin-only reverse). Either declare the admin UI as out-of-scope for this FRS or remove the verb. | LOW | Add to §9 Non-goals: "Admin UI to reverse a Lost referral — separate Sample Shipment admin work." Keep the verb in case the existing Sample Shipment admin already triggers it. |
+| F-14 | F (cross-module harmonization) | FRS §4.4 Outstanding view, mockup display | "Days outstanding" uses 7/30 thresholds that match the Unassigned Samples aging convention (also 7/30 per the Box FRS §5.7 BR-029). Good harmonization. | — | No issue; documented for traceability |
+| F-15 | I (stubbed preview) | preview.html · all three views | All views populated with realistic mock data. Activity logs realistic. Modals populated. NO stubs detected. ✓ | — | No issue |
+| F-16 | H (multitenancy) | All artifacts | No Lab selector, Site filter, or tenant dropdown anywhere. Reference Lab is a destination Organization, not a tenant. ✓ | — | No issue |
+| F-17 | J (permissions) | FRS §2.5, §8.1 | No invented per-action permission keys. Attaches to existing role bundles (Validator, Lab Manager, Analyst, Reception, Provider, Admin). ✓ | — | No issue |
+| F-18 | L (Envers) | FRS §8.3 | No new entities; existing `@Audited` on `Referral` covers new columns. ✓ | — | No issue |
+| F-19 | A (i18n) | mockup.jsx · `Outstanding referrals`, `${rows.length} referrals at reference labs awaiting results` description | Pluralization not handled (would read "1 referrals" with one row). Use ICU plural format or conditional. | MEDIUM | Use `t('referral.table.outstanding.desc', '{N} referrals at reference labs awaiting results', { N: rows.length })` with a fallback that handles plural |
+| F-20 | E (coverage) | FRS §11 Open question 2 (multi-test Accept) | Spec leaves "per-test or all-or-nothing" undecided. This needs resolution before `/breakdown` because it affects v1 story estimation. | MEDIUM | Decide in next iteration; recommend per-test with a summary confirmation |
+| F-21 | E (coverage) | FRS §11 Open question 3 (re-refer after Reject UX) | Affects FR-RETURNED-003 follow-through. Recommended yes; mockup currently doesn't surface the "re-refer?" prompt. | MEDIUM | Mockup the re-refer prompt as a Carbon `InlineNotification kind="info"` with a button on the original Analysis page (lives outside this FRS but worth a sketch) |
+
+---
+
+## Constitution check
+
+No CRITICAL constitution violations.
+- Principle 1 (i18n): mockup is mostly compliant but has 3 CRITICAL hardcoded-string gaps (F-01, F-02, F-03). Localization table is well-organized but missing 16 keys (F-04).
+- Principle 2 (Carbon fidelity): two justified deviations (F-07, F-08) lifted from the deployed Sample Shipment UI; both documented.
+- Principle 3 (interaction patterns): inline row expansion used, modals only for destructive confirmations. ✓
+- Principle 4 (permissions): no invented per-action keys, existing role bundles attached. ✓
+- Principle 5 (data reuse): all UI elements trace to real schema. One MEDIUM clarification needed on DiagnosticReport-vs-Result data source (F-05).
+- Principle 6 (no multitenancy): clean. ✓
+- Principle 7 (design brief): produced in brainstorm v2. ✓
+
+---
+
+## Recommended fix order
+
+**Before `/breakdown` (CRITICAL):**
+1. F-01, F-02, F-03 — wrap hardcoded strings in `t()`
+2. F-04 — add 16 missing i18n keys to §7 of FRS
+
+**Before build (HIGH/MEDIUM):**
+3. F-05 — one paragraph in FRS §4.6.1 on DiagnosticReport-vs-Result rendering
+4. F-19 — fix pluralization in table descriptions
+5. F-20 — decide multi-test Accept behavior (per-test recommended)
+6. F-21 — sketch the re-refer prompt on Analysis page (out-of-scope surface; just a note)
+
+**LOW polish (can defer):**
+7. F-06 — expand FHIR on first use
+8. F-07, F-08 — document the Carbon deviations
+9. F-13 — add Lost-reversal to §9 Non-goals
+
+---
+
+## Ready for `/breakdown`?
+
+**After fixing F-01 through F-04**, yes. The CRITICAL findings are mechanical i18n cleanup — about 15 minutes of edits.
+
+The MEDIUM findings are policy questions that can be answered during `/breakdown` Stage 1 or in the first build sprint without blocking story creation.

--- a/designs/sample-collection/reference-lab-results-brainstorm.md
+++ b/designs/sample-collection/reference-lab-results-brainstorm.md
@@ -1,0 +1,237 @@
+# Referral Redesign — Problem Framing & Brainstorm (v2)
+
+**Author:** Casey + Claude
+**Date:** 2026-05-28
+**Status:** Pre-FRS direction-setting (v2 — re-scoped after Box of Samples integration)
+**Umbrella Jira:** OGC-796 (to be promoted to Epic)
+**Related tickets:** OGC-624 (in progress), OGC-589 (in progress), OGC-605 (backlog), OGC-503, OGC-449 (closed)
+**Sibling feature already live:** Sample Shipment / Referred Sample Container Management — `/SampleShipment/*` on testing.openelis-global.org
+
+---
+
+## 1. The reframing
+
+The original brainstorm assumed the Referral feature would handle the full lifecycle from refer-out through return-of-result. After loading the Referred Sample Container spec and mining the deployed `Sample Shipment` feature on testing, the picture is different:
+
+**The Sample Shipment system already exists, is live, and owns:**
+- Box creation, sample assignment, manifest generation, label printing
+- The full 9-state physical shipment lifecycle: `Draft → Ready to Send → Sent → In Transit → Partially Received → Received → Reconciled → Cancelled → Lost in Transit`
+- An "Unassigned Samples" tab for referred samples not yet in a box
+- Receiving workflow with non-conformity capture
+- FHIR `SupplyDelivery` exchange and facility registry admin
+- A shipping dashboard with metric tiles: IN TRANSIT / DELIVERED / RECONCILED / TOTAL SAMPLES
+
+**What the Sample Shipment system does NOT own:**
+- The data state of an individual referred Analysis after the box has been received at the reference lab
+- The arrival, reconciliation, and acceptance of returned `DiagnosticReport` results into the local Analyses
+- A view of "what tests am I still waiting on from reference labs?"
+- A view of "what results came back today and need a validator's eye?"
+
+That gap — **between Box.Received and Box.Reconciled** — is the Referral redesign's home. Conceptually:
+
+| FHIR resource | Owned by | Lifecycle |
+|---|---|---|
+| `SupplyDelivery` | Sample Shipment | Physical shipping of boxes |
+| `Task` + `ServiceRequest` | **Referral (this redesign)** | Per-sample referral state, return-result reconciliation |
+| `DiagnosticReport` | Referral inbound side | Results returning from reference labs |
+
+The two systems run on parallel lifecycles, tightly coupled but separately rendered.
+
+---
+
+## 2. Locked decisions (carried forward from /clarify, all still valid)
+
+| Q | Decision |
+|---|---|
+| 1. State machine | FHIR Task states canonical (`draft → requested → received → in-progress → completed` + `cancelled`/`rejected` as exits) |
+| 2. Creation paths | Both Order Entry Step 3 AND Result Entry, dedupe on Analysis ID |
+| 3. Inbound enhancement | None in v1 — existing Incoming Orders queue handles it; no Source column |
+| 4. Ticket umbrella | OGC-796 = Epic; OGC-605/OGC-589 fold in; OGC-624 surgery on state model |
+
+The /clarify pass results stand. The Box integration narrows scope but does not invalidate any decision.
+
+---
+
+## 3. New scope — what the redesigned Referral feature actually does
+
+### 3.1 Surface 1: Outstanding Tests dashboard
+Sample-level view of every referral where the local FHIR Task is in `requested`, `received`, or `in-progress` and no `DiagnosticReport` has arrived. Filter by reference lab, days outstanding, priority. SLA timer per row. Direct link to the Box that carried the sample (read-only).
+
+### 3.2 Surface 2: Result Return inbox
+The primary attention lane. Rows where `Task.status = completed` and a `DiagnosticReport` has arrived, but a validator hasn't yet accepted the result into the local Analysis. Three actions per row: **Accept to Analysis** (commits the result, advances local Analysis to validation queue), **Reject with reason** (sends `Task.status = rejected` back, re-opens local Analysis), **Open in Result Entry** (jump to the existing Logbook page with the sample loaded).
+
+### 3.3 Surface 3: Performed / Rejected history
+Closed referrals — completed and reconciled, or rejected, or cancelled. Read-only audit view. Filter, search, export.
+
+### 3.4 State-model migration (existing scope)
+`ReferralStatus` enum → FHIR Task states. Liquibase migration. Update outbound write path in `FhirReferralServiceImpl` to emit the full lifecycle (today only `REQUESTED → COMPLETED` are written; `CANCELLED` is commented out).
+
+### 3.5 Integration with Sample Shipment
+- Each Referral row links to its containing Box (forward link, read-only)
+- Each Box row in Sample Shipment gains a "View Referrals" overflow action (back link, read-only) — small change to existing screen, flag as a dependency
+- When a Box transitions to `Reconciled`, the system asserts that all Referrals contained have Task status of `completed` or `rejected`; if not, raise an inline warning (does not block reconciliation, just surfaces drift)
+
+### 3.6 OGC-605 Order Entry Step 3 hook
+Locked in via Q2 — declared at order time, dedupe on Analysis. The order-entry-side Refer Out checkbox writes the Referral row in `draft` state and feeds it into the Unassigned Samples tab on Sample Shipment automatically.
+
+---
+
+## 4. IA placement — SideNav submenu item, internal filter chips (no in-page tabs)
+
+**Decision:** The redesigned Referral surface is a **new SideNav submenu item** under the existing `Sample Shipment` group. **No in-page Carbon Tabs** — per OpenELIS convention, multi-view screens use SideNav submenu items, not tabs. The page itself uses a **filter chip group** to switch between the three view states.
+
+> *Note on the deployed Sample Shipment UI: it currently renders Dashboard / Create Box / Receive Box / Reports / Settings as Carbon Tabs in addition to being separate SideNav-reachable routes. That double rendering is a violation of the sidenav convention but is shipped — out of scope to fix here. The new Reference Lab Results page only renders in SideNav; it does NOT add to the tab strip.*
+
+### 4.1 SideNav structure
+```
+Sample Shipment (top-level)
+├── Dashboard              /SampleShipment/dashboard
+├── Create Box             /SampleShipment/create-box
+├── Receive Box            /SampleShipment/receive
+├── Reference Lab Results  /SampleShipment/reference-lab-results  ← NEW
+├── Reports                /SampleShipment/reports
+└── Settings               /SampleShipment/settings
+```
+
+The new SideNav item gets a count badge (e.g. `Reference Lab Results [3]` when 3 results are awaiting reconciliation) to drive attention without requiring the user to open the page first.
+
+### 4.2 Page layout — single scroll, internal filter switching
+
+```
+Header: Reference Lab Results  (h1)
+Breadcrumb: Home / Sample Shipment / Reference Lab Results
+────────────────────────────────────────────────────────
+Metric tiles row (Carbon Tile, thick left border):
+  [Outstanding: 12]  [Returned — needs action: 3]  [Reconciled today: 7]  [Rejected: 1]
+────────────────────────────────────────────────────────
+Filter chip group (Carbon ChipSet, single-select):
+  ( Outstanding ) ( Returned — needs action ) ( History )
+Plus secondary filters: Reference Lab • Date range • Priority • Days outstanding bucket
+────────────────────────────────────────────────────────
+DataTable (single table, contents driven by the active chip):
+  columns vary per filter state (see below)
+  inline row expand for detail panel
+```
+
+The filter chip is reflected in the URL as a query parameter (`?view=outstanding|returned|history`) so the view is deep-linkable. Clicking a metric tile sets the corresponding chip.
+
+### 4.3 The three filter states
+
+| Chip | Drives DataTable to show | Default sort |
+|---|---|---|
+| **Outstanding** | Task status `requested` / `received` / `in-progress`, no DiagnosticReport yet | Days outstanding, descending |
+| **Returned — needs action** | Task status `completed`, DiagnosticReport present, not yet reconciled | Returned date, descending |
+| **History** | Reconciled, Rejected, Cancelled — read-only | Closed date, descending |
+
+### 4.4 Default columns per filter state
+
+**Outstanding:** Lab Number · Patient · Test(s) · Reference Lab · Box ID · Sent Date · Status · Days outstanding · Priority
+
+**Returned — needs action:** Lab Number · Patient · Test(s) · Reference Lab · Result · Returned Date · Original requestor · Action menu (Accept / Reject / Open in Result Entry)
+
+**History:** Lab Number · Patient · Test(s) · Reference Lab · Outcome · Closed date · Box ID · Days total
+
+### 4.5 Shared secondary filters
+Date range (sent date) · Reference lab · Priority · Days outstanding bucket (matching the Unassigned Samples aging convention: 0-7 / 7-30 / >30 days)
+
+### 4.6 Per-row expand panel
+Same Carbon inline-row expand convention (NOT a modal). Sections:
+- **Original order context** — local lab number, original Analysis state, requesting provider, collection date
+- **Reference lab transit** — Box ID (link), dispatched date, received-at-reference-lab date, manifest version
+- **Result** (Returned tab only) — DiagnosticReport summary, returned value(s), units, reference range, peer's interpretation
+- **Activity log** — Task state transitions, who, when, audit trail
+
+---
+
+## 5. Visual conventions to lift from the deployed Sample Shipment UI
+
+These will land verbatim in the mockup:
+
+- **Metric tiles** — Carbon Tile with thick colored left border, large numeric value, uppercase caption underneath. Color family: green for active in-flight, teal for completed-and-good, blue for total, red for attention-needed.
+- **Sticky Summary side-panel** — when a referral row is in detail view, the right-side panel holds the Accept / Reject / Open buttons (matches Create Box's pattern).
+- **Yellow `InlineNotification` stack** — for validation gates (e.g. "Cannot accept — reference range missing").
+- **Sub-tab pattern** — Carbon Tabs with iconDescription, count tags for attention.
+- **Single-scroll page** — no accordion, no modals (modals only for destructive confirmations like Reject).
+- **Empty state copy** — "No X found for selected filters."
+
+---
+
+## 6. Updated state-model migration plan
+
+Same as v1 brainstorm — no change. Repeating here for completeness:
+
+1. Liquibase migration: `ReferralStatus` enum values rename to FHIR-aligned strings. Keep old values readable for transition window.
+2. Update `FhirReferralServiceImpl.createReferralTask`:
+   - `draft` set at creation (no Task emitted yet)
+   - `requested` set when Box transitions to `Sent` (matches the existing wire moment in Sample Shipment)
+   - `received` set when Box transitions to `Received` (NEW — wires from Sample Shipment receive action)
+   - `in-progress` set when peer's Task PUT or first partial DiagnosticReport arrives (NEW handler)
+   - `completed` set when full DiagnosticReport arrives (existing behavior; refine)
+   - `cancelled` set on sender-initiated cancel (un-comment existing code path)
+   - `rejected` set on validator's Reject action (NEW handler)
+3. Backfill: `CREATED → draft`, `RECEIVED → received` if no result yet else `completed`, `CANCELED → cancelled`. Dead `SENT/FINISHED` rows shouldn't exist; if they do, map to `requested/completed` respectively.
+4. The Box's existing `Reconciled` state is the box-level signal that all contained Referrals have reached `completed` or `rejected`. The Referral state machine and the Box state machine are joined at the Box.Reconciled transition (asserted, not auto-cascaded).
+
+---
+
+## 7. OGC-624 reconciliation — updated
+
+OGC-624 (Inter-Lab Transfer & Subcontract) proposes a `subcontractStatus` field with `DRAFT → DISPATCHED → RECEIVED → RESULTS_RETURNED → CLOSED`. Most of this is already covered by the Box's 9-state model. The redesign supersedes the state-field proposal.
+
+**Reconciliation plan:**
+- **Close OGC-624's state-model scope.** Code already written for `subcontractStatus` re-points at the unified `ReferralStatus` (now FHIR-aligned) on the sample side, and the existing 9-state box enum on the box side. Two clean state machines (Box logistics + Referral data state) — no third invented status field.
+- **OGC-624's subcontract metadata panel** is already covered by Sample Shipment's destination/temperature/notes fields. Re-point.
+- **OGC-624's outbound WhatsApp/email** integrates with OGC-589's notification infra. Lives on the Referral row's expand panel as a "Notify reference lab" action that fires the existing trigger.
+- **OGC-624's inbound FHIR registration** — already covered by existing Incoming Orders behavior per Q3.
+- **Coordinate with OGC-624's owner before any surgery.** Likely Herbert per memory; confirm during /breakdown.
+
+---
+
+## 8. Open risks
+
+1. **Box.Reconciled definition is firm: received AND all samples accepted into the workflow.** Confirmed by Casey 2026-05-28. A Box cannot reach `Reconciled` until every contained Referral has been either accepted to its local Analysis (`Task.status = completed` + result reconciled) or formally rejected/cancelled. **The Referral feature explicitly drives the transition to Reconciled** — every Accept action on the Returned tab is a step toward closing a Box. The Sample Shipment UI may want to surface, on the Box detail, "N samples awaiting reconciliation in Reference Lab Results" with a deep link.
+
+2. **Stuck Boxes are the real drift case.** A Box can sit at `Received` indefinitely if a peer never returns the DiagnosticReport. The Outstanding view's "Days outstanding" SLA timer is the primary signal. Risk: lab managers don't notice; need an aging banner on the Reference Lab Results page when there are >X stuck referrals.
+
+3. **State-model migration is destructive.** Liquibase must be reversible. Migration tested on a copy of production. Pre-conditions and rollback block on the changeset are non-negotiable.
+
+4. **Peer-OE state synchronization is async.** Peer's Task PUT to `received` may arrive before local `requested` write commits (race on first dispatch). Receive endpoint must idempotently accept the latest state regardless of order.
+
+5. **A peer-rejected referral needs to put the original Analysis back into a workable state.** Today no such code path exists. Spec must define: which Analysis state does it return to (`not_started`? `in_progress`?), is the Refer Out flag retained, does the validator get notified.
+
+6. **OGC-605 is in backlog.** If it doesn't land in the same sprint cluster as the Referral dashboard, v1 dashboard will only see referrals created via Result Entry. Acceptable; the empty/sparse state of the dashboard is fine.
+
+7. **Bulk re-referral.** If a Reject sends the Analysis back, can the validator re-refer immediately? Yes, but to which lab — the same one (with a manual override) or a different one? FRS-level decision.
+
+---
+
+## 9. Out of scope for v1 (explicit)
+
+- **All of Sample Shipment** — box creation, sample-to-box assignment, manifest generation, label printing, receiving workflow, non-conformity capture, facility registry, label preset admin, FHIR `SupplyDelivery` exchange. **Already shipped, not touched.**
+- **Unassigned Samples tab** — already shipped at `/SampleShipment/unassigned`. Our work feeds it via OGC-605 (Order Entry refer-out path) and the Result Entry path.
+- Source detection on Incoming Orders (Q3)
+- Auto-accept inbound FHIR (Q3)
+- Reference Lab admin redesign — already exists, reused
+- Multi-test bulk dispatch as a single Referral (one-Analysis-per-Referral stays the invariant)
+- Metrics/turnaround reports — separate Reports work, not the operational dashboard
+- Mobile app for outstanding-test lookup
+- Predictive alerts for aging referrals
+
+---
+
+## 10. What I need from you before I write the FRS
+
+**Resolved by Casey 2026-05-28:**
+
+- ✅ Three-surface decomposition (Outstanding / Returned / History)
+- ✅ Lives under `/SampleShipment/*` as a SideNav submenu item, not a tab
+- ✅ `Reconciled` = received AND all samples accepted into the workflow
+
+**Remaining for FRS:**
+
+- Default columns per filter state (§4.4) — open for tweaks
+- Inline-row expand sections (§4.6) — open for tweaks
+- Visual conventions to lift from the deployed Sample Shipment UI (§5)
+- OGC-624 reconciliation plan (§7) — confirm OGC-624 owner before any ticket surgery in `/breakdown`
+
+If no further pushback, I'll start the FRS.

--- a/designs/sample-collection/reference-lab-results-breakdown.md
+++ b/designs/sample-collection/reference-lab-results-breakdown.md
@@ -1,0 +1,133 @@
+# Reference Lab Results — Story Breakdown
+
+**Mockup:** `referral-redesign-mockup.jsx`
+**FRS:** `referral-redesign-frs.md`
+**Total versions:** 3
+**Total points:** 58
+**Sprints required (estimate):** 3 × 2-week sprints
+
+---
+
+## Epic
+
+**Title:** Reference Lab Results — Outstanding tests + result reconciliation
+**Description summary:**
+Adds a sample-level data-state tracking surface for referrals: dashboard for outstanding tests at reference labs, an inbox for returning DiagnosticReports awaiting validator acceptance, and a closed-referral history. Includes migration of `ReferralStatus` to FHIR Task-aligned states and wiring of the full Task lifecycle on both outbound and inbound paths. Complements the shipped Sample Shipment feature (which owns physical shipping logistics) by handling the per-sample data state between Box.Received and Box.Reconciled.
+
+**Parent / linked program epic:** none — standalone Epic; coordinate with OGC-624 (in-progress) for state-model surgery
+**Promote from:** OGC-796 (created 2026-05-28; promote to Epic on approval)
+**Labels:** `referral`, `sample-shipment`, `fhir`, `madagascar`, `global`
+**Folds in:** OGC-605, OGC-589 (their scope absorbed as child stories below)
+
+---
+
+## v1 — Read-only foundation + state-model migration
+
+**Sprint target:** 20 points
+**Actual:** 20 points
+**Shippable slice:** Lab managers and validators can open Reference Lab Results, see what's outstanding at reference labs with how many days, **manually post results from non-OpenELIS reference labs via the existing Result Entry screen** (state advances automatically), browse a History of closed referrals, and mark stuck samples as Lost. State-model migration runs cleanly in the background. Auto-driven DiagnosticReport routing and Accept/Reject for peer OpenELIS labs lands in v2.
+
+| Story | Points | FRs covered | Cross-cutting included |
+|---|---|---|---|
+| **S1.1 — Migrate ReferralStatus to FHIR Task states** | 5 | FR-MIG-001 through FR-MIG-005 | Liquibase changeset (with rollback + preConditions); Java enum update in `org.openelisglobal.referral.valueholder.ReferralStatus`; reference updates across `ReferralService`, `ReferralResultService`, `FhirReferralServiceImpl`, `ReferredOutTestsRestController`. i18n keys `referral.status.*` (8 keys per §6.4 of FRS). `audit_trail` plumbing for `REFERRAL_STATE_CHANGED` verb (writes start in v2 actions). Envers — no new entities. |
+| **S1.2 — Scaffold Reference Lab Results page** | 5 | FR-PAGE-001/002/003/004, FR-METRIC-001/002/003, FR-FILTER-001/002/003/004 | New Spring controller + REST endpoint at `/SampleShipment/reference-lab-results`; React page shell with breadcrumb + h1; new SideNav submenu item under Sample Shipment (count-badge wired in v2 when Returned counts are non-zero); 4 metric tiles with clickable filter triggers; primary filter ChipSet; secondary filter row (Reference Lab dropdown from existing Organization Management, Date range, Priority MultiSelect, Days bucket Select); URL query-param deep-linkability; role attachment to existing Validator / Lab Manager / Admin (read-only for Analyst / Reception / Provider). i18n keys: `referral.page.title`, `referral.sidenav.*`, `referral.breadcrumb.*`, `referral.chip.*`, `referral.metric.*`, `referral.filter.*`. |
+| **S1.3 — Outstanding DataTable + inline expand + Manual Entry path + Mark Lost** | 5 | FR-OUTSTANDING-001/002/003/004/005, FR-EXPAND-001/002/003/005/006, FR-FHIR-001 (manual-entry trigger row) | 9-column DataTable + actions column with server-side sort and pagination; inline row expansion (3-column panel: Original order context, Reference lab transit, Status detail); Activity log StructuredList. **Manual Entry path**: per-row **two-line "Enter result" Button** (visible, NOT in an overflow menu — see FR-OUTSTANDING-004) + expand-panel primary Button, both deep-link to `/result?sampleId=<labNumber>` (zero new UI — reuses existing Result Entry); server-side hook in `ResultService.create` / `LogbookResultsController` detects "save against open Referral" and advances `Task.status = completed`, sets `reconciled`, `reconciled_at`, `reconciled_by`, `manually_entered = true`, emits FHIR Task PUT, emits `audit_trail` `REFERRAL_RESULT_RECEIVED` with `source: manual`. Mark Lost button + modal + write path (expand-panel only). New columns on `referral`: `manually_entered` (Liquibase). i18n keys: column headers, expand-panel labels, `referral.action.enterResult`, `referral.tag.manuallyEntered`, Mark Lost modal copy. `audit_trail` verbs `REFERRAL_MARKED_LOST` and `REFERRAL_RESULT_RECEIVED`. |
+| **S1.4 — History DataTable + inline expand** | 3 | FR-HISTORY-001/002/003 | 8-column DataTable; read-only inline expand (Outcome detail panel); reuses the activity-log component from S1.3. i18n keys: outcome labels, column headers. |
+| **S1.5 — Aging banner + threshold seed** | 2 | FR-AGING-001/002/003 | Liquibase row insert: `unassigned_alert_config.referralStuckThresholdDays` default 7 (additive only; reuses existing config table from Sample Shipment); Carbon `InlineNotification kind="warning"` with count + "Filter to stuck only" action. i18n keys: `referral.banner.*`. |
+
+---
+
+## v2 — Result acceptance + DiagnosticReport routing
+
+**Sprint target:** 20 points
+**Actual:** 20 points
+**Shippable slice:** When a result returns from a reference lab via FHIR `DiagnosticReport`, it appears in the Returned — needs action view. Validators can Accept (commits to local Analysis, advances to validation queue) or Reject (sends FHIR Task PUT with reason, re-opens local Analysis). State-machine drives Box.Reconciled correctly.
+
+| Story | Points | FRs covered | Cross-cutting included |
+|---|---|---|---|
+| **S2.1 — Returned DataTable + result-card rendering** | 5 | FR-RETURNED-001/005, FR-EXPAND-004, FR-EXPAND-005.1 | 8-column DataTable; inline expand with result-card stack reading directly from FHIR `DiagnosticReport.Observation` resources (no schema additions); CRITICAL flag highlight; multi-test row support; SideNav count-badge now populates. i18n keys: result-card labels, returned-view column headers, critical-badge label. |
+| **S2.2 — Receive-to-Analysis action (reception model) + per-test handling + Alerts hook** | 5 | FR-RETURNED-002, FR-RETURNED-002.1, FR-RETURNED-002.2, FR-RETURNED-004 | Reception (not revalidation): map `DiagnosticReport.Observation` → `Result` via existing `ResultService.create`; set Analysis status to **`validated`/released** (NOT `not_validated` — peer already validated); set `Referral.reconciled = true`, `reconciled_at`, `reconciled_by`; confirming `Task.status = completed`; per-test Accept + "Accept all results" shortcut on multi-test referrals; Box-detail "ready to close box" notification when last Referral resolves; "Open in Result Entry" deep link; **emit trigger into Alerts feature when peer-flag is Critical/Abnormal** (the Alerts feature owns the ack UX — this story only fires the trigger); identifier-mismatch exception (no exception queue UI in v1 — just an exception tag on the row). i18n keys: `referral.action.accept`, `referral.action.acceptToAnalysis`, `referral.action.acceptAll`, `referral.exception.identifierMismatch`. `audit_trail` verb `REFERRAL_RESULT_RECEIVED`. New columns on `referral`: `reconciled`, `reconciled_at`, `reconciled_by` (Liquibase) — Envers covers automatically via existing `@Audited`. **Dependency**: existing Alerts feature must accept inbound trigger payloads (confirm shape before build). |
+| **S2.3 — Reject action + terminal-close + re-collection notification** | 5 | FR-RETURNED-003 | Reject modal (only destructive modal in this feature); Select pre-filled from peer's `Task.statusReason.text`; free-text TextArea (maxCount 500); FHIR PUT `Task.status = rejected`; **close original Analysis as terminal** with new status `rejected_by_reference_lab` (NEW Analysis status value — Liquibase seed); fire OGC-589 notification event `REFERRAL_REJECTED_NEEDS_RECOLLECTION` to requesting clinician; emit trigger into existing Alerts feature for lab-side ack. i18n keys: `referral.reject.*`. `audit_trail` verb `REFERRAL_RESULT_REJECTED` with reason in payload. New columns on `referral`: `reject_reason_code`, `reject_reason_text` (Liquibase). New Analysis status value via Liquibase. **Dependency**: OGC-589 must accept the new event type; existing Alerts feature must accept the lab-side trigger. |
+| **S2.4 — DiagnosticReport inbound routing** | 5 | FR-FHIR-003 | New handler matches `DiagnosticReport.basedOn` → `Referral.fhirUuid` (ServiceRequest UUID); sets `Referral.diagnosticReportUuid` (NEW column — Liquibase); sets `Task.status = completed`; triggers Returned view surface; idempotent re-handling. `audit_trail` verb `REFERRAL_STATE_CHANGED` with `source=peer`. |
+
+---
+
+## v3 — Box integration + Order Entry hook + Inbound peer states
+
+**Sprint target:** 20 points
+**Actual:** 18 points (headroom: could absorb a 2-pt polish story, see Open Items)
+**Shippable slice:** Refer-out can be declared at Order Entry Step 3 (OGC-605 lands). Sample Shipment Box detail surfaces referral-reconciliation status. Box can't be Reconciled until all contained Referrals are terminal. Peer reference labs can drive state transitions via FHIR Task PUTs. Outbound notification to reference labs (OGC-589 hook) wired.
+
+| Story | Points | FRs covered | Cross-cutting included |
+|---|---|---|---|
+| **S3.1 — Box-to-Referral back link on Box detail** | 3 | FR-INT-001 | Small change to existing Sample Shipment Box detail page: new "Reference Lab Results" section listing Referral count grouped by Task status with deep link. Coordinate with Sample Shipment team. i18n keys: `referral.boxDetail.referralStatusSummary`. |
+| **S3.2 — Box.Reconciled gate** | 2 | FR-INT-002 | Block Box transition to `Reconciled` if any contained Referral is non-terminal. Carbon `InlineNotification kind="error"` on existing Box transition UI. Coordinate with Sample Shipment team. i18n keys: `referral.box.cannotReconcileMessage`. |
+| **S3.3 — Order Entry Step 3 Refer Out hook (OGC-605)** | 5 | FR-OE-001, FR-OE-002 | Per-test Refer Out checkbox on Step 3 of the 4-step Order Entry wizard; create Referral row at order save with `status = draft`; dedupe with Result Entry path on Analysis ID; feeds existing Unassigned Samples tab automatically via existing `referral_flag` on Sample. Coordinate with Order Entry team. Absorbs OGC-605. i18n keys: `orderEntry.step3.referOut.*`. |
+| **S3.4 — Inbound peer Task state reads** | 5 | FR-FHIR-001 (received/in-progress/rejected portions), FR-FHIR-002 | New endpoint or extension accepts peer Task PUTs; updates local Referral for `received`, `in-progress`, `rejected` peer-driven transitions; idempotency + out-of-order latching per NFR-6. `audit_trail` verb `REFERRAL_STATE_CHANGED` with `source=peer` per transition. |
+| **S3.5 — Notify reference lab action (OGC-589 integration)** | 3 | FR-624-002 (notify portion) | "Notify reference lab" button in expand panel; fires existing OGC-589 trigger with referral context; coordinate with notification team. Absorbs OGC-589. i18n keys: `referral.action.notifyReferenceLab`, `referral.notify.*`. |
+
+---
+
+## Coordination items (not stories — handle before/during /breakdown Jira creation)
+
+- **OGC-624 state-field surgery.** Close OGC-624's `subcontractStatus` scope; re-point any in-progress code at the unified FHIR-aligned `ReferralStatus`. Coordinate with OGC-624's owner (likely Herbert per memory; **confirm before Jira surgery**). Other OGC-624 scope (subcontract metadata panel, shipment fields) is already covered by Sample Shipment, so most of OGC-624 just closes as superseded.
+- **OGC-605 absorbed by S3.3.** Close OGC-605 on the new Epic creation; reopen if S3.3 slips out of v3.
+- **OGC-589 absorbed by S3.5.** OGC-589's notification infra is the dependency; the trigger registration for `REFERRAL_OUT` event type lives in OGC-589's own deliverable. Confirm with the OGC-589 owner that the event type registration accommodates a "validator-initiated re-notify" use case (per S3.5).
+- **OGC-796** is the Epic on creation. Description gets refreshed with this breakdown plan's link.
+
+---
+
+## Coverage check
+
+- **Every FR from the FRS appears in at least one version:** ✅
+  - All FR-PAGE-*, FR-METRIC-*, FR-FILTER-*, FR-OUTSTANDING-*, FR-EXPAND-* → v1
+  - All FR-RETURNED-*, FR-FHIR-003 → v2
+  - All FR-INT-*, FR-OE-*, FR-FHIR-001/002, FR-624-002 → v3
+  - All FR-MIG-*, FR-AGING-* → v1
+  - All FR-HISTORY-* → v1
+  - FR-FHIR-004 (no peer-lab distinction) is a NON-action; documented in FRS §4.11, no story needed
+- **Every UI element in the mockup gets built by at least one story:** ✅
+  - Metric tiles, ChipSet, secondary filter row, Outstanding table, History table, expand panels, aging banner → v1
+  - Returned table, result cards, Accept/Reject buttons, Reject modal → v2
+- **All cross-cutting concerns assigned:**
+  - i18n keys: ✅ (each story carries the keys it introduces)
+  - Role attachment: ✅ (Validator / Lab Manager / Admin for write actions; existing bundles)
+  - `audit_trail` entries: ✅ (5 verbs distributed across stories — `REFERRAL_STATE_CHANGED`, `REFERRAL_MARKED_LOST`, `REFERRAL_RESULT_ACCEPTED`, `REFERRAL_RESULT_REJECTED`, plus reserved `REFERRAL_LOST_REVERSED` which the existing Sample Shipment admin path will trigger)
+  - Envers coverage: ✅ (no new entities; new columns auto-covered by existing `@Audited` on `Referral`)
+
+---
+
+## Open items (resolve before Jira creation OR during sprint planning, not blocking the plan)
+
+1. **OGC-624 owner confirmation.** Reach out before Epic promotion / story creation.
+2. ~~**Multi-test Accept behavior**~~ **Resolved 2026-05-28**: per-test with "Accept all results" shortcut. Folded into S2.2.
+3. ~~**Re-refer prompt after Reject**~~ **Resolved 2026-05-28**: no re-refer prompt. Reject closes Analysis as terminal `rejected_by_reference_lab`; clinician notified via OGC-589 (`REFERRAL_REJECTED_NEEDS_RECOLLECTION`); lab-side ack via existing Alerts feature; new sample → new order → new Analysis through existing order-entry flow.
+4. **Provider-role "own referrals only" scoping** (FRS §11.1). Probably 2 pts to wire correctly; not in any current story. Add to v3 or v4.
+5. ~~**Reception vs revalidation model**~~ **Resolved 2026-05-28**: reception model. Returning results post directly as `validated`; critical-flag results emit a trigger into the existing Alerts feature for acknowledgment; identifier-mismatch routes to lightweight exception tag in v1.
+
+---
+
+## Stage 5 — Jira creation plan (run after your green light)
+
+Order:
+1. **Promote OGC-796 to Epic.** Update title to "Reference Lab Results — Outstanding tests + result reconciliation". Update description with link to this breakdown plan and the FRS gallery permalink. Add labels.
+2. **For each v1 story (S1.1 – S1.5):** create as Issue Type = Story, set Epic Link = OGC-796, set Story Points (per table), add labels (Epic labels + `v1`), title format `Reference Lab Results: <story summary> (v1)`. Description uses `references/jira-template.md` with acceptance criteria tracing back to the listed FRs.
+3. **For each v2 and v3 story:** same pattern with `v2` / `v3` labels.
+4. **OGC-605 and OGC-589:** add comment linking to OGC-796 and S3.3 / S3.5 respectively; set "is part of" link; set status to Closed (Superseded) only after confirming with owners.
+5. **OGC-624:** add comment with the state-model surgery plan; **do not close** until confirming with owner.
+6. **Report back:** Epic key + counts of stories created per version + links.
+
+---
+
+## Summary
+
+| Version | Points | Stories | Outcome |
+|---|---|---|---|
+| v1 | 20 | 5 | Read-only dashboard + history + state-model migration ships |
+| v2 | 20 | 4 | Result acceptance/rejection ships; DiagnosticReport routing live |
+| v3 | 18 | 5 | OGC-605 and OGC-589 absorbed; Box integration gated; peer-driven state machine complete |
+| **Total** | **58** | **14** | **3 sprints** |
+
+The plan respects: ≤20 points per version, thin shippable slice at every step, no forward dependencies, no backend-only versions, FRS stays version-agnostic.
+
+**Awaiting your green light to create Jira tickets.** After approval I'll promote OGC-796 to Epic and create the 14 child Stories with labels and acceptance criteria.

--- a/designs/sample-collection/reference-lab-results-dev-primer.md
+++ b/designs/sample-collection/reference-lab-results-dev-primer.md
@@ -1,0 +1,213 @@
+# Reference Lab Results — Dev Primer
+
+**Audience:** Backend or frontend developer with no clinical laboratory background, picking up the Reference Lab Results Epic (OGC-796) for the first time.
+**Read time:** ~12 minutes.
+**Goal of this document:** Give you the workflow narrative grounded in what a lab actually does, so the 14 stories under this Epic feel like one coherent feature rather than 14 disconnected tickets.
+
+---
+
+## 1. Why this exists in plain English
+
+A clinical laboratory can't run every test in-house. Specialized assays — HIV viral load, M. tuberculosis culture, whole exome sequencing, certain confirmatory tests — go to a **reference lab** (a partner laboratory with the equipment, expertise, or accreditation the local lab doesn't have). When that happens, the local lab packages up the sample, ships it, waits days or weeks, gets a result back, and posts that result into the patient's record.
+
+Two pieces of software work together to make this happen in OpenELIS:
+
+| System | What it owns |
+|---|---|
+| **Sample Shipment** (already shipped — `/SampleShipment/*`) | The physical lifecycle: packing samples into boxes, printing labels and manifests, scanning at the receiving lab, capturing non-conformities, exchanging FHIR `SupplyDelivery` messages. |
+| **Reference Lab Results** (this Epic — new, `/SampleShipment/reference-lab-results`) | The data lifecycle: which samples are still out at reference labs, which results have come back, posting those results to the right local `Analysis`, handling rejections and lost samples. |
+
+The two systems are tightly coupled but separately rendered. They share the `Box` entity (Sample Shipment owns it) and the `Referral` entity (this Epic owns it). They join at one transition: a Box can only reach `Reconciled` when every contained Referral has been resolved (either result posted, or rejected, or cancelled).
+
+If you remember nothing else from this primer: **Sample Shipment = "where's my shipment?". Reference Lab Results = "where's my result?".**
+
+---
+
+## 2. Walk through a realistic case — the happy path
+
+Meet **Jean Rakoto**, a 42-year-old man living with HIV in Antananarivo, Madagascar. His clinician orders a quarterly HIV-1 RNA viral load test to monitor his treatment response. The local district hospital lab can draw the blood but doesn't have the molecular biology equipment to run viral loads, so they refer to **CEDRES Reference Laboratory** in Abidjan.
+
+Here is the full timeline. Story IDs in parentheses tie back to the breakdown plan.
+
+### Step 1 — Order entry
+The reception clerk creates a new order in OpenELIS. On Step 3 of the order entry wizard, they tick "Refer Out" next to the Viral Load test and pick CEDRES as the reference lab. *(S3.3 — Order Entry Step 3 hook)*
+A `Referral` row is created with `Task.status = draft`. The sample, when collected, will carry `referral_flag = true`. It immediately appears in Sample Shipment's **Unassigned Samples** tab — "this sample needs a box."
+
+> Alternative entry point: a tech might decide mid-bench, during Result Entry, that the test needs to go out. They tick "Refer Out" on the result row. Same outcome — a `Referral` in `draft`, sample tagged for shipment. Both creation paths dedupe on `analysis_id`.
+
+### Step 2 — Boxing the sample
+Across the lab, a shipping coordinator opens Sample Shipment, sees the unassigned sample on the dashboard, and adds it to a Box bound for CEDRES with 8 other samples. They mark the Box **Ready to Send**, print the label, generate the manifest, then click Send. The Box transitions to `Sent`.
+
+Behind the scenes, the Sample Shipment server emits a FHIR PUT for each contained Referral: `Task.status = requested`. A FHIR `SupplyDelivery` message goes to CEDRES's endpoint with the manifest. *(S1.1 — State migration, S3.1/S3.2 — Box integration plumbing)*
+
+### Step 3 — In transit
+For two days, Jean Rakoto's sample sits in a cold-chain courier box flying from Tana to Abidjan. The Referral row in OpenELIS shows `Task.status = requested`. If a lab manager opens **Reference Lab Results → Outstanding** they see the row with "2 days outstanding" and status `Sent — awaiting acceptance`. *(S1.2/S1.3 — Scaffolding + Outstanding view)*
+
+### Step 4 — Arrival at the reference lab
+The box arrives at CEDRES. A CEDRES tech scans the box ID and each sample barcode. CEDRES is on OpenELIS too, so their system emits FHIR PUTs back: `Task.status = received` for each sample. Our local Referral row updates automatically. The Outstanding view now shows `At reference lab`. *(S3.4 — Inbound peer Task state reads)*
+
+CEDRES sets up the viral load assay; they emit another PUT: `Task.status = in-progress`. Our Outstanding view shows `In progress at reference lab`.
+
+### Step 5 — Result returns
+Two days later CEDRES finishes the test, validates the result on their end, and emits a FHIR `DiagnosticReport` with one `Observation`: HIV-1 RNA = "< 20 copies/mL (undetectable)". *(S2.4 — DiagnosticReport inbound routing)*
+
+The local OpenELIS server receives the report, matches `DiagnosticReport.basedOn` to the stored ServiceRequest UUID on the Referral, sets `Referral.diagnostic_report_uuid`, and advances `Task.status = completed`.
+
+### Step 6 — Validator reception
+A validator opens Reference Lab Results the next morning. The **Returned — needs action** chip is showing a count of `1`. They click it, see Jean Rakoto's row, expand it. The right-hand panel shows the result card: `< 20 copies/mL`, reference range `Undetectable: < 20`, flag `Normal`. They click **Accept to Analysis**. *(S2.1, S2.2 — Returned view + Accept action)*
+
+The server-side handler maps `DiagnosticReport.Observation` → `Result` row tied to Jean Rakoto's original Analysis via the existing `ResultService.create`. The Analysis is set to `validated` (released) — **no local revalidation step**, because CEDRES already validated it on their end. `Referral.reconciled = true`. An `audit_trail` row with verb `REFERRAL_RESULT_RECEIVED` records who did the reception and when.
+
+### Step 7 — Box reconciliation
+When the validator accepts the last unresolved Referral in this Box, a notification surfaces on the Box detail page in Sample Shipment: **"All referrals reconciled — ready to close box."** The shipping coordinator marks the Box **Reconciled**, terminal state.
+
+The patient record now shows Jean Rakoto's viral load result. The clinician sees it on their next visit. End of the happy path.
+
+---
+
+## 3. Alternative narratives — the cases the spec actually has to handle
+
+The happy path is the easy story. Real lab work has more variety. The Epic handles five more narratives that all flow through the same surface.
+
+### 3a. The reference lab isn't on OpenELIS — manual entry
+CEDRES is fictional-on-OpenELIS for this example. Most reference labs aren't. **Central Public Health Laboratory (CPHL)**, for instance, returns CD4 counts by phone. The validator answers the call, has the result on a sticky note, and clicks the visible two-line **"Enter result"** button on the row in Outstanding. *(S1.3 — Manual Entry path)*
+
+That button is a deep link to the existing Result Entry screen with the order's lab number pre-loaded. The validator types in the value, sets the reference-lab reported date/time (the existing date capture in Result Entry), saves. A server-side hook in `ResultService.create` notices: "this Result lands on an Analysis with an open Referral." It advances `Task.status = completed`, sets `manually_entered = true`, and the row jumps from Outstanding straight to History with a **Manually entered** tag.
+
+This is the single most common case in practice. The two-line button (not an overflow menu) reflects that.
+
+### 3b. Critical result
+CPHL returns a positive Cryptococcal antigen titer of 1:80 on a patient with suspected HIV-related opportunistic infection. The DiagnosticReport carries `Observation.interpretation = Critical`. When the validator clicks Accept, the result posts normally, AND a trigger fires into the existing **Alerts feature** (separate from this Epic — see the global "Critical Result Acknowledgment" idea). The Alerts feature owns the acknowledgment UX; this Epic only emits the trigger. *(S2.2 — Critical hook)*
+
+### 3c. The reference lab rejects the sample
+Insufficient volume. Wrong tube type. Hemolyzed. Damaged container. Temperature deviation in transit. Mislabeled.
+
+In every realistic case the existing physical sample is gone or unusable. The reference lab sends `Task.status = rejected` with a reason in `Task.statusReason.text`. Our local validator opens Reference Lab Results, sees the row in Returned, expands it, sees the reason, clicks **Reject**. *(S2.3 — Reject action)*
+
+The modal confirms the action. On confirm:
+- `Task.status = rejected` (PUT emitted to peer for symmetry — peer already set it but our PUT confirms)
+- Original `Analysis` is closed with a new terminal status `rejected_by_reference_lab` — not re-opened
+- A notification fires to the requesting clinician via the existing OGC-589 trigger registry (`REFERRAL_REJECTED_NEEDS_RECOLLECTION`) so they know to ask the patient back for a new sample
+- A trigger fires to the Alerts feature for lab-side acknowledgment
+- The row moves to History with Outcome = Rejected
+
+**Important workflow detail:** the validator does NOT "re-refer" the same sample. The clinician arranges re-collection, the patient comes back, a NEW order is created through the existing order-entry flow with a fresh sample and fresh Analysis. Each Lab Number represents one collection event.
+
+### 3d. The box is lost in transit
+A courier loses the box. Two weeks pass, no FHIR PUTs from the reference lab. The Outstanding view's aging banner lights up: "5 referrals have been at a reference lab for more than 7 days." *(S1.5 — Aging banner)*
+
+The lab manager calls the courier, confirms the loss, and on the relevant rows clicks **Mark Lost** from the expand panel. They enter a free-text reason ("courier confirmed loss in transit"). The Referral row gets `lostStatus = true`, `lostDate = now`, and moves to History with Outcome = Lost. The FHIR Task stays in `requested` (lost is a local-only flag, not a FHIR state transition).
+
+Like rejection, recovery means a new order with a fresh sample.
+
+### 3e. Multi-test referrals
+Some referrals carry more than one test. A Hep-B/Hep-C combined referral arrives with two Observations in the DiagnosticReport: HBV DNA = `2.1 × 10⁴ IU/mL` (abnormal — active replication), HCV RNA = `Not detected` (normal). *(S2.2 — Multi-test handling)*
+
+The expand panel shows two stacked result cards. The validator can Accept individual tests with a per-test button, or click **Accept all results** to commit everything at once. Real-world usage is dominated by the "everything looks fine, accept all" case; the per-test option exists for the edge cases where one test in a combined panel needs investigation while the other is ready to release.
+
+---
+
+## 4. The state machine you actually need to understand
+
+Two state machines on parallel lifecycles, joined at the Box.Reconciled transition.
+
+### 4a. Referral state machine (this Epic owns it)
+
+```
+draft ──→ requested ──→ received ──→ in-progress ──→ completed
+  │           │             │             │              │
+  │           │             │             │              └──→ (Accept) reconciled (terminal)
+  │           │             │             │              └──→ (Reject) rejected (terminal)
+  │           │             │             │
+  │           │             │             └──→ (peer reject) rejected (terminal)
+  │           │             │             └──→ (peer in-progress) in-progress
+  │           │             │
+  │           │             └──→ (peer reject) rejected (terminal)
+  │           │
+  │           └──→ (user cancel) cancelled (terminal)
+  │           └──→ (peer reject) rejected (terminal)
+  │
+  └──→ (user cancel) cancelled (terminal)
+
+Plus local-only side flag: lostStatus = true (FHIR state unchanged; row appears as Lost in History)
+```
+
+These are FHIR `Task.status` values — same vocabulary the reference lab uses, which means peer-OpenELIS labs and our local UI agree on what every state means. Display labels stay localizable (the UI may say "Sent — awaiting acceptance" instead of "requested" — the i18n table in §7 of the FRS handles that).
+
+The migration from the old `CREATED/SENT/RECEIVED/FINISHED/CANCELED` enum to these FHIR-aligned values is a one-shot Liquibase changeset with rollback. *(S1.1)*
+
+### 4b. Box state machine (Sample Shipment owns it — for reference only)
+
+```
+Draft → Ready to Send → Sent → In Transit → Partially Received → Received → Reconciled
+                                                                                  ↑
+                                              (gated: all Referrals must be      │
+                                              completed/rejected/cancelled/lost  │
+                                              before the Box can reach this state)
+```
+
+The gate is enforced by S3.2. Block the transition with an `InlineNotification kind="error"` if any contained Referral is still non-terminal.
+
+### 4c. Where they touch
+- Box.Sent emits `requested` on every contained Referral
+- Box.Received emits `received` on every contained Referral (or peer's PUT does — either way idempotent)
+- Box.Reconciled is gated by every Referral being terminal
+- That's it. No other coupling.
+
+---
+
+## 5. How the 14 stories map onto the narrative
+
+| Narrative step | Stories |
+|---|---|
+| Refer Out at order entry OR result entry | S3.3 (OE Step 3 hook) |
+| State migration (old enum → FHIR Task) | S1.1 |
+| The Reference Lab Results page itself | S1.2 |
+| Outstanding view + Mark Lost + Manual Entry | S1.3 |
+| History view | S1.4 |
+| Aging banner for stuck referrals | S1.5 |
+| Returned — needs action view | S2.1 |
+| Accept-to-Analysis (reception model) + Critical hook + Multi-test | S2.2 |
+| Reject + clinician notify + Alerts ack | S2.3 |
+| Inbound DiagnosticReport routing | S2.4 |
+| Box detail back link to Referrals | S3.1 |
+| Box.Reconciled gate | S3.2 |
+| Inbound peer Task PUTs (received/in-progress/rejected) | S3.4 |
+| Notify reference lab from expand panel | S3.5 |
+
+---
+
+## 6. Integration points (what we touch elsewhere)
+
+- **Sample Shipment** (existing, live on testing). We add: a count summary on the Box detail page (S3.1), a state-transition gate (S3.2). We do NOT touch any other Sample Shipment surface.
+- **Result Entry / Logbook** (existing). We add: a server-side hook in `ResultService.create` / `LogbookResultsController` that detects "this Result save lands on an Analysis with an open Referral" and advances the Referral state. We do NOT change the Result Entry UI.
+- **Order Entry wizard** (in flight as OGC-605). We absorb OGC-605 into S3.3. Coordinate with the Order Entry team during sprint planning.
+- **OGC-589 Notifications**. We absorb OGC-589 into S3.5 and add a new event type `REFERRAL_REJECTED_NEEDS_RECOLLECTION` to the trigger registry in S2.3. Coordinate with the notifications owner.
+- **Alerts feature** (separate Epic — "Critical Result Acknowledgment"). We emit triggers for critical-result reception (S2.2) and reject (S2.3). The Alerts feature owns the acknowledgment UX. We do NOT design that surface in this Epic.
+- **OGC-624 Inter-Lab Transfer & Subcontract** (in progress, owner Samuel Male). Its proposed parallel `subcontractStatus` field is superseded — coordinate with Samuel before any state-field surgery.
+
+---
+
+## 7. What success looks like
+
+After all three sprints ship:
+
+- The Referrals page at `/ReferredOutTests` can be retired (or redirected to the new surface)
+- Every referral has a single FHIR-aligned state visible to validators, lab managers, and the requesting clinician
+- No more silent stuck boxes — the aging banner surfaces them
+- Reference-lab-not-on-OpenELIS labs are first-class citizens via the Enter result button
+- Critical and rejected results route to the Alerts feature for centralized lab-side acknowledgment
+- The two systems (Sample Shipment + Reference Lab Results) stay separately responsible but never drift, because they share the Referral table and the Box.Reconciled gate enforces convergence
+
+If you remember nothing else from this primer, again: **Sample Shipment = "where's my shipment?". Reference Lab Results = "where's my result?".** Build accordingly.
+
+---
+
+## 8. Source artifacts
+
+- FRS: `referral-redesign-frs.md`
+- Mockup: `referral-redesign-mockup.jsx`
+- Visual preview: `referral-redesign-preview.html` (open in any browser)
+- Breakdown plan: `referral-redesign-breakdown.md`
+- Brainstorm / problem framing: `referral-redesign-brainstorm.md`
+- `/analyze` quality report: `referral-redesign-analyze-report.md`

--- a/designs/sample-collection/reference-lab-results.html
+++ b/designs/sample-collection/reference-lab-results.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reference Lab Results — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; color: #161616; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem; max-width: 1440px; margin: 0 auto; background: white; min-height: 100vh; }
+
+    .breadcrumb { font-size: 0.875rem; color: #525252; margin-bottom: 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+    .breadcrumb a:hover { text-decoration: underline; }
+    .breadcrumb .sep { margin: 0 0.5rem; }
+    .breadcrumb .current { color: #161616; }
+
+    h1 { font-weight: 300; margin: 0.5rem 0 1.5rem 0; font-size: 2rem; }
+    h5 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #525252; margin: 0 0 0.75rem 0; }
+
+    .banner-warning {
+      background: #fcf4d6; border-left: 3px solid #f1c21b; padding: 1rem 1.25rem; margin-bottom: 1rem;
+      display: flex; align-items: flex-start; justify-content: space-between;
+    }
+    .banner-warning .body { flex: 1; }
+    .banner-warning .title { font-weight: 600; margin-bottom: 0.25rem; }
+    .banner-warning .subtitle { font-size: 0.875rem; color: #525252; }
+    .banner-warning .action { padding-left: 1rem; }
+
+    .metric-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
+    .metric-tile {
+      background: white; padding: 1.25rem 1rem; cursor: pointer;
+      border: 1px solid #e0e0e0; text-align: left; width: 100%; font-family: inherit;
+    }
+    .metric-tile.active { box-shadow: 0 0 0 1px #0f62fe inset; }
+    .metric-tile .count { font-size: 2.5rem; font-weight: 300; line-height: 1; color: #161616; }
+    .metric-tile .label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #525252; margin-top: 0.5rem; }
+    .metric-tile.green { border-left: 6px solid #24a148; }
+    .metric-tile.red { border-left: 6px solid #da1e28; }
+    .metric-tile.teal { border-left: 6px solid #005d5d; }
+    .metric-tile.purple { border-left: 6px solid #8a3ffc; }
+
+    .chip-row { display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
+    .chip {
+      background: white; color: #161616; border: 1px solid #8d8d8d;
+      border-radius: 999px; padding: 0.375rem 1rem; font-size: 0.875rem; cursor: pointer;
+      font-family: inherit;
+    }
+    .chip.active { background: #0f62fe; color: white; border-color: #0f62fe; }
+    .chip:hover:not(.active) { background: #e8e8e8; }
+
+    .filter-row {
+      background: #f4f4f4; padding: 1rem; margin-bottom: 1rem;
+      display: grid; grid-template-columns: 1fr 1.5fr 1fr 0.8fr auto; gap: 1rem;
+      align-items: end;
+    }
+    .filter-row label { display: block; font-size: 0.75rem; color: #525252; margin-bottom: 0.25rem; font-weight: 600; }
+    .filter-row select, .filter-row input {
+      width: 100%; padding: 0.5rem; border: 1px solid #8d8d8d; background: white; font-family: inherit;
+      font-size: 0.875rem; color: #161616;
+    }
+    .filter-row .clear { white-space: nowrap; }
+
+    .table-container { background: white; border: 1px solid #e0e0e0; margin-bottom: 2rem; }
+    .table-header { padding: 1rem; border-bottom: 1px solid #e0e0e0; }
+    .table-header .title { font-size: 1.125rem; font-weight: 400; margin-bottom: 0.25rem; }
+    .table-header .desc { font-size: 0.875rem; color: #525252; }
+
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; padding: 0.75rem 1rem; font-weight: 600; font-size: 0.875rem; background: #f4f4f4; border-bottom: 1px solid #e0e0e0; color: #161616; }
+    td { padding: 0.75rem 1rem; font-size: 0.875rem; border-bottom: 1px solid #e0e0e0; vertical-align: middle; }
+    tr.expandable-row { cursor: pointer; }
+    tr.expandable-row:hover { background: #f4f4f4; }
+    .expand-toggle { width: 32px; padding: 0; text-align: center; user-select: none; }
+    .expand-icon { display: inline-block; transition: transform 0.15s; }
+    .expand-icon.open { transform: rotate(90deg); }
+
+    .tag {
+      display: inline-block; padding: 0.125rem 0.625rem; border-radius: 999px;
+      font-size: 0.75rem; font-weight: 500; line-height: 1.25rem; white-space: nowrap;
+    }
+    .tag-gray { background: #e0e0e0; color: #161616; }
+    .tag-red { background: #ffd7d9; color: #750e13; }
+    .tag-blue { background: #d0e2ff; color: #0043ce; }
+    .tag-purple { background: #e8daff; color: #491d8b; }
+    .tag-teal { background: #9ef0f0; color: #004144; }
+    .tag-green { background: #a7f0ba; color: #044317; }
+    .tag-warm-gray { background: #e5e0df; color: #43413e; }
+
+    .empty-state { text-align: center; padding: 3rem 1rem; color: #525252; }
+
+    .days-warn { color: #f1c21b; font-weight: 600; }
+    .days-alert { color: #da1e28; font-weight: 600; }
+
+    .expand-panel { background: #f4f4f4; padding: 1.5rem; border-top: 1px solid #e0e0e0; }
+    .expand-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1.5rem; }
+    .detail-row { display: flex; justify-content: space-between; padding: 0.375rem 0; border-bottom: 1px solid #e0e0e0; font-size: 0.875rem; gap: 0.5rem; }
+    .detail-row .label { color: #525252; flex-shrink: 0; }
+    .detail-row .value { text-align: right; max-width: 60%; word-break: break-word; }
+
+    .result-card { background: white; border: 1px solid #e0e0e0; padding: 0.75rem; margin-bottom: 0.5rem; }
+    .result-card .test { font-weight: 600; }
+    .result-card .value { font-size: 1.25rem; margin: 0.25rem 0; }
+    .result-card .units { color: #525252; font-size: 0.875rem; }
+    .result-card .range { font-size: 0.75rem; color: #525252; }
+    .result-card .notes { font-size: 0.75rem; font-style: italic; margin-top: 4px; color: #525252; }
+
+    .btn {
+      display: inline-block; padding: 0.5rem 1rem; font-size: 0.875rem; cursor: pointer;
+      border: 1px solid transparent; font-family: inherit; font-weight: 400;
+    }
+    .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.75rem; }
+    .btn-primary { background: #0f62fe; color: white; }
+    .btn-primary:hover { background: #0353e9; }
+    .btn-ghost { background: transparent; color: #0f62fe; }
+    .btn-ghost:hover { background: #e8e8e8; }
+    .btn-danger { background: white; color: #da1e28; border-color: #da1e28; }
+    .btn-danger:hover { background: #fff1f1; }
+    .btn-danger-primary { background: #da1e28; color: white; }
+
+    .action-cell { display: flex; gap: 0.5rem; align-items: center; }
+    .overflow-menu {
+      position: relative; display: inline-block;
+    }
+    .overflow-menu-btn {
+      width: 32px; height: 32px; background: transparent; border: none; cursor: pointer; font-size: 1.25rem;
+    }
+    .overflow-menu-btn:hover { background: #e8e8e8; }
+
+    .btn-enter-result {
+      width: 88px; min-height: 40px; padding: 4px 8px;
+      background: white; color: #0f62fe; border: 1px solid #0f62fe;
+      font-family: inherit; font-size: 0.75rem; font-weight: 400; line-height: 1.15;
+      cursor: pointer; text-align: center; white-space: normal;
+    }
+    .btn-enter-result:hover { background: #e8e8e8; }
+
+    .activity-table { background: white; border: 1px solid #e0e0e0; margin-top: 0.5rem; }
+    .activity-table th { background: white; font-size: 0.75rem; padding: 0.5rem 0.75rem; }
+    .activity-table td { font-size: 0.75rem; padding: 0.5rem 0.75rem; }
+
+    .modal-backdrop {
+      position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(22, 22, 22, 0.5); display: flex; align-items: center; justify-content: center;
+      z-index: 100;
+    }
+    .modal {
+      background: white; max-width: 560px; width: 90%; padding: 0;
+    }
+    .modal-header { padding: 1.5rem 1.5rem 0.5rem 1.5rem; }
+    .modal-title { font-size: 1.25rem; font-weight: 400; margin: 0; }
+    .modal-body { padding: 1rem 1.5rem; }
+    .modal-footer {
+      padding: 1rem 1.5rem; display: flex; justify-content: flex-end; gap: 0.5rem;
+      background: #f4f4f4; border-top: 1px solid #e0e0e0;
+    }
+    .form-field { margin-bottom: 1rem; }
+    .form-field label { display: block; font-size: 0.75rem; font-weight: 600; color: #525252; margin-bottom: 0.25rem; }
+    .form-field input, .form-field select, .form-field textarea {
+      width: 100%; padding: 0.5rem; border: 1px solid #8d8d8d; background: white; font-family: inherit; font-size: 0.875rem;
+    }
+
+    a { color: #0f62fe; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .crit-badge { background: #da1e28; color: white; padding: 0.125rem 0.5rem; font-size: 0.625rem; font-weight: 700; letter-spacing: 0.05em; margin-right: 0.5rem; border-radius: 2px; }
+    .stuck-icon { color: #f1c21b; vertical-align: middle; margin-right: 4px; font-size: 1rem; }
+    .stuck-alert-icon { color: #da1e28; }
+    .uuid { font-family: monospace; font-size: 0.75rem; }
+  </style>
+</head>
+<body class="cds--white">
+
+  <div class="preview-banner">
+    ⚡ Visual Preview — Reference Lab Results &nbsp;|&nbsp; Route: /SampleShipment/reference-lab-results &nbsp;|&nbsp; OpenELIS Design Mockup
+  </div>
+
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo, useCallback, Fragment } = React;
+
+    // ───── Mock data ─────
+    const REFERENCE_LABS = [
+      { id: 'org-cedres', name: 'CEDRES Reference Laboratory' },
+      { id: 'org-ihrip', name: 'IHRIP Microbiology Centre' },
+      { id: 'org-cphl', name: 'Central Public Health Laboratory' },
+      { id: 'org-pasteur', name: 'Institut Pasteur Antananarivo' },
+    ];
+
+    const REFERRALS = [
+      { id:'R-7001', labNumber:'L-2026-04123', patient:'Rakoto, Jean (M, 42)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0312', sentDate:'2026-05-26T08:14:00Z', daysOut:2, status:'requested', priority:'Routine', requestor:'Dr. Andrianasolo, M.', fhirTaskUuid:'urn:uuid:a2c4-7b9d-...-3f12', boxReceivedDate:null,
+        activity:[
+          { ts:'2026-05-26T08:14:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+          { ts:'2026-05-26T07:55:00Z', actor:'A. Razafy (Tech)', from:'created', to:'draft', notes:'Refer Out flagged at Result Entry' },
+        ]},
+      { id:'R-7002', labNumber:'L-2026-04124', patient:'Voahangy, Lalao (F, 28)', tests:['HBV DNA Quantitative','HCV RNA Quantitative'], referenceLab:'org-cedres', boxId:'BOX-2026-0312', sentDate:'2026-05-26T08:14:00Z', daysOut:2, status:'received', priority:'Routine', requestor:'Dr. Andrianasolo, M.', fhirTaskUuid:'urn:uuid:b8d1-3e72-...-91f4', boxReceivedDate:'2026-05-27T14:02:00Z',
+        activity:[
+          { ts:'2026-05-27T14:02:00Z', actor:'CEDRES (peer)', from:'requested', to:'received', notes:'Box scanned in at CEDRES receiving' },
+          { ts:'2026-05-26T08:14:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7003', labNumber:'L-2026-04098', patient:'Andriamasy, Pierre (M, 67)', tests:['M. tuberculosis culture + AST'], referenceLab:'org-ihrip', boxId:'BOX-2026-0309', sentDate:'2026-05-22T09:30:00Z', daysOut:6, status:'in-progress', priority:'Urgent', requestor:'Dr. Rakotonirina, S.', fhirTaskUuid:'urn:uuid:c1f9-2a4e-...-7b08', boxReceivedDate:'2026-05-23T11:45:00Z',
+        activity:[
+          { ts:'2026-05-24T08:30:00Z', actor:'IHRIP (peer)', from:'received', to:'in-progress', notes:'Culture set up' },
+          { ts:'2026-05-23T11:45:00Z', actor:'IHRIP (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-22T09:30:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7004', labNumber:'L-2026-03891', patient:'Razanamparany, Marie (F, 35)', tests:['Karyotyping — peripheral blood'], referenceLab:'org-pasteur', boxId:'BOX-2026-0297', sentDate:'2026-05-09T10:00:00Z', daysOut:19, status:'in-progress', priority:'Routine', requestor:'Dr. Ratsimbazafy, H.', fhirTaskUuid:'urn:uuid:d4e2-9f81-...-4c93', boxReceivedDate:'2026-05-11T15:20:00Z', stuck:true,
+        activity:[
+          { ts:'2026-05-12T09:00:00Z', actor:'Pasteur (peer)', from:'received', to:'in-progress', notes:'Culture initiated' },
+          { ts:'2026-05-11T15:20:00Z', actor:'Pasteur (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-09T10:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7005', labNumber:'L-2026-02156', patient:'Ramaroson, Henri (M, 58)', tests:['Whole Exome Sequencing'], referenceLab:'org-pasteur', boxId:'BOX-2026-0214', sentDate:'2026-04-15T11:20:00Z', daysOut:43, status:'in-progress', priority:'Urgent', requestor:'Dr. Rajaonarivelo, T.', fhirTaskUuid:'urn:uuid:e7a3-1b5c-...-2d68', boxReceivedDate:'2026-04-18T09:15:00Z', stuck:true, criticallyStuck:true,
+        activity:[
+          { ts:'2026-04-20T14:00:00Z', actor:'Pasteur (peer)', from:'received', to:'in-progress', notes:'Library prep started' },
+          { ts:'2026-04-18T09:15:00Z', actor:'Pasteur (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-04-15T11:20:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+
+      // Returned — needs action
+      { id:'R-7006', labNumber:'L-2026-04201', patient:'Razafindrakoto, Aina (F, 31)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0314', sentDate:'2026-05-23T08:00:00Z', daysOut:5, status:'completed', priority:'Routine', requestor:'Dr. Andrianasolo, M.', returnedDate:'2026-05-28T07:42:00Z', fhirTaskUuid:'urn:uuid:f9c2-4d8a-...-5e17', boxReceivedDate:'2026-05-24T10:30:00Z',
+        resultSummary:'< 20 copies/mL (undetectable)',
+        results:[{ test:'HIV-1 RNA Viral Load', value:'< 20', units:'copies/mL', range:'Undetectable: < 20', flag:'Normal', notes:'Below limit of quantification.' }],
+        activity:[
+          { ts:'2026-05-28T07:42:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received' },
+          { ts:'2026-05-24T11:00:00Z', actor:'CEDRES (peer)', from:'received', to:'in-progress', notes:'' },
+          { ts:'2026-05-24T10:30:00Z', actor:'CEDRES (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-23T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7007', labNumber:'L-2026-04156', patient:'Andriamampianina, Bako (M, 24)', tests:['HBV DNA Quantitative','HCV RNA Quantitative'], referenceLab:'org-cedres', boxId:'BOX-2026-0314', sentDate:'2026-05-23T08:00:00Z', daysOut:5, status:'completed', priority:'Routine', requestor:'Dr. Rakotonirina, S.', returnedDate:'2026-05-28T07:55:00Z', fhirTaskUuid:'urn:uuid:h2k4-...-7d12', boxReceivedDate:'2026-05-24T10:30:00Z',
+        resultSummary:'HBV: 2.1 × 10⁴ IU/mL · HCV: not detected',
+        results:[
+          { test:'HBV DNA Quantitative', value:'2.1 × 10⁴', units:'IU/mL', range:'< 20 IU/mL undetectable', flag:'Abnormal', notes:'Active replication.' },
+          { test:'HCV RNA Quantitative', value:'Not detected', units:'IU/mL', range:'< 15 IU/mL', flag:'Normal', notes:'' },
+        ],
+        activity:[
+          { ts:'2026-05-28T07:55:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received' },
+          { ts:'2026-05-23T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7008', labNumber:'L-2026-04188', patient:'Rabearisoa, Olivier (M, 51)', tests:['Cryptococcal antigen (CrAg)'], referenceLab:'org-cphl', boxId:'BOX-2026-0311', sentDate:'2026-05-25T09:15:00Z', daysOut:3, status:'completed', priority:'STAT', requestor:'Dr. Ratsimbazafy, H.', returnedDate:'2026-05-27T18:20:00Z', fhirTaskUuid:'urn:uuid:l5m6-...-9c87', boxReceivedDate:'2026-05-26T08:00:00Z',
+        resultSummary:'POSITIVE — titer 1:80',
+        results:[{ test:'Cryptococcal antigen (CrAg)', value:'POSITIVE', units:'— (titer 1:80)', range:'Negative', flag:'Critical', notes:'Consistent with disseminated cryptococcosis. Recommend LP.' }],
+        activity:[
+          { ts:'2026-05-27T18:20:00Z', actor:'CPHL (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received — CRITICAL' },
+          { ts:'2026-05-25T09:15:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+
+      // History — manually entered (reference lab not on OpenELIS, called result by phone)
+      { id:'R-7013', labNumber:'L-2026-03654', patient:'Rafanomezantsoa, Lova (F, 44)', tests:['CD4 absolute count'], referenceLab:'org-cphl', boxId:'BOX-2026-0265', sentDate:'2026-04-23T09:00:00Z', status:'reconciled', outcome:'Reconciled', priority:'Routine', closedDate:'2026-05-01T14:22:00Z', daysTotal:8, manuallyEntered:true, requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-01T14:22:00Z', actor:'P. Rasoanirina (Validator)', from:'requested', to:'reconciled', notes:'Result phoned in by CPHL — manually entered via Result Entry' },
+          { ts:'2026-04-23T09:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      // History — reconciled (auto via DiagnosticReport)
+      { id:'R-7009', labNumber:'L-2026-03997', patient:'Razanadrakoto, Felana (F, 39)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0301', sentDate:'2026-05-18T08:30:00Z', status:'reconciled', outcome:'Reconciled', priority:'Routine', closedDate:'2026-05-25T11:14:00Z', daysTotal:7, requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-25T11:14:00Z', actor:'P. Rasoanirina (Validator)', from:'completed', to:'reconciled', notes:'Result accepted into local Analysis' },
+          { ts:'2026-05-24T15:30:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'' },
+          { ts:'2026-05-18T08:30:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+      // History — rejected
+      { id:'R-7010', labNumber:'L-2026-03812', patient:'Andriantsoa, Tahina (M, 19)', tests:['Mycobacterium spp. molecular ID'], referenceLab:'org-ihrip', boxId:'BOX-2026-0286', sentDate:'2026-05-04T07:45:00Z', status:'rejected', outcome:'Rejected', priority:'Routine', closedDate:'2026-05-09T13:00:00Z', daysTotal:5, rejectReason:'Insufficient volume (received 0.4 mL, need ≥ 2 mL). Resubmit with larger draw.', requestor:'Dr. Rakotonirina, S.',
+        activity:[
+          { ts:'2026-05-09T13:00:00Z', actor:'IHRIP (peer)', from:'received', to:'rejected', notes:'Insufficient volume — 0.4 mL' },
+          { ts:'2026-05-05T10:00:00Z', actor:'IHRIP (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-04T07:45:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+      // History — cancelled
+      { id:'R-7011', labNumber:'L-2026-03734', patient:'Rakotomalala, Hery (M, 47)', tests:['Karyotyping — peripheral blood'], referenceLab:'org-pasteur', boxId:'BOX-2026-0273', sentDate:'2026-04-27T09:00:00Z', status:'cancelled', outcome:'Cancelled', priority:'Routine', closedDate:'2026-04-27T16:30:00Z', daysTotal:0, cancelReason:'Clinician withdrew request (treatment changed).', requestor:'Dr. Rajaonarivelo, T.',
+        activity:[
+          { ts:'2026-04-27T16:30:00Z', actor:'P. Rasoanirina (Validator)', from:'draft', to:'cancelled', notes:'Clinician withdrew request' },
+        ]},
+      // History — lost
+      { id:'R-7012', labNumber:'L-2026-03551', patient:'Razafindramanana, Soa (F, 62)', tests:['HBsAg confirmatory'], referenceLab:'org-cphl', boxId:'BOX-2026-0258', sentDate:'2026-04-19T08:00:00Z', status:'requested', outcome:'Lost', priority:'Routine', closedDate:'2026-05-02T10:00:00Z', daysTotal:13, lostStatus:true, lostReason:'Box never arrived at CPHL — courier confirmed loss. Sample re-collected and re-referred under L-2026-04201.', requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-02T10:00:00Z', actor:'P. Rasoanirina (Validator)', from:'requested', to:'(lost flag set)', notes:'Marked lost — courier confirmed' },
+          { ts:'2026-04-19T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+    ];
+
+    const refLabName = (id) => REFERENCE_LABS.find(r => r.id === id)?.name || id;
+
+    const STATUS_KIND = {
+      draft:'gray', requested:'blue', received:'purple', 'in-progress':'warm-gray',
+      completed:'teal', rejected:'red', cancelled:'gray', reconciled:'teal',
+    };
+    const STATUS_LABEL = {
+      draft:'Draft', requested:'Sent — awaiting acceptance', received:'At reference lab',
+      'in-progress':'In progress at reference lab', completed:'Result returned',
+      rejected:'Rejected by reference lab', cancelled:'Cancelled', reconciled:'Reconciled',
+    };
+    const PRIORITY_KIND = { Routine:'gray', Urgent:'warm-gray', STAT:'red' };
+    const OUTCOME_KIND = { Reconciled:'teal', Rejected:'red', Cancelled:'gray', Lost:'red' };
+
+    const formatDate = (iso) => {
+      if (!iso) return '—';
+      const d = new Date(iso);
+      return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}`;
+    };
+
+    function Tag({ kind, children }) {
+      return <span className={`tag tag-${kind}`}>{children}</span>;
+    }
+
+    function MetricTile({ color, label, count, onClick, active }) {
+      return (
+        <button className={`metric-tile ${color} ${active ? 'active' : ''}`} onClick={onClick}>
+          <div className="count">{count}</div>
+          <div className="label">{label}</div>
+        </button>
+      );
+    }
+
+    function Chip({ active, onClick, children }) {
+      return <button className={`chip ${active ? 'active' : ''}`} onClick={onClick}>{children}</button>;
+    }
+
+    function DetailRow({ label, value }) {
+      return (
+        <div className="detail-row">
+          <span className="label">{label}</span>
+          <span className="value">{value}</span>
+        </div>
+      );
+    }
+
+    function ActivityLog({ activity }) {
+      return (
+        <table className="activity-table">
+          <thead><tr><th>Timestamp</th><th>Actor</th><th>From</th><th>To</th><th>Notes</th></tr></thead>
+          <tbody>
+            {activity.map((a, i) => (
+              <tr key={i}>
+                <td>{formatDate(a.ts)}</td>
+                <td>{a.actor}</td>
+                <td>{a.from}</td>
+                <td>{a.to}</td>
+                <td>{a.notes || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+
+    function ExpandPanel({ row, mode, onMarkLost, onReject }) {
+      return (
+        <div className="expand-panel">
+          <div className="expand-grid">
+            <div>
+              <h5>Original order context</h5>
+              <DetailRow label="Lab Number" value={<a href={`/Patient/${row.labNumber}`}>{row.labNumber}</a>} />
+              <DetailRow label="Patient" value={row.patient} />
+              <DetailRow label="Tests" value={row.tests.join(', ')} />
+              <DetailRow label="Original requestor" value={row.requestor} />
+              <DetailRow label="Priority" value={<Tag kind={PRIORITY_KIND[row.priority]}>{row.priority}</Tag>} />
+            </div>
+
+            <div>
+              <h5>Reference lab transit</h5>
+              <DetailRow label="Reference Lab" value={refLabName(row.referenceLab)} />
+              <DetailRow label="Box ID" value={<a href={`/SampleShipment/box/${row.boxId}`}>{row.boxId}</a>} />
+              <DetailRow label="Dispatched" value={formatDate(row.sentDate)} />
+              <DetailRow label="Received at lab" value={formatDate(row.boxReceivedDate)} />
+              <DetailRow label="FHIR Task" value={<span className="uuid">{row.fhirTaskUuid}</span>} />
+            </div>
+
+            <div>
+              {mode === 'outstanding' && (
+                <Fragment>
+                  <h5>Status detail</h5>
+                  <DetailRow label="Current status" value={<Tag kind={STATUS_KIND[row.status]}>{STATUS_LABEL[row.status]}</Tag>} />
+                  <DetailRow label="Days outstanding" value={`${row.daysOut} days`} />
+                  {row.stuck && (
+                    <div className="banner-warning" style={{ marginTop:'0.75rem' }}>
+                      <div className="body">
+                        <div className="title">Stuck</div>
+                        <div className="subtitle">Consider contacting the reference lab.</div>
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ marginTop:'1rem', display:'flex', gap:'0.5rem' }}>
+                    <button className="btn btn-sm btn-primary" onClick={() => alert(`Would deep-link to /result?sampleId=${row.labNumber}`)}>Enter result</button>
+                    <button className="btn btn-sm btn-ghost" onClick={() => onMarkLost(row)}>⚠ Mark Lost</button>
+                  </div>
+                </Fragment>
+              )}
+
+              {mode === 'returned' && (
+                <Fragment>
+                  <h5>Result</h5>
+                  {row.results?.map((res, i) => (
+                    <div key={i} className="result-card">
+                      <div className="test">{res.test}</div>
+                      <div className="value">{res.value} <span className="units">{res.units}</span></div>
+                      <div className="range">Reference range: {res.range}</div>
+                      {res.flag && <span className="tag" style={{
+                        background: res.flag === 'Critical' ? '#ffd7d9' : res.flag === 'Abnormal' ? '#e5e0df' : '#a7f0ba',
+                        color: res.flag === 'Critical' ? '#750e13' : res.flag === 'Abnormal' ? '#43413e' : '#044317',
+                        marginTop: 4, display:'inline-block',
+                      }}>{res.flag}</span>}
+                      {res.notes && <div className="notes">{res.notes}</div>}
+                    </div>
+                  ))}
+                  <div style={{ marginTop:'0.5rem', display:'flex', gap:'0.5rem', flexWrap:'wrap' }}>
+                    <button className="btn btn-sm btn-primary">✓ Accept to Analysis</button>
+                    <button className="btn btn-sm btn-danger" onClick={() => onReject(row)}>Reject…</button>
+                    <button className="btn btn-sm btn-ghost" onClick={() => alert(`Would navigate to /result?sampleId=${row.labNumber}`)}>Open in Result Entry</button>
+                  </div>
+                </Fragment>
+              )}
+
+              {mode === 'history' && (
+                <Fragment>
+                  <h5>Outcome detail</h5>
+                  <DetailRow label="Outcome" value={<Tag kind={OUTCOME_KIND[row.outcome]}>{row.outcome}</Tag>} />
+                  <DetailRow label="Closed" value={formatDate(row.closedDate)} />
+                  <DetailRow label="Total days" value={`${row.daysTotal} days`} />
+                  {row.rejectReason && <DetailRow label="Rejection reason" value={row.rejectReason} />}
+                  {row.cancelReason && <DetailRow label="Cancellation reason" value={row.cancelReason} />}
+                  {row.lostReason && <DetailRow label="Lost reason" value={row.lostReason} />}
+                </Fragment>
+              )}
+            </div>
+          </div>
+
+          <div style={{ marginTop:'1.5rem' }}>
+            <h5>Activity log</h5>
+            <ActivityLog activity={row.activity || []} />
+          </div>
+        </div>
+      );
+    }
+
+    function OutstandingTable({ rows, expanded, toggle, onMarkLost }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">Outstanding referrals</div>
+            <div className="desc">{rows.length} referrals at reference labs awaiting results</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Box ID</th><th>Sent Date</th><th>Status</th><th>Days outstanding</th><th>Priority</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="11" className="empty-state">No referrals found for the selected filters.</td></tr>}
+              {rows.map(row => (
+                <Fragment key={row.id}>
+                  <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                    <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                    <td>{row.labNumber}</td>
+                    <td>{row.patient}</td>
+                    <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                    <td>{refLabName(row.referenceLab)}</td>
+                    <td><a href={`/SampleShipment/box/${row.boxId}`} onClick={(e) => e.stopPropagation()}>{row.boxId}</a></td>
+                    <td>{formatDate(row.sentDate)}</td>
+                    <td><Tag kind={STATUS_KIND[row.status]}>{STATUS_LABEL[row.status]}</Tag></td>
+                    <td>
+                      <span className={row.daysOut > 30 ? 'days-alert' : row.daysOut > 7 ? 'days-warn' : ''}>
+                        {row.stuck && <span className={`stuck-icon ${row.criticallyStuck ? 'stuck-alert-icon' : ''}`}>⚠</span>}
+                        {row.daysOut} {row.daysOut === 1 ? 'day' : 'days'}
+                      </span>
+                    </td>
+                    <td><Tag kind={PRIORITY_KIND[row.priority]}>{row.priority}</Tag></td>
+                    <td onClick={(e) => e.stopPropagation()}>
+                      <button
+                        className="btn-enter-result"
+                        onClick={() => alert(`Would deep-link to /result?sampleId=${row.labNumber}`)}
+                      >Enter<br/>result</button>
+                    </td>
+                  </tr>
+                  {expanded === row.id && <tr><td colSpan="11" style={{ padding: 0 }}><ExpandPanel row={row} mode="outstanding" onMarkLost={onMarkLost} /></td></tr>}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function ReturnedTable({ rows, expanded, toggle, onReject }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">Returned — needs action</div>
+            <div className="desc">{rows.length} results awaiting reconciliation to local Analysis</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Result summary</th><th>Returned Date</th><th>Original requestor</th><th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="9" className="empty-state">No returned results awaiting action.</td></tr>}
+              {rows.map(row => {
+                const hasCrit = row.results?.some(r => r.flag === 'Critical');
+                return (
+                  <Fragment key={row.id}>
+                    <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                      <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                      <td>{row.labNumber}</td>
+                      <td>{row.patient}</td>
+                      <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                      <td>{refLabName(row.referenceLab)}</td>
+                      <td>{hasCrit && <span className="crit-badge">CRITICAL</span>}{row.resultSummary}</td>
+                      <td>{formatDate(row.returnedDate)}</td>
+                      <td>{row.requestor}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <div className="action-cell">
+                          <button className="btn btn-sm btn-primary">Accept</button>
+                          <button className="btn btn-sm btn-danger" onClick={() => onReject(row)}>Reject…</button>
+                        </div>
+                      </td>
+                    </tr>
+                    {expanded === row.id && <tr><td colSpan="9" style={{ padding: 0 }}><ExpandPanel row={row} mode="returned" onReject={onReject} /></td></tr>}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function HistoryTable({ rows, expanded, toggle }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">History</div>
+            <div className="desc">{rows.length} closed referrals</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Outcome</th><th>Closed date</th><th>Box ID</th><th>Days total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="9" className="empty-state">No closed referrals match the selected filters.</td></tr>}
+              {rows.map(row => (
+                <Fragment key={row.id}>
+                  <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                    <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                    <td>{row.labNumber}</td>
+                    <td>{row.patient}</td>
+                    <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                    <td>{refLabName(row.referenceLab)}</td>
+                    <td>
+                      <Tag kind={OUTCOME_KIND[row.outcome]}>{row.outcome}</Tag>
+                      {row.manuallyEntered && <span style={{ marginLeft: 4 }}><Tag kind="warm-gray">Manually entered</Tag></span>}
+                    </td>
+                    <td>{formatDate(row.closedDate)}</td>
+                    <td><a href={`/SampleShipment/box/${row.boxId}`} onClick={(e) => e.stopPropagation()}>{row.boxId}</a></td>
+                    <td>{row.daysTotal} {row.daysTotal === 1 ? 'day' : 'days'}</td>
+                  </tr>
+                  {expanded === row.id && <tr><td colSpan="9" style={{ padding: 0 }}><ExpandPanel row={row} mode="history" /></td></tr>}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function RejectModal({ row, onClose }) {
+      const [code, setCode] = useState('');
+      const [text, setText] = useState('');
+      return (
+        <div className="modal-backdrop" onClick={onClose}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header"><h3 className="modal-title">Reject referral</h3></div>
+            <div className="modal-body">
+              <div style={{ marginBottom:'1rem' }}>
+                <strong>{row.labNumber}</strong> — {row.patient}<br/>
+                <span style={{ color:'#525252' }}>{row.tests.join(', ')} → {refLabName(row.referenceLab)}</span>
+              </div>
+              <div className="form-field">
+                <label>Common reason (optional)</label>
+                <select value={code} onChange={(e) => setCode(e.target.value)}>
+                  <option value="">— Select reason —</option>
+                  <option value="insufficientVolume">Insufficient volume</option>
+                  <option value="wrongSampleType">Wrong sample type</option>
+                  <option value="damagedContainer">Damaged container</option>
+                  <option value="temperatureDeviation">Temperature deviation</option>
+                  <option value="hemolyzed">Hemolyzed</option>
+                  <option value="clotted">Clotted</option>
+                  <option value="mislabeled">Mislabeled</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <div className="form-field">
+                <label>Reason for rejection</label>
+                <textarea rows="3" maxLength="500" value={text} onChange={(e) => setText(e.target.value)} placeholder="Describe why this referral is being rejected"></textarea>
+              </div>
+              <div className="banner-warning" style={{ marginTop:'1rem' }}>
+                <div className="body">
+                  <div className="title">This closes the Analysis as rejected</div>
+                  <div className="subtitle">Rejecting closes the Analysis as terminal-rejected. The requesting clinician will be notified to arrange re-collection. A new order will be needed when a fresh sample is collected.</div>
+                </div>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+              <button className="btn btn-danger-primary">Reject and notify clinician</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function MarkLostModal({ row, onClose }) {
+      const [reason, setReason] = useState('');
+      return (
+        <div className="modal-backdrop" onClick={onClose}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header"><h3 className="modal-title">Mark referral lost in transit</h3></div>
+            <div className="modal-body">
+              <div style={{ marginBottom:'1rem' }}>
+                <strong>{row.labNumber}</strong> — {row.patient}<br/>
+                <span style={{ color:'#525252' }}>Box {row.boxId} → {refLabName(row.referenceLab)}</span>
+              </div>
+              <div className="form-field">
+                <label>Reason</label>
+                <textarea rows="3" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="What happened to the sample?"></textarea>
+              </div>
+              <div className="banner-warning" style={{ marginTop:'1rem' }}>
+                <div className="body">
+                  <div className="title">Reversible only by an administrator</div>
+                  <div className="subtitle">Marking this referral as lost is reversible only by an administrator.</div>
+                </div>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+              <button className="btn btn-danger-primary">Mark Lost</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function App() {
+      const [view, setView] = useState('outstanding');
+      const [refLab, setRefLab] = useState('');
+      const [priority, setPriority] = useState('');
+      const [bucket, setBucket] = useState('all');
+      const [expanded, setExpanded] = useState(null);
+      const [rejectRow, setRejectRow] = useState(null);
+      const [lostRow, setLostRow] = useState(null);
+
+      const filtered = useMemo(() => {
+        let rows = REFERRALS;
+        if (view === 'outstanding') rows = rows.filter(r => ['requested','received','in-progress'].includes(r.status));
+        else if (view === 'returned') rows = rows.filter(r => r.status === 'completed');
+        else rows = rows.filter(r => ['reconciled','rejected','cancelled'].includes(r.status) || r.lostStatus);
+
+        if (refLab) rows = rows.filter(r => r.referenceLab === refLab);
+        if (priority) rows = rows.filter(r => r.priority === priority);
+        if (view === 'outstanding' && bucket !== 'all') {
+          rows = rows.filter(r => {
+            if (bucket === '0-7') return r.daysOut <= 7;
+            if (bucket === '7-30') return r.daysOut > 7 && r.daysOut <= 30;
+            if (bucket === '>30') return r.daysOut > 30;
+            return true;
+          });
+        }
+        return rows;
+      }, [view, refLab, priority, bucket]);
+
+      const stuckCount = REFERRALS.filter(r => r.stuck).length;
+
+      const counts = {
+        outstanding: REFERRALS.filter(r => ['requested','received','in-progress'].includes(r.status)).length,
+        returned: REFERRALS.filter(r => r.status === 'completed').length,
+        reconciledToday: 1,
+        rejectedThisWeek: REFERRALS.filter(r => r.status === 'rejected').length,
+      };
+
+      const toggle = (id) => setExpanded(expanded === id ? null : id);
+      const clear = () => { setRefLab(''); setPriority(''); setBucket('all'); };
+
+      return (
+        <Fragment>
+          <div className="breadcrumb">
+            <a href="/">Home</a><span className="sep">/</span>
+            <a href="/SampleShipment/dashboard">Sample Shipment</a><span className="sep">/</span>
+            <span className="current">Reference Lab Results</span>
+          </div>
+
+          <h1>Reference Lab Results</h1>
+
+          {stuckCount > 0 && view === 'outstanding' && (
+            <div className="banner-warning">
+              <div className="body">
+                <div className="title">Stuck referrals require attention</div>
+                <div className="subtitle">{stuckCount} referrals have been at a reference lab for more than 7 days. Consider contacting the reference lab or reassigning.</div>
+              </div>
+              <div className="action">
+                <button className="btn btn-sm btn-ghost" onClick={() => { setView('outstanding'); setBucket('>30'); }}>Filter to stuck only</button>
+              </div>
+            </div>
+          )}
+
+          <div className="metric-row">
+            <MetricTile color="green" label="OUTSTANDING" count={counts.outstanding} onClick={() => { setView('outstanding'); clear(); }} active={view === 'outstanding'} />
+            <MetricTile color="red" label="RETURNED — NEEDS ACTION" count={counts.returned} onClick={() => { setView('returned'); clear(); }} active={view === 'returned'} />
+            <MetricTile color="teal" label="RECONCILED TODAY" count={counts.reconciledToday} onClick={() => { setView('history'); clear(); }} />
+            <MetricTile color="purple" label="REJECTED THIS WEEK" count={counts.rejectedThisWeek} onClick={() => { setView('history'); clear(); }} />
+          </div>
+
+          <div className="chip-row">
+            <Chip active={view === 'outstanding'} onClick={() => setView('outstanding')}>Outstanding ({counts.outstanding})</Chip>
+            <Chip active={view === 'returned'} onClick={() => setView('returned')}>Returned — needs action ({counts.returned})</Chip>
+            <Chip active={view === 'history'} onClick={() => setView('history')}>History</Chip>
+          </div>
+
+          <div className="filter-row">
+            <div>
+              <label>Reference Lab</label>
+              <select value={refLab} onChange={(e) => setRefLab(e.target.value)}>
+                <option value="">All reference labs</option>
+                {REFERENCE_LABS.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label>Date range</label>
+              <input type="text" placeholder="mm/dd/yyyy – mm/dd/yyyy" />
+            </div>
+            <div>
+              <label>Priority</label>
+              <select value={priority} onChange={(e) => setPriority(e.target.value)}>
+                <option value="">All priorities</option>
+                <option value="Routine">Routine</option>
+                <option value="Urgent">Urgent</option>
+                <option value="STAT">STAT</option>
+              </select>
+            </div>
+            {view === 'outstanding' && (
+              <div>
+                <label>Days outstanding</label>
+                <select value={bucket} onChange={(e) => setBucket(e.target.value)}>
+                  <option value="all">All</option>
+                  <option value="0-7">0-7</option>
+                  <option value="7-30">7-30</option>
+                  <option value=">30">&gt;30</option>
+                </select>
+              </div>
+            )}
+            <div className="clear">
+              <button className="btn btn-sm btn-ghost" onClick={clear}>Clear filters</button>
+            </div>
+          </div>
+
+          {view === 'outstanding' && <OutstandingTable rows={filtered} expanded={expanded} toggle={toggle} onMarkLost={setLostRow} />}
+          {view === 'returned' && <ReturnedTable rows={filtered} expanded={expanded} toggle={toggle} onReject={setRejectRow} />}
+          {view === 'history' && <HistoryTable rows={filtered} expanded={expanded} toggle={toggle} />}
+
+          {rejectRow && <RejectModal row={rejectRow} onClose={() => setRejectRow(null)} />}
+          {lostRow && <MarkLostModal row={lostRow} onClose={() => setLostRow(null)} />}
+        </Fragment>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/designs/sample-collection/reference-lab-results.jsx
+++ b/designs/sample-collection/reference-lab-results.jsx
@@ -1,0 +1,997 @@
+// Route: /SampleShipment/reference-lab-results
+// SideNav: Sample Shipment → Reference Lab Results
+// Breadcrumb: Home / Sample Shipment / Reference Lab Results
+//
+// Reference Lab Results — Carbon mockup
+// Companion FRS: referral-redesign-frs.md
+//
+// IA convention: single-scroll page, ChipSet primary filter, NO Carbon Tabs.
+// Visual conventions lifted from deployed /SampleShipment/* on testing.openelis-global.org
+
+import React, { useState, useMemo, useCallback } from 'react';
+import {
+  Breadcrumb, BreadcrumbItem,
+  Grid, Column, Stack,
+  Tile,
+  Tag,
+  DataTable, TableContainer, Table, TableHead, TableRow, TableHeader,
+  TableBody, TableCell, TableExpandHeader, TableExpandRow, TableExpandedRow,
+  TableToolbar, TableToolbarContent, TableToolbarSearch,
+  Button, OverflowMenu, OverflowMenuItem,
+  InlineNotification,
+  Modal,
+  TextArea, Select, SelectItem,
+  Dropdown, DatePicker, DatePickerInput, MultiSelect,
+  StructuredListWrapper, StructuredListHead, StructuredListRow, StructuredListCell, StructuredListBody,
+  Link as CarbonLink,
+} from '@carbon/react';
+import {
+  ArrowRight, Warning, WarningAlt, CheckmarkFilled, ErrorFilled,
+  Information, Time, Box, NotificationFilled,
+} from '@carbon/icons-react';
+
+const t = (key, fallback) => fallback || key;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock data — realistic enough to evaluate the design
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REFERENCE_LABS = [
+  { id: 'org-cedres', name: 'CEDRES Reference Laboratory' },
+  { id: 'org-ihrip', name: 'IHRIP Microbiology Centre' },
+  { id: 'org-cphl', name: 'Central Public Health Laboratory' },
+  { id: 'org-pasteur', name: 'Institut Pasteur Antananarivo' },
+];
+
+const REFERRALS = [
+  // Outstanding — recent
+  {
+    id: 'R-7001', labNumber: 'L-2026-04123', patient: 'Rakoto, Jean (M, 42)',
+    tests: ['HIV-1 RNA Viral Load'], referenceLab: 'org-cedres',
+    boxId: 'BOX-2026-0312', sentDate: '2026-05-26T08:14:00Z', daysOut: 2,
+    status: 'requested', priority: 'Routine', requestor: 'Dr. Andrianasolo, M.',
+    fhirTaskUuid: 'urn:uuid:a2c4-7b9d-...-3f12', boxReceivedDate: null,
+    activity: [
+      { ts: '2026-05-26T08:14:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+      { ts: '2026-05-26T07:55:00Z', actor: 'A. Razafy (Tech)', from: 'created', to: 'draft', notes: 'Refer Out flagged at Result Entry' },
+    ],
+  },
+  {
+    id: 'R-7002', labNumber: 'L-2026-04124', patient: 'Voahangy, Lalao (F, 28)',
+    tests: ['HBV DNA Quantitative', 'HCV RNA Quantitative'],
+    referenceLab: 'org-cedres', boxId: 'BOX-2026-0312',
+    sentDate: '2026-05-26T08:14:00Z', daysOut: 2,
+    status: 'received', priority: 'Routine', requestor: 'Dr. Andrianasolo, M.',
+    fhirTaskUuid: 'urn:uuid:b8d1-3e72-...-91f4', boxReceivedDate: '2026-05-27T14:02:00Z',
+    activity: [
+      { ts: '2026-05-27T14:02:00Z', actor: 'CEDRES (peer)', from: 'requested', to: 'received', notes: 'Box scanned in at CEDRES receiving' },
+      { ts: '2026-05-26T08:14:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  {
+    id: 'R-7003', labNumber: 'L-2026-04098', patient: 'Andriamasy, Pierre (M, 67)',
+    tests: ['M. tuberculosis culture + AST'], referenceLab: 'org-ihrip',
+    boxId: 'BOX-2026-0309', sentDate: '2026-05-22T09:30:00Z', daysOut: 6,
+    status: 'in-progress', priority: 'Urgent', requestor: 'Dr. Rakotonirina, S.',
+    fhirTaskUuid: 'urn:uuid:c1f9-2a4e-...-7b08', boxReceivedDate: '2026-05-23T11:45:00Z',
+    activity: [
+      { ts: '2026-05-24T08:30:00Z', actor: 'IHRIP (peer)', from: 'received', to: 'in-progress', notes: 'Culture set up' },
+      { ts: '2026-05-23T11:45:00Z', actor: 'IHRIP (peer)', from: 'requested', to: 'received', notes: '' },
+      { ts: '2026-05-22T09:30:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  // Outstanding — STUCK >7 days
+  {
+    id: 'R-7004', labNumber: 'L-2026-03891', patient: 'Razanamparany, Marie (F, 35)',
+    tests: ['Karyotyping — peripheral blood'], referenceLab: 'org-pasteur',
+    boxId: 'BOX-2026-0297', sentDate: '2026-05-09T10:00:00Z', daysOut: 19,
+    status: 'in-progress', priority: 'Routine', requestor: 'Dr. Ratsimbazafy, H.',
+    fhirTaskUuid: 'urn:uuid:d4e2-9f81-...-4c93', boxReceivedDate: '2026-05-11T15:20:00Z',
+    stuck: true,
+    activity: [
+      { ts: '2026-05-12T09:00:00Z', actor: 'Pasteur (peer)', from: 'received', to: 'in-progress', notes: 'Culture initiated' },
+      { ts: '2026-05-11T15:20:00Z', actor: 'Pasteur (peer)', from: 'requested', to: 'received', notes: '' },
+      { ts: '2026-05-09T10:00:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  // Outstanding — STUCK >30 days
+  {
+    id: 'R-7005', labNumber: 'L-2026-02156', patient: 'Ramaroson, Henri (M, 58)',
+    tests: ['Whole Exome Sequencing'], referenceLab: 'org-pasteur',
+    boxId: 'BOX-2026-0214', sentDate: '2026-04-15T11:20:00Z', daysOut: 43,
+    status: 'in-progress', priority: 'Urgent', requestor: 'Dr. Rajaonarivelo, T.',
+    fhirTaskUuid: 'urn:uuid:e7a3-1b5c-...-2d68', boxReceivedDate: '2026-04-18T09:15:00Z',
+    stuck: true, criticallyStuck: true,
+    activity: [
+      { ts: '2026-04-20T14:00:00Z', actor: 'Pasteur (peer)', from: 'received', to: 'in-progress', notes: 'Library prep started' },
+      { ts: '2026-04-18T09:15:00Z', actor: 'Pasteur (peer)', from: 'requested', to: 'received', notes: '' },
+      { ts: '2026-04-15T11:20:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+
+  // Returned — needs action
+  {
+    id: 'R-7006', labNumber: 'L-2026-04201', patient: 'Razafindrakoto, Aina (F, 31)',
+    tests: ['HIV-1 RNA Viral Load'], referenceLab: 'org-cedres',
+    boxId: 'BOX-2026-0314', sentDate: '2026-05-23T08:00:00Z', daysOut: 5,
+    status: 'completed', priority: 'Routine', requestor: 'Dr. Andrianasolo, M.',
+    returnedDate: '2026-05-28T07:42:00Z',
+    fhirTaskUuid: 'urn:uuid:f9c2-4d8a-...-5e17', boxReceivedDate: '2026-05-24T10:30:00Z',
+    diagnosticReportUuid: 'urn:uuid:g1h2-...-DR',
+    resultSummary: '< 20 copies/mL (undetectable)',
+    results: [
+      { test: 'HIV-1 RNA Viral Load', value: '< 20', units: 'copies/mL', range: 'Undetectable: < 20', flag: 'Normal', notes: 'Below limit of quantification.' },
+    ],
+    activity: [
+      { ts: '2026-05-28T07:42:00Z', actor: 'CEDRES (peer)', from: 'in-progress', to: 'completed', notes: 'DiagnosticReport received' },
+      { ts: '2026-05-24T11:00:00Z', actor: 'CEDRES (peer)', from: 'received', to: 'in-progress', notes: '' },
+      { ts: '2026-05-24T10:30:00Z', actor: 'CEDRES (peer)', from: 'requested', to: 'received', notes: '' },
+      { ts: '2026-05-23T08:00:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  {
+    id: 'R-7007', labNumber: 'L-2026-04156', patient: 'Andriamampianina, Bako (M, 24)',
+    tests: ['HBV DNA Quantitative', 'HCV RNA Quantitative'], referenceLab: 'org-cedres',
+    boxId: 'BOX-2026-0314', sentDate: '2026-05-23T08:00:00Z', daysOut: 5,
+    status: 'completed', priority: 'Routine', requestor: 'Dr. Rakotonirina, S.',
+    returnedDate: '2026-05-28T07:55:00Z',
+    fhirTaskUuid: 'urn:uuid:h2k4-...-7d12', boxReceivedDate: '2026-05-24T10:30:00Z',
+    diagnosticReportUuid: 'urn:uuid:i3j4-...-DR',
+    resultSummary: 'HBV: 2.1 × 10⁴ IU/mL  ·  HCV: not detected',
+    results: [
+      { test: 'HBV DNA Quantitative', value: '2.1 × 10⁴', units: 'IU/mL', range: '< 20 IU/mL undetectable', flag: 'Abnormal', notes: 'Active replication.' },
+      { test: 'HCV RNA Quantitative', value: 'Not detected', units: 'IU/mL', range: '< 15 IU/mL', flag: 'Normal', notes: '' },
+    ],
+    activity: [
+      { ts: '2026-05-28T07:55:00Z', actor: 'CEDRES (peer)', from: 'in-progress', to: 'completed', notes: 'DiagnosticReport received' },
+      { ts: '2026-05-23T08:00:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  {
+    id: 'R-7008', labNumber: 'L-2026-04188', patient: 'Rabearisoa, Olivier (M, 51)',
+    tests: ['Cryptococcal antigen (CrAg)'], referenceLab: 'org-cphl',
+    boxId: 'BOX-2026-0311', sentDate: '2026-05-25T09:15:00Z', daysOut: 3,
+    status: 'completed', priority: 'STAT', requestor: 'Dr. Ratsimbazafy, H.',
+    returnedDate: '2026-05-27T18:20:00Z',
+    fhirTaskUuid: 'urn:uuid:l5m6-...-9c87', boxReceivedDate: '2026-05-26T08:00:00Z',
+    diagnosticReportUuid: 'urn:uuid:n7o8-...-DR',
+    resultSummary: 'POSITIVE — titer 1:80',
+    results: [
+      { test: 'Cryptococcal antigen (CrAg)', value: 'POSITIVE', units: '— (titer 1:80)', range: 'Negative', flag: 'Critical', notes: 'Consistent with disseminated cryptococcosis. Recommend LP.' },
+    ],
+    activity: [
+      { ts: '2026-05-27T18:20:00Z', actor: 'CPHL (peer)', from: 'in-progress', to: 'completed', notes: 'DiagnosticReport received — CRITICAL' },
+      { ts: '2026-05-25T09:15:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+
+  // History — reconciled
+  {
+    id: 'R-7009', labNumber: 'L-2026-03997', patient: 'Razanadrakoto, Felana (F, 39)',
+    tests: ['HIV-1 RNA Viral Load'], referenceLab: 'org-cedres',
+    boxId: 'BOX-2026-0301', sentDate: '2026-05-18T08:30:00Z',
+    status: 'reconciled', outcome: 'Reconciled', priority: 'Routine',
+    closedDate: '2026-05-25T11:14:00Z', daysTotal: 7,
+    requestor: 'Dr. Andrianasolo, M.',
+    activity: [
+      { ts: '2026-05-25T11:14:00Z', actor: 'P. Rasoanirina (Validator)', from: 'completed', to: 'reconciled', notes: 'Result accepted into local Analysis' },
+      { ts: '2026-05-24T15:30:00Z', actor: 'CEDRES (peer)', from: 'in-progress', to: 'completed', notes: '' },
+      { ts: '2026-05-18T08:30:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: '' },
+    ],
+  },
+  // History — rejected
+  {
+    id: 'R-7010', labNumber: 'L-2026-03812', patient: 'Andriantsoa, Tahina (M, 19)',
+    tests: ['Mycobacterium spp. molecular ID'], referenceLab: 'org-ihrip',
+    boxId: 'BOX-2026-0286', sentDate: '2026-05-04T07:45:00Z',
+    status: 'rejected', outcome: 'Rejected', priority: 'Routine',
+    closedDate: '2026-05-09T13:00:00Z', daysTotal: 5,
+    rejectReason: 'Insufficient volume (received 0.4 mL, need ≥ 2 mL). Resubmit with larger draw.',
+    requestor: 'Dr. Rakotonirina, S.',
+    activity: [
+      { ts: '2026-05-09T13:00:00Z', actor: 'IHRIP (peer)', from: 'received', to: 'rejected', notes: 'Insufficient volume — 0.4 mL' },
+      { ts: '2026-05-05T10:00:00Z', actor: 'IHRIP (peer)', from: 'requested', to: 'received', notes: '' },
+      { ts: '2026-05-04T07:45:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: '' },
+    ],
+  },
+  // History — cancelled
+  {
+    id: 'R-7011', labNumber: 'L-2026-03734', patient: 'Rakotomalala, Hery (M, 47)',
+    tests: ['Karyotyping — peripheral blood'], referenceLab: 'org-pasteur',
+    boxId: 'BOX-2026-0273', sentDate: '2026-04-27T09:00:00Z',
+    status: 'cancelled', outcome: 'Cancelled', priority: 'Routine',
+    closedDate: '2026-04-27T16:30:00Z', daysTotal: 0,
+    cancelReason: 'Clinician withdrew request (treatment changed).',
+    requestor: 'Dr. Rajaonarivelo, T.',
+    activity: [
+      { ts: '2026-04-27T16:30:00Z', actor: 'P. Rasoanirina (Validator)', from: 'draft', to: 'cancelled', notes: 'Clinician withdrew request' },
+    ],
+  },
+  // History — manually entered (reference lab not on OpenELIS, called result by phone)
+  {
+    id: 'R-7013', labNumber: 'L-2026-03654', patient: 'Rafanomezantsoa, Lova (F, 44)',
+    tests: ['CD4 absolute count'], referenceLab: 'org-cphl',
+    boxId: 'BOX-2026-0265', sentDate: '2026-04-23T09:00:00Z',
+    status: 'reconciled', outcome: 'Reconciled', priority: 'Routine',
+    closedDate: '2026-05-01T14:22:00Z', daysTotal: 8, manuallyEntered: true,
+    requestor: 'Dr. Andrianasolo, M.',
+    activity: [
+      { ts: '2026-05-01T14:22:00Z', actor: 'P. Rasoanirina (Validator)', from: 'requested', to: 'reconciled', notes: 'Result phoned in by CPHL — manually entered via Result Entry' },
+      { ts: '2026-04-23T09:00:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: 'Box dispatched' },
+    ],
+  },
+  // History — lost
+  {
+    id: 'R-7012', labNumber: 'L-2026-03551', patient: 'Razafindramanana, Soa (F, 62)',
+    tests: ['HBsAg confirmatory'], referenceLab: 'org-cphl',
+    boxId: 'BOX-2026-0258', sentDate: '2026-04-19T08:00:00Z',
+    status: 'requested', outcome: 'Lost', priority: 'Routine',
+    closedDate: '2026-05-02T10:00:00Z', daysTotal: 13, lostStatus: true,
+    lostReason: 'Box never arrived at CPHL — courier confirmed loss. Sample re-collected and re-referred under L-2026-04201.',
+    requestor: 'Dr. Andrianasolo, M.',
+    activity: [
+      { ts: '2026-05-02T10:00:00Z', actor: 'P. Rasoanirina (Validator)', from: 'requested', to: '(lost flag set)', notes: 'Marked lost — courier confirmed' },
+      { ts: '2026-04-19T08:00:00Z', actor: 'A. Razafy (Tech)', from: 'draft', to: 'requested', notes: '' },
+    ],
+  },
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+const refLabName = (id) => REFERENCE_LABS.find((r) => r.id === id)?.name || id;
+
+const statusTagKind = {
+  draft: 'gray',
+  requested: 'blue',
+  received: 'purple',
+  'in-progress': 'warm-gray',
+  completed: 'teal',
+  rejected: 'red',
+  cancelled: 'gray',
+  reconciled: 'teal',
+};
+
+const statusLabel = (s) => ({
+  draft: 'Draft',
+  requested: 'Sent — awaiting acceptance',
+  received: 'At reference lab',
+  'in-progress': 'In progress at reference lab',
+  completed: 'Result returned',
+  rejected: 'Rejected by reference lab',
+  cancelled: 'Cancelled',
+  reconciled: 'Reconciled',
+}[s] || s);
+
+const priorityTagKind = (p) => ({ Routine: 'gray', Urgent: 'warm-gray', STAT: 'red' }[p] || 'gray');
+
+const outcomeTagKind = (o) => ({
+  Reconciled: 'teal', Rejected: 'red', Cancelled: 'gray', Lost: 'red',
+}[o] || 'gray');
+
+const formatDate = (iso) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main component
+// ─────────────────────────────────────────────────────────────────────────────
+
+export default function ReferenceLabResultsPage() {
+  const [activeView, setActiveView] = useState('outstanding'); // outstanding | returned | history
+  const [filterRefLab, setFilterRefLab] = useState(null);
+  const [filterPriority, setFilterPriority] = useState([]);
+  const [filterDaysBucket, setFilterDaysBucket] = useState('all');
+  const [expandedRow, setExpandedRow] = useState(null);
+  const [rejectModalRow, setRejectModalRow] = useState(null);
+  const [markLostModalRow, setMarkLostModalRow] = useState(null);
+
+  // Filter data
+  const filtered = useMemo(() => {
+    let rows = REFERRALS;
+    if (activeView === 'outstanding') {
+      rows = rows.filter((r) => ['requested', 'received', 'in-progress'].includes(r.status));
+    } else if (activeView === 'returned') {
+      rows = rows.filter((r) => r.status === 'completed');
+    } else {
+      rows = rows.filter((r) => ['reconciled', 'rejected', 'cancelled'].includes(r.status) || r.lostStatus);
+    }
+    if (filterRefLab) rows = rows.filter((r) => r.referenceLab === filterRefLab);
+    if (filterPriority.length) rows = rows.filter((r) => filterPriority.includes(r.priority));
+    if (activeView === 'outstanding' && filterDaysBucket !== 'all') {
+      rows = rows.filter((r) => {
+        if (filterDaysBucket === '0-7') return r.daysOut <= 7;
+        if (filterDaysBucket === '7-30') return r.daysOut > 7 && r.daysOut <= 30;
+        if (filterDaysBucket === '>30') return r.daysOut > 30;
+        return true;
+      });
+    }
+    return rows;
+  }, [activeView, filterRefLab, filterPriority, filterDaysBucket]);
+
+  const stuckCount = REFERRALS.filter((r) => r.stuck).length;
+
+  // Metric counts (always reflect ALL data, not filtered)
+  const counts = {
+    outstanding: REFERRALS.filter((r) => ['requested', 'received', 'in-progress'].includes(r.status)).length,
+    returned: REFERRALS.filter((r) => r.status === 'completed').length,
+    reconciledToday: 1, // mocked
+    rejectedThisWeek: REFERRALS.filter((r) => r.status === 'rejected').length,
+  };
+
+  const toggleExpand = useCallback((id) => {
+    setExpandedRow((prev) => (prev === id ? null : id));
+  }, []);
+
+  const clearFilters = () => {
+    setFilterRefLab(null);
+    setFilterPriority([]);
+    setFilterDaysBucket('all');
+  };
+
+  return (
+    <div style={{ padding: '1rem 2rem', maxWidth: 1440, margin: '0 auto' }}>
+
+      {/* Breadcrumb */}
+      <Breadcrumb noTrailingSlash>
+        <BreadcrumbItem href="/">{t('breadcrumb.home', 'Home')}</BreadcrumbItem>
+        <BreadcrumbItem href="/SampleShipment/dashboard">{t('breadcrumb.sampleShipment', 'Sample Shipment')}</BreadcrumbItem>
+        <BreadcrumbItem isCurrentPage>{t('referral.breadcrumb.referenceLabResults', 'Reference Lab Results')}</BreadcrumbItem>
+      </Breadcrumb>
+
+      <h1 style={{ margin: '0.5rem 0 1.5rem 0' }}>{t('referral.page.title', 'Reference Lab Results')}</h1>
+
+      {/* Aging banner */}
+      {stuckCount > 0 && activeView === 'outstanding' && (
+        <InlineNotification
+          kind="warning"
+          lowContrast
+          hideCloseButton
+          title={t('referral.banner.stuckReferralsTitle', 'Stuck referrals require attention')}
+          subtitle={`${stuckCount} referrals have been at a reference lab for more than 7 days. Consider contacting the reference lab or reassigning.`}
+          actions={
+            <Button kind="ghost" size="sm" onClick={() => setFilterDaysBucket('>30')}>
+              {t('referral.banner.filterToStuck', 'Filter to stuck only')}
+            </Button>
+          }
+          style={{ marginBottom: '1rem', maxWidth: 'none' }}
+        />
+      )}
+
+      {/* Metric tiles */}
+      <Grid narrow style={{ marginBottom: '1.5rem' }}>
+        <Column lg={4} md={4} sm={2}>
+          <MetricTile
+            color="#24a148"
+            label="OUTSTANDING"
+            count={counts.outstanding}
+            onClick={() => { setActiveView('outstanding'); clearFilters(); }}
+            active={activeView === 'outstanding'}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={2}>
+          <MetricTile
+            color="#da1e28"
+            label="RETURNED — NEEDS ACTION"
+            count={counts.returned}
+            onClick={() => { setActiveView('returned'); clearFilters(); }}
+            active={activeView === 'returned'}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={2}>
+          <MetricTile
+            color="#005d5d"
+            label="RECONCILED TODAY"
+            count={counts.reconciledToday}
+            onClick={() => { setActiveView('history'); clearFilters(); }}
+          />
+        </Column>
+        <Column lg={4} md={4} sm={2}>
+          <MetricTile
+            color="#8a3ffc"
+            label="REJECTED THIS WEEK"
+            count={counts.rejectedThisWeek}
+            onClick={() => { setActiveView('history'); clearFilters(); }}
+          />
+        </Column>
+      </Grid>
+
+      {/* Primary filter — ChipSet (Carbon ChipSet not yet generally available; render as button group with cds--btn-set semantics) */}
+      <div style={{ marginBottom: '1rem' }}>
+        <Stack orientation="horizontal" gap={3}>
+          <FilterChip active={activeView === 'outstanding'} onClick={() => setActiveView('outstanding')}>
+            {t('referral.chip.outstanding', 'Outstanding')} ({counts.outstanding})
+          </FilterChip>
+          <FilterChip active={activeView === 'returned'} onClick={() => setActiveView('returned')}>
+            {t('referral.chip.returned', 'Returned — needs action')} ({counts.returned})
+          </FilterChip>
+          <FilterChip active={activeView === 'history'} onClick={() => setActiveView('history')}>
+            {t('referral.chip.history', 'History')}
+          </FilterChip>
+        </Stack>
+      </div>
+
+      {/* Secondary filters */}
+      <div style={{ marginBottom: '1rem', padding: '1rem', background: '#f4f4f4' }}>
+        <Grid narrow>
+          <Column lg={4} md={4}>
+            <Dropdown
+              id="filter-ref-lab"
+              titleText={t('referral.filter.referenceLab', 'Reference Lab')}
+              label={t('referral.filter.allRefLabs', 'All reference labs')}
+              items={[{ id: null, name: 'All reference labs' }, ...REFERENCE_LABS]}
+              itemToString={(item) => (item ? item.name : '')}
+              selectedItem={REFERENCE_LABS.find((r) => r.id === filterRefLab) || { id: null, name: 'All reference labs' }}
+              onChange={({ selectedItem }) => setFilterRefLab(selectedItem?.id || null)}
+            />
+          </Column>
+          <Column lg={4} md={4}>
+            <DatePicker datePickerType="range">
+              <DatePickerInput
+                id="filter-date-from"
+                labelText={t('referral.filter.dateRange', 'Date range')}
+                placeholder="mm/dd/yyyy"
+              />
+              <DatePickerInput id="filter-date-to" labelText="" placeholder="mm/dd/yyyy" />
+            </DatePicker>
+          </Column>
+          <Column lg={4} md={4}>
+            <MultiSelect
+              id="filter-priority"
+              titleText={t('referral.filter.priority', 'Priority')}
+              label={t('referral.filter.allPriorities', 'All priorities')}
+              items={['Routine', 'Urgent', 'STAT']}
+              itemToString={(i) => i}
+              selectedItems={filterPriority}
+              onChange={({ selectedItems }) => setFilterPriority(selectedItems)}
+            />
+          </Column>
+          {activeView === 'outstanding' && (
+            <Column lg={3} md={3}>
+              <Select
+                id="filter-days-bucket"
+                labelText={t('referral.filter.daysOutstandingBucket', 'Days outstanding')}
+                value={filterDaysBucket}
+                onChange={(e) => setFilterDaysBucket(e.target.value)}
+              >
+                <SelectItem value="all" text="All" />
+                <SelectItem value="0-7" text="0-7" />
+                <SelectItem value="7-30" text="7-30" />
+                <SelectItem value=">30" text=">30" />
+              </Select>
+            </Column>
+          )}
+          <Column lg={1} md={1}>
+            <div style={{ paddingTop: '1.5rem' }}>
+              <Button kind="ghost" size="sm" onClick={clearFilters}>
+                {t('referral.action.clearFilters', 'Clear filters')}
+              </Button>
+            </div>
+          </Column>
+        </Grid>
+      </div>
+
+      {/* DataTable per active view */}
+      {activeView === 'outstanding' && (
+        <OutstandingTable
+          rows={filtered}
+          expandedRow={expandedRow}
+          toggleExpand={toggleExpand}
+          onMarkLost={(row) => setMarkLostModalRow(row)}
+        />
+      )}
+      {activeView === 'returned' && (
+        <ReturnedTable
+          rows={filtered}
+          expandedRow={expandedRow}
+          toggleExpand={toggleExpand}
+          onReject={(row) => setRejectModalRow(row)}
+        />
+      )}
+      {activeView === 'history' && (
+        <HistoryTable
+          rows={filtered}
+          expandedRow={expandedRow}
+          toggleExpand={toggleExpand}
+        />
+      )}
+
+      {/* Reject modal */}
+      {rejectModalRow && (
+        <RejectModal row={rejectModalRow} onClose={() => setRejectModalRow(null)} />
+      )}
+      {markLostModalRow && (
+        <MarkLostModal row={markLostModalRow} onClose={() => setMarkLostModalRow(null)} />
+      )}
+
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MetricTile — thick-left-border pattern lifted from deployed /SampleShipment/dashboard
+// ─────────────────────────────────────────────────────────────────────────────
+function MetricTile({ color, label, count, onClick, active }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        background: 'white',
+        borderLeft: `6px solid ${color}`,
+        padding: '1.25rem 1rem',
+        textAlign: 'left',
+        width: '100%',
+        border: active ? `1px solid ${color}` : '1px solid #e0e0e0',
+        borderLeft: `6px solid ${color}`,
+        cursor: 'pointer',
+        outline: 'none',
+      }}
+    >
+      <div style={{ fontSize: '2.5rem', fontWeight: 300, lineHeight: 1, color: '#161616' }}>{count}</div>
+      <div style={{ fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', color: '#525252', marginTop: '0.5rem' }}>{label}</div>
+    </button>
+  );
+}
+
+// FilterChip — chip pattern (no Carbon Tabs)
+function FilterChip({ active, onClick, children }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        background: active ? '#0f62fe' : 'white',
+        color: active ? 'white' : '#161616',
+        border: `1px solid ${active ? '#0f62fe' : '#8d8d8d'}`,
+        borderRadius: '999px',
+        padding: '0.375rem 1rem',
+        fontSize: '0.875rem',
+        cursor: 'pointer',
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OutstandingTable
+// ─────────────────────────────────────────────────────────────────────────────
+function OutstandingTable({ rows, expandedRow, toggleExpand, onMarkLost }) {
+  const headers = [
+    { key: 'labNumber', header: 'Lab Number' },
+    { key: 'patient', header: 'Patient' },
+    { key: 'tests', header: 'Test(s)' },
+    { key: 'referenceLab', header: 'Reference Lab' },
+    { key: 'boxId', header: 'Box ID' },
+    { key: 'sentDate', header: 'Sent Date' },
+    { key: 'status', header: 'Status' },
+    { key: 'daysOut', header: 'Days outstanding' },
+    { key: 'priority', header: 'Priority' },
+    { key: 'actions', header: '' },
+  ];
+  return (
+    <TableContainer
+      title={t('referral.table.outstanding.title', 'Outstanding referrals')}
+      description={t('referral.table.outstanding.desc', `${rows.length} referrals at reference labs awaiting results`, { N: rows.length })}
+    >
+      <Table size="md">
+        <TableHead>
+          <TableRow>
+            <TableExpandHeader />
+            {headers.map((h) => <TableHeader key={h.key}>{h.header}</TableHeader>)}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.length === 0 && (
+            <TableRow><TableCell colSpan={headers.length + 1} style={{ textAlign: 'center', padding: '2rem', color: '#525252' }}>
+              {t('referral.emptyState', 'No referrals found for the selected filters.')}
+            </TableCell></TableRow>
+          )}
+          {rows.map((row) => (
+            <React.Fragment key={row.id}>
+              <TableExpandRow isExpanded={expandedRow === row.id} onExpand={() => toggleExpand(row.id)}>
+                <TableCell>{row.labNumber}</TableCell>
+                <TableCell>{row.patient}</TableCell>
+                <TableCell>
+                  {row.tests.slice(0, 2).join(', ')}{row.tests.length > 2 && ` +${row.tests.length - 2} ${t('referral.testsOverflow', 'more')}`}
+                </TableCell>
+                <TableCell>{refLabName(row.referenceLab)}</TableCell>
+                <TableCell><CarbonLink href={`/SampleShipment/box/${row.boxId}`}>{row.boxId}</CarbonLink></TableCell>
+                <TableCell>{formatDate(row.sentDate)}</TableCell>
+                <TableCell><Tag type={statusTagKind[row.status]} size="sm">{statusLabel(row.status)}</Tag></TableCell>
+                <TableCell>
+                  <span style={{
+                    color: row.daysOut > 30 ? '#da1e28' : row.daysOut > 7 ? '#f1c21b' : '#161616',
+                    fontWeight: row.stuck ? 600 : 400,
+                  }}>
+                    {row.stuck && <Warning size={16} style={{ verticalAlign: 'middle', marginRight: 4 }} />}
+                    {t('referral.daysUnit', `${row.daysOut} ${row.daysOut === 1 ? 'day' : 'days'}`, { N: row.daysOut })}
+                  </span>
+                </TableCell>
+                <TableCell><Tag type={priorityTagKind(row.priority)} size="sm">{row.priority}</Tag></TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Button
+                    kind="tertiary"
+                    size="sm"
+                    href={`/result?sampleId=${row.labNumber}`}
+                    style={{
+                      width: '88px',
+                      whiteSpace: 'normal',
+                      lineHeight: '1.15',
+                      textAlign: 'center',
+                      paddingTop: '0.25rem',
+                      paddingBottom: '0.25rem',
+                    }}
+                  >
+                    {t('referral.action.enterResult', 'Enter result')}
+                  </Button>
+                </TableCell>
+              </TableExpandRow>
+              {expandedRow === row.id && (
+                <TableExpandedRow colSpan={headers.length + 1}>
+                  <ExpandPanel row={row} mode="outstanding" onMarkLost={onMarkLost} />
+                </TableExpandedRow>
+              )}
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ReturnedTable
+// ─────────────────────────────────────────────────────────────────────────────
+function ReturnedTable({ rows, expandedRow, toggleExpand, onReject }) {
+  const headers = [
+    { key: 'labNumber', header: 'Lab Number' },
+    { key: 'patient', header: 'Patient' },
+    { key: 'tests', header: 'Test(s)' },
+    { key: 'referenceLab', header: 'Reference Lab' },
+    { key: 'resultSummary', header: 'Result summary' },
+    { key: 'returnedDate', header: 'Returned Date' },
+    { key: 'requestor', header: 'Original requestor' },
+    { key: 'actions', header: 'Actions' },
+  ];
+  return (
+    <TableContainer
+      title={t('referral.table.returned.title', 'Returned — needs action')}
+      description={t('referral.table.returned.desc', `${rows.length} results awaiting reconciliation to local Analysis`, { N: rows.length })}
+    >
+      <Table size="md">
+        <TableHead>
+          <TableRow>
+            <TableExpandHeader />
+            {headers.map((h) => <TableHeader key={h.key}>{h.header}</TableHeader>)}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.length === 0 && (
+            <TableRow><TableCell colSpan={headers.length + 1} style={{ textAlign: 'center', padding: '2rem', color: '#525252' }}>
+              No returned results awaiting action.
+            </TableCell></TableRow>
+          )}
+          {rows.map((row) => {
+            const hasCritical = row.results?.some((r) => r.flag === 'Critical');
+            return (
+              <React.Fragment key={row.id}>
+                <TableExpandRow isExpanded={expandedRow === row.id} onExpand={() => toggleExpand(row.id)}>
+                  <TableCell>{row.labNumber}</TableCell>
+                  <TableCell>{row.patient}</TableCell>
+                  <TableCell>{row.tests.slice(0, 2).join(', ')}{row.tests.length > 2 && ` +${row.tests.length - 2} more`}</TableCell>
+                  <TableCell>{refLabName(row.referenceLab)}</TableCell>
+                  <TableCell>
+                    {hasCritical && <Tag type="red" size="sm" style={{ marginRight: 6 }}>CRITICAL</Tag>}
+                    {row.resultSummary}
+                  </TableCell>
+                  <TableCell>{formatDate(row.returnedDate)}</TableCell>
+                  <TableCell>{row.requestor}</TableCell>
+                  <TableCell onClick={(e) => e.stopPropagation()}>
+                    <Stack orientation="horizontal" gap={2}>
+                      <Button kind="primary" size="sm" onClick={() => { /* accept */ }}>{t('referral.action.accept', 'Accept')}</Button>
+                      <Button kind="danger--ghost" size="sm" onClick={() => onReject(row)}>{t('referral.action.reject', 'Reject…')}</Button>
+                    </Stack>
+                  </TableCell>
+                </TableExpandRow>
+                {expandedRow === row.id && (
+                  <TableExpandedRow colSpan={headers.length + 1}>
+                    <ExpandPanel row={row} mode="returned" onReject={onReject} />
+                  </TableExpandedRow>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HistoryTable
+// ─────────────────────────────────────────────────────────────────────────────
+function HistoryTable({ rows, expandedRow, toggleExpand }) {
+  const headers = [
+    { key: 'labNumber', header: 'Lab Number' },
+    { key: 'patient', header: 'Patient' },
+    { key: 'tests', header: 'Test(s)' },
+    { key: 'referenceLab', header: 'Reference Lab' },
+    { key: 'outcome', header: 'Outcome' },
+    { key: 'closedDate', header: 'Closed date' },
+    { key: 'boxId', header: 'Box ID' },
+    { key: 'daysTotal', header: 'Days total' },
+  ];
+  return (
+    <TableContainer
+      title={t('referral.table.history.title', 'History')}
+      description={t('referral.table.history.desc', `${rows.length} closed referrals`, { N: rows.length })}
+    >
+      <Table size="md">
+        <TableHead>
+          <TableRow>
+            <TableExpandHeader />
+            {headers.map((h) => <TableHeader key={h.key}>{h.header}</TableHeader>)}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {rows.length === 0 && (
+            <TableRow><TableCell colSpan={headers.length + 1} style={{ textAlign: 'center', padding: '2rem', color: '#525252' }}>
+              No closed referrals match the selected filters.
+            </TableCell></TableRow>
+          )}
+          {rows.map((row) => (
+            <React.Fragment key={row.id}>
+              <TableExpandRow isExpanded={expandedRow === row.id} onExpand={() => toggleExpand(row.id)}>
+                <TableCell>{row.labNumber}</TableCell>
+                <TableCell>{row.patient}</TableCell>
+                <TableCell>{row.tests.slice(0, 2).join(', ')}{row.tests.length > 2 && ` +${row.tests.length - 2} more`}</TableCell>
+                <TableCell>{refLabName(row.referenceLab)}</TableCell>
+                <TableCell>
+                  <Tag type={outcomeTagKind(row.outcome)} size="sm">{row.outcome}</Tag>
+                  {row.manuallyEntered && <Tag type="warm-gray" size="sm" style={{ marginLeft: 4 }}>{t('referral.tag.manuallyEntered', 'Manually entered')}</Tag>}
+                </TableCell>
+                <TableCell>{formatDate(row.closedDate)}</TableCell>
+                <TableCell><CarbonLink href={`/SampleShipment/box/${row.boxId}`}>{row.boxId}</CarbonLink></TableCell>
+                <TableCell>{row.daysTotal} {row.daysTotal === 1 ? 'day' : 'days'}</TableCell>
+              </TableExpandRow>
+              {expandedRow === row.id && (
+                <TableExpandedRow colSpan={headers.length + 1}>
+                  <ExpandPanel row={row} mode="history" />
+                </TableExpandedRow>
+              )}
+            </React.Fragment>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ExpandPanel — shared inline-expand detail
+// ─────────────────────────────────────────────────────────────────────────────
+function ExpandPanel({ row, mode, onMarkLost, onReject }) {
+  return (
+    <div style={{ padding: '1.5rem', background: '#f4f4f4' }}>
+      <Grid narrow>
+        {/* Left: Original order context */}
+        <Column lg={4} md={4} sm={4}>
+          <h5 style={{ marginTop: 0 }}>{t('referral.expand.originalOrderContext', 'Original order context')}</h5>
+          <DetailRow label="Lab Number" value={<CarbonLink href={`/Patient/${row.labNumber}`}>{row.labNumber}</CarbonLink>} />
+          <DetailRow label="Patient" value={row.patient} />
+          <DetailRow label="Tests" value={row.tests.join(', ')} />
+          <DetailRow label="Original requestor" value={row.requestor} />
+          <DetailRow label="Priority" value={<Tag type={priorityTagKind(row.priority)} size="sm">{row.priority}</Tag>} />
+        </Column>
+
+        {/* Middle: Reference lab transit */}
+        <Column lg={4} md={4} sm={4}>
+          <h5 style={{ marginTop: 0 }}>{t('referral.expand.referenceLabTransit', 'Reference lab transit')}</h5>
+          <DetailRow label="Reference Lab" value={refLabName(row.referenceLab)} />
+          <DetailRow label="Box ID" value={<CarbonLink href={`/SampleShipment/box/${row.boxId}`}>{row.boxId}</CarbonLink>} />
+          <DetailRow label="Dispatched" value={formatDate(row.sentDate)} />
+          <DetailRow label="Received at lab" value={formatDate(row.boxReceivedDate)} />
+          <DetailRow label="FHIR Task" value={<code style={{ fontSize: '0.75rem' }}>{row.fhirTaskUuid}</code>} />
+        </Column>
+
+        {/* Right: Result (returned/history) or actions (outstanding) */}
+        <Column lg={4} md={4} sm={4}>
+          {mode === 'outstanding' && (
+            <>
+              <h5 style={{ marginTop: 0 }}>{t('referral.expand.statusDetail', 'Status detail')}</h5>
+              <DetailRow label="Current status" value={<Tag type={statusTagKind[row.status]} size="sm">{statusLabel(row.status)}</Tag>} />
+              <DetailRow label="Days outstanding" value={`${row.daysOut} days`} />
+              {row.stuck && (
+                <InlineNotification
+                  kind="warning"
+                  lowContrast
+                  hideCloseButton
+                  title="Stuck"
+                  subtitle="Consider contacting the reference lab."
+                  style={{ marginTop: '0.75rem', maxWidth: 'none' }}
+                />
+              )}
+              <Stack orientation="horizontal" gap={2} style={{ marginTop: '1rem' }}>
+                <Button
+                  kind="primary"
+                  size="sm"
+                  href={`/result?sampleId=${row.labNumber}`}
+                >
+                  {t('referral.action.enterResult', 'Enter result')}
+                </Button>
+                <Button kind="ghost" size="sm" renderIcon={WarningAlt} onClick={() => onMarkLost(row)}>
+                  {t('referral.action.markLost', 'Mark Lost')}
+                </Button>
+              </Stack>
+            </>
+          )}
+          {mode === 'returned' && (
+            <>
+              <h5 style={{ marginTop: 0 }}>{t('referral.expand.result', 'Result')}</h5>
+              {row.results?.map((res, i) => (
+                <div key={i} style={{ marginBottom: '0.75rem', padding: '0.75rem', background: 'white', border: '1px solid #e0e0e0' }}>
+                  <div style={{ fontWeight: 600 }}>{res.test}</div>
+                  <div style={{ fontSize: '1.25rem', margin: '0.25rem 0' }}>{res.value} <span style={{ color: '#525252' }}>{res.units}</span></div>
+                  <div style={{ fontSize: '0.75rem', color: '#525252' }}>{t('referral.result.referenceRange', 'Reference range:')} {res.range}</div>
+                  {res.flag && <Tag type={res.flag === 'Critical' ? 'red' : res.flag === 'Abnormal' ? 'warm-gray' : 'green'} size="sm" style={{ marginTop: 4 }}>{res.flag}</Tag>}
+                  {res.notes && <div style={{ fontSize: '0.75rem', marginTop: 4, fontStyle: 'italic' }}>{res.notes}</div>}
+                </div>
+              ))}
+              <Stack orientation="horizontal" gap={2}>
+                <Button kind="primary" size="sm" renderIcon={CheckmarkFilled}>{t('referral.action.acceptToAnalysis', 'Accept to Analysis')}</Button>
+                <Button kind="danger--ghost" size="sm" onClick={() => onReject(row)}>{t('referral.action.reject', 'Reject…')}</Button>
+                <Button kind="ghost" size="sm" href={`/result?sampleId=${row.labNumber}`}>{t('referral.action.openInResultEntry', 'Open in Result Entry')}</Button>
+              </Stack>
+            </>
+          )}
+          {mode === 'history' && (
+            <>
+              <h5 style={{ marginTop: 0 }}>{t('referral.expand.outcomeDetail', 'Outcome detail')}</h5>
+              <DetailRow label="Outcome" value={<Tag type={outcomeTagKind(row.outcome)} size="sm">{row.outcome}</Tag>} />
+              <DetailRow label="Closed" value={formatDate(row.closedDate)} />
+              <DetailRow label="Total days" value={`${row.daysTotal} days`} />
+              {row.rejectReason && <DetailRow label="Rejection reason" value={row.rejectReason} />}
+              {row.cancelReason && <DetailRow label="Cancellation reason" value={row.cancelReason} />}
+              {row.lostReason && <DetailRow label="Lost reason" value={row.lostReason} />}
+            </>
+          )}
+        </Column>
+      </Grid>
+
+      {/* Activity log */}
+      <div style={{ marginTop: '1.5rem' }}>
+        <h5>{t('referral.expand.activityLog', 'Activity log')}</h5>
+        <StructuredListWrapper isCondensed>
+          <StructuredListHead>
+            <StructuredListRow head>
+              <StructuredListCell head>Timestamp</StructuredListCell>
+              <StructuredListCell head>Actor</StructuredListCell>
+              <StructuredListCell head>From</StructuredListCell>
+              <StructuredListCell head>To</StructuredListCell>
+              <StructuredListCell head>Notes</StructuredListCell>
+            </StructuredListRow>
+          </StructuredListHead>
+          <StructuredListBody>
+            {row.activity?.map((a, i) => (
+              <StructuredListRow key={i}>
+                <StructuredListCell>{formatDate(a.ts)}</StructuredListCell>
+                <StructuredListCell>{a.actor}</StructuredListCell>
+                <StructuredListCell>{a.from}</StructuredListCell>
+                <StructuredListCell>{a.to}</StructuredListCell>
+                <StructuredListCell>{a.notes || '—'}</StructuredListCell>
+              </StructuredListRow>
+            ))}
+          </StructuredListBody>
+        </StructuredListWrapper>
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, value }) {
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', padding: '0.375rem 0', borderBottom: '1px solid #e0e0e0', fontSize: '0.875rem' }}>
+      <span style={{ color: '#525252' }}>{label}</span>
+      <span style={{ textAlign: 'right', maxWidth: '60%' }}>{value}</span>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Reject modal
+// ─────────────────────────────────────────────────────────────────────────────
+function RejectModal({ row, onClose }) {
+  const [reasonCode, setReasonCode] = useState('');
+  const [reasonText, setReasonText] = useState('');
+  return (
+    <Modal
+      open
+      modalHeading={t('referral.reject.modalTitle', 'Reject referral')}
+      primaryButtonText={t('referral.reject.confirmButton', 'Reject and notify clinician')}
+      secondaryButtonText="Cancel"
+      danger
+      onRequestClose={onClose}
+      onRequestSubmit={onClose}
+    >
+      <div style={{ marginBottom: '1rem' }}>
+        <strong>{row.labNumber}</strong> — {row.patient}<br />
+        <span style={{ color: '#525252' }}>{row.tests.join(', ')} → {refLabName(row.referenceLab)}</span>
+      </div>
+      <Select id="reject-reason-code" labelText={t('referral.reject.preFilledReasonLabel', 'Common reason (optional)')} value={reasonCode} onChange={(e) => setReasonCode(e.target.value)}>
+        <SelectItem value="" text="— Select reason —" />
+        <SelectItem value="insufficientVolume" text="Insufficient volume" />
+        <SelectItem value="wrongSampleType" text="Wrong sample type" />
+        <SelectItem value="damagedContainer" text="Damaged container" />
+        <SelectItem value="temperatureDeviation" text="Temperature deviation" />
+        <SelectItem value="hemolyzed" text="Hemolyzed" />
+        <SelectItem value="clotted" text="Clotted" />
+        <SelectItem value="mislabeled" text="Mislabeled" />
+        <SelectItem value="other" text="Other" />
+      </Select>
+      <TextArea
+        id="reject-reason-text"
+        labelText={t('referral.reject.reasonLabel', 'Reason for rejection')}
+        placeholder={t('referral.reject.reasonPlaceholder', 'Describe why this referral is being rejected')}
+        value={reasonText}
+        onChange={(e) => setReasonText(e.target.value)}
+        rows={3}
+        maxCount={500}
+        enableCounter
+        style={{ marginTop: '1rem' }}
+      />
+      <InlineNotification
+        kind="warning"
+        lowContrast
+        hideCloseButton
+        title={t('referral.reject.warningTitle', 'This closes the Analysis as rejected')}
+        subtitle={t('referral.reject.warning', 'Rejecting closes the Analysis as terminal-rejected. The requesting clinician will be notified to arrange re-collection. A new order will be needed when a fresh sample is collected.')}
+        style={{ marginTop: '1rem', maxWidth: 'none' }}
+      />
+    </Modal>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mark Lost modal
+// ─────────────────────────────────────────────────────────────────────────────
+function MarkLostModal({ row, onClose }) {
+  const [reason, setReason] = useState('');
+  return (
+    <Modal
+      open
+      modalHeading={t('referral.markLost.modalTitle', 'Mark referral lost in transit')}
+      primaryButtonText="Mark Lost"
+      secondaryButtonText="Cancel"
+      danger
+      onRequestClose={onClose}
+      onRequestSubmit={onClose}
+    >
+      <div style={{ marginBottom: '1rem' }}>
+        <strong>{row.labNumber}</strong> — {row.patient}<br />
+        <span style={{ color: '#525252' }}>Box {row.boxId} → {refLabName(row.referenceLab)}</span>
+      </div>
+      <TextArea
+        id="lost-reason"
+        labelText={t('referral.markLost.reasonLabel', 'Reason')}
+        placeholder="What happened to the sample?"
+        value={reason}
+        onChange={(e) => setReason(e.target.value)}
+        rows={3}
+      />
+      <InlineNotification
+        kind="warning"
+        lowContrast
+        hideCloseButton
+        title="Reversible only by an administrator"
+        subtitle={t('referral.markLost.warning', 'Marking this referral as lost is reversible only by an administrator.')}
+        style={{ marginTop: '1rem', maxWidth: 'none' }}
+      />
+    </Modal>
+  );
+}

--- a/designs/sample-collection/reference-lab-results.md
+++ b/designs/sample-collection/reference-lab-results.md
@@ -1,0 +1,767 @@
+# Reference Lab Results — Functional Requirements Specification
+
+**Version:** 1.0 (Draft)
+**Date:** 2026-05-28
+**Module:** Sample Shipment → Reference Lab Results
+**Route:** `/SampleShipment/reference-lab-results`
+**SideNav:** Sample Shipment → Reference Lab Results
+**Breadcrumb:** Home / Sample Shipment / Reference Lab Results
+**Owner:** Casey + OpenELIS team
+**Status:** Draft for review
+**Umbrella Jira:** OGC-796 (to be promoted to Epic)
+**Folds in:** OGC-605, OGC-589, parts of OGC-624
+
+---
+
+## 1. Lab Context
+
+### 1.1 Current State
+
+A clinical laboratory often can't perform every test it's asked to run. Some tests need specialized equipment (HIV viral load, genetic sequencing, certain microbiology cultures, antimicrobial susceptibility on rare organisms). Some need reagents that ran out. Some need confirmatory analysis at a higher-tier reference lab. In all these cases the lab **refers out** — physically packages and sends the sample to a partner reference lab, then waits for the result to come back.
+
+In OpenELIS today, when a technician decides to refer a test out, they check a "Refer Out" box on the Result Entry (Logbook) page. The system records the referral but does almost nothing with it afterward. There is a search page at `/ReferredOutTests` titled "Referrals" — it is a three-pane search shell over an empty table. No live tracking, no view of what's outstanding, no clear path to reconcile results when they come back. Labs work around this gap with email, paper logs, and spreadsheets.
+
+A sibling feature called **Sample Shipment** (recently shipped to the testing instance at `/SampleShipment/*`) handles the physical side: packing samples into boxes, printing labels and manifests, scanning boxes at the receiving lab, capturing non-conformities, exchanging FHIR (Fast Healthcare Interoperability Resources) `SupplyDelivery` messages between sender and receiver. That feature ends when a box is physically received and all samples have been accepted into the receiving lab's workflow (the "Reconciled" state). What happens to the test results in between — who is tracking what is still outstanding at the reference lab, what has come back, what needs a validator's eye — has no surface today.
+
+### 1.2 Pain
+
+- A reference lab returns a result via FHIR `DiagnosticReport`. The receiving OpenELIS instance accepts the resource but no one notices. The lab manager finds out two weeks later when the requesting clinician calls asking for the result.
+- The `ReferralStatus` enum on the `Referral` entity has 5 values (`CREATED, SENT, RECEIVED, FINISHED, CANCELED`) but the code only ever writes 3 (`CREATED, RECEIVED, CANCELED`). `SENT` and `FINISHED` are dead. A validator looking at a referral has no way to tell whether the sample is still en route, at the reference lab, in progress at the reference lab, or returned.
+- The `Referral` entity has rich shipment-tracking fields (`assignedBox`, `lostStatus`, `lostDate`, `lostReason`, `priority`) populated nowhere in the UI. The schema knows what was wanted; the wiring never happened.
+- A box reaches `Received` at the reference lab and the lab manager has no signal that result reconciliation needs to happen. The Box state stays at `Received` indefinitely until someone manually marks it `Reconciled`. The "stuck Box" problem is real and silent.
+- OGC-624 (currently in progress) proposes a *second* status field (`subcontractStatus`) parallel to `ReferralStatus` with a different lifecycle (`DRAFT → DISPATCHED → RECEIVED → RESULTS_RETURNED → CLOSED`). If both ship as proposed, the same row will carry two divergent state fields.
+- When a peer reference lab rejects a referral (sends FHIR `Task.status = rejected`), today there is no code path that puts the original local Analysis back into a workable state. The Analysis is orphaned and the validator has to manually delete and re-create the order to re-refer.
+- **Most reference labs are not on OpenELIS.** Results return by phone, fax, paper, or email — no FHIR `DiagnosticReport` flows back. Today there is no path to manually post such a result against the original referred Analysis from the Referral view. The validator has to navigate separately to Result Entry, search for the lab number, type the value, save — and the Referral row stays in `requested` forever because nothing tells the Referral state machine that the result is in.
+
+### 1.3 What Changes
+
+A new SideNav item called **Reference Lab Results** lives under Sample Shipment. Lab managers, validators, and clinicians open it any time of day and see, in one place: how many tests are outstanding at reference labs (with how many days have passed since dispatch), how many results have come back today and need acceptance, and the history of everything closed in the past N days.
+
+When a result arrives via `DiagnosticReport`, the row appears in the "Returned — needs action" view. A validator clicks **Accept**, the result flows into the local Analysis, and the validator continues into Result Entry as they would for any other result. If the reference lab rejected the sample, a **Reject** action sends `Task.status = rejected` back and re-opens the local Analysis with the original Refer Out flag intact — the validator can re-refer to a different reference lab without re-keying patient or test information.
+
+The `ReferralStatus` enum migrates to FHIR `Task.status`–aligned values via a one-time Liquibase migration. The `cancelled` and `rejected` paths get wired into `FhirReferralServiceImpl` (today they are commented out). The full FHIR Task lifecycle (`draft → requested → received → in-progress → completed`, plus `cancelled` and `rejected` as exits) is the canonical state machine for every referral. Display labels remain localizable so the UI can still read "Sent — awaiting acceptance" or "At reference lab" without inventing new enum values.
+
+Stuck Boxes stop being silent. An aging banner appears on the Reference Lab Results page when referrals cross threshold (default >7 days outstanding, configurable). The lab manager has a single page that says "you have N tests still at reference labs, M of them are over threshold."
+
+For reference labs that aren't on OpenELIS, every Outstanding row has a **"Manually enter result"** action that deep-links to the existing Result Entry screen with the order pre-loaded. The validator types in the value and the reference lab's reported date/time, saves, and the Referral state machine advances to `completed` automatically. No new entry form, no duplicate code — just a deep link into existing Result Entry plus a small server-side hook that detects "this Result save lands on an Analysis with an open Referral" and advances the Referral.
+
+---
+
+## 2. Overview
+
+### 2.1 Purpose
+
+Provide a single operational surface for tracking the **data lifecycle** of every referred sample after physical shipment — from "sent to reference lab" through "result returned and reconciled into local Analysis." Complements the existing Sample Shipment feature, which owns the physical lifecycle (boxes, manifests, receiving). The two surfaces are tightly coupled at the Box.Reconciled transition: a Box cannot be marked Reconciled until every contained Referral has reached `completed` (result accepted) or `rejected`/`cancelled` (terminal exit).
+
+### 2.2 Scope
+
+In scope for this FRS:
+- New SideNav item under Sample Shipment, single-page surface with internal filter switching
+- Three filter views: Outstanding · Returned — needs action · History
+- Per-row inline-expand detail panel
+- Accept / Reject / Open in Result Entry actions on the Returned view
+- State-model migration from current `ReferralStatus` enum to FHIR Task statuses
+- Outbound write path: emit the full FHIR Task lifecycle in `FhirReferralServiceImpl`
+- Inbound read path: handle peer `Task.status = received | in-progress | rejected` updates
+- Result reconciliation: when `DiagnosticReport` arrives, route to original `Analysis` and surface
+- Order Entry Step 3 refer-out hook (OGC-605)
+- Box ↔ Referral cross-links (read-only)
+- Stuck-referral aging banner
+- Audit_trail entries for state transitions and validator actions
+- Liquibase migration with reversibility
+
+### 2.3 Non-goals
+
+Explicitly NOT in scope:
+- Anything inside the Sample Shipment feature (box creation, sample assignment, manifest, label, receiving workflow, non-conformity capture, facility registry, label preset admin, FHIR SupplyDelivery exchange) — already shipped
+- The Unassigned Samples tab at `/SampleShipment/unassigned` — already shipped
+- Source detection on Incoming Orders (deferred per `/clarify` Q3)
+- Auto-accept inbound FHIR Task (deferred)
+- Reference Lab admin redesign (uses existing Organization Management)
+- Admin UI to reverse a Lost referral (the audit verb `REFERRAL_LOST_REVERSED` is reserved for the existing Sample Shipment admin path; this FRS does not design that UI)
+- Multi-test bulk dispatch as a single Referral row (one Analysis per Referral stays the invariant)
+- Turnaround-time / rejection-rate metrics dashboard (separate Reports work)
+- Mobile responsiveness beyond Carbon defaults
+
+### 2.4 IA placement
+
+| Item | Value |
+|---|---|
+| SideNav | Sample Shipment → Reference Lab Results |
+| Route | `/SampleShipment/reference-lab-results` |
+| Query params | `?view=outstanding\|returned\|history` (default: outstanding) · `?refLab=<id>` · `?range=7\|30\|90` |
+| Breadcrumb | Home / Sample Shipment / Reference Lab Results |
+| Page title (h1) | Reference Lab Results |
+| Count badge on SideNav item | Renders count of Returned — needs action when > 0 (e.g. `Reference Lab Results [3]`) |
+
+The page is a single scroll surface. No in-page Carbon Tabs — the three filter views switch via a Carbon `ChipSet` (single-select) at the top of the page. View state is encoded in the URL query string for deep-linkability.
+
+### 2.5 Roles and access
+
+Attaches to existing OpenELIS role bundles. No new permission keys.
+
+| Role bundle | Outstanding view | Returned view | History view | Accept / Reject |
+|---|---|---|---|---|
+| Validator | read | read | read | write |
+| Lab Manager | read | read | read | write |
+| Analyst | read | read | read | — |
+| Reception | read (no patient PHI) | — | — | — |
+| Provider | read (only their own referrals) | — | — | — |
+| Admin | full | full | full | write |
+
+**No invented per-action permission keys.** Access is granted by membership in the existing role bundles. UI hides actions the role cannot perform.
+
+### 2.6 Audit
+
+Every state-changing action writes an `audit_trail` row. See §10 for the full table; summary:
+
+| Action | Audit verb | Target |
+|---|---|---|
+| Validator/Reception receives a returned result | `REFERRAL_RESULT_RECEIVED` | `Referral.id` |
+| Validator Rejects a returned result | `REFERRAL_RESULT_REJECTED` | `Referral.id` |
+| Referral state transitions (any) | `REFERRAL_STATE_CHANGED` | `Referral.id` |
+| Validator opens in Result Entry | not audited (read) | — |
+| Lab manager marks Lost | `REFERRAL_MARKED_LOST` | `Referral.id` |
+
+Envers coverage: the existing `Referral` and `ReferralResult` entities already have `@Audited`; no new entities introduced.
+
+---
+
+## 3. User Stories
+
+**US-1 — Lab Manager: Daily outstanding-tests review.** *As a Lab Manager, I want to open Reference Lab Results each morning and see, in one place, every test that's still out at a reference lab with how long it has been waiting, so that I can identify stuck samples and chase the reference lab when needed.*
+
+**US-2 — Validator: Result return reconciliation.** *As a Validator, I want to see at a glance which results came back from reference labs today, and accept each one into the originating local Analysis with a single click, so that those results flow into the normal validation queue without manual re-entry.*
+
+**US-3 — Validator: Handling a rejection.** *As a Validator, when a reference lab rejects a sample (insufficient volume, wrong tube type, hemolysis, etc.), I want to reject the referral in the system with a reason, close the original Analysis as terminal-rejected, and have the system notify the requesting clinician and the lab-side Alerts screen so re-collection gets arranged. A new sample will require a new order — I don't try to recycle the broken one.*
+
+**US-4 — Lab Manager: Stuck-box surfacing.** *As a Lab Manager, I want the system to highlight referrals that are over an aging threshold (default 7 days outstanding) so I notice stuck cases before clinicians call.*
+
+**US-5 — Sample Shipping coordinator: Closing the loop.** *As a Sample Shipping coordinator, I want to see, on a Box's detail page, how many of its samples still need result reconciliation before the Box can be marked Reconciled, so the physical workflow and the data workflow stay aligned.*
+
+---
+
+## 4. Functional requirements
+
+### 4.1 Page-level structure
+
+**FR-PAGE-001 — Single scroll layout.**
+The page renders in this vertical order:
+1. Page header with h1 "Reference Lab Results" and breadcrumb
+2. Aging banner (conditionally rendered, see FR-AGING-001)
+3. Metric tiles row (4 tiles, Carbon Tile with thick colored left border)
+4. Primary filter ChipSet (single-select: Outstanding · Returned — needs action · History)
+5. Secondary filter row (Reference Lab dropdown · Date range picker · Priority MultiSelect · Days outstanding bucket Select)
+6. DataTable (columns vary per active filter chip — see FR-COLUMNS-* below)
+7. Per-row inline-expand detail panel (Carbon `TableExpandedRow`, NOT a modal)
+
+**FR-PAGE-002 — No in-page tabs.**
+The three filter states use a Carbon `ChipSet`. The page MUST NOT render Carbon `Tabs` for switching between Outstanding / Returned / History. Modals are only used for destructive confirmation (Reject, Mark Lost).
+
+**FR-PAGE-003 — Deep-linkability.**
+The active filter chip and secondary filter selections MUST be reflected in the URL query string. Pasting the URL into a new tab MUST land on the same view. Browser back/forward navigation MUST move between previous filter states.
+
+**FR-PAGE-004 — Carbon visual conventions match deployed Sample Shipment.**
+- Metric tiles use the thick-colored-left-border pattern (uppercase caption, large number above)
+- Yellow `InlineNotification kind="warning"` for the aging banner
+- Empty state copy: "No referrals found for the selected filters."
+
+### 4.2 Metric tiles
+
+**FR-METRIC-001 — Four tiles, left-to-right.**
+| Tile label | Color accent | Count source |
+|---|---|---|
+| OUTSTANDING | green | Count of Referrals with Task status ∈ {requested, received, in-progress}, DiagnosticReport absent |
+| RETURNED — NEEDS ACTION | red | Count of Referrals with Task status = completed AND DiagnosticReport present AND not yet reconciled to local Analysis |
+| RECONCILED TODAY | teal | Count of Referrals reconciled (`REFERRAL_RESULT_RECEIVED` event) since 00:00 local time |
+| REJECTED THIS WEEK | warm-gray | Count of Referrals with Task status = rejected, rejection date within last 7 days |
+
+**FR-METRIC-002 — Clickable filter trigger.**
+Clicking a metric tile MUST set the primary filter chip to the matching view (Outstanding → Outstanding, Returned → Returned, Reconciled Today → History with date filter = today, Rejected This Week → History with status filter = rejected and date filter = last 7 days).
+
+**FR-METRIC-003 — Real-time refresh.**
+Counts refresh on page load and on any state-changing action (Accept / Reject / Mark Lost). No background polling in v1.
+
+### 4.3 Filter behavior
+
+**FR-FILTER-001 — Primary filter chip is single-select.**
+ChipSet with three chips: `Outstanding`, `Returned — needs action`, `History`. Default selection: Outstanding. Selection persists across page reloads via URL.
+
+**FR-FILTER-002 — Secondary filters apply AND-style.**
+All secondary filters combine with AND logic against the primary chip's base query.
+
+**FR-FILTER-003 — Secondary filter list.**
+| Filter | Component | Source / values |
+|---|---|---|
+| Reference Lab | Dropdown | From existing Organization Management (organizations tagged as `referenceLab`) |
+| Date range | DatePicker (range) | Applies to Sent Date by default; switches to Closed Date when primary chip = History |
+| Priority | MultiSelect | Routine, Urgent, STAT — values from existing `priority` field on `Referral` |
+| Days outstanding bucket | Select | All · 0-7 · 7-30 · >30 — only visible when primary chip = Outstanding |
+
+**FR-FILTER-004 — Clear all.**
+A "Clear filters" ghost button next to the secondary filter row resets all secondary filters but does NOT change the primary chip.
+
+### 4.4 Outstanding view
+
+**FR-OUTSTANDING-001 — DataTable columns.**
+| Column | Sortable | Default |
+|---|---|---|
+| Lab Number | yes | — |
+| Patient | yes | — |
+| Test(s) | no | shows comma-separated test names; truncated at 3 with "+N more" overflow |
+| Reference Lab | yes | — |
+| Box ID | no | Carbon Link to `/SampleShipment/box/<id>`; opens in same tab |
+| Sent Date | yes | descending — DEFAULT SORT |
+| Status | yes | Carbon Tag with kind from §6 mapping table |
+| Days outstanding | yes | computed; cell turns yellow at >7 days, red at >30 days |
+| Priority | yes | Carbon Tag (Routine=gray, Urgent=warm-gray, STAT=red) |
+
+**FR-OUTSTANDING-002 — Default sort.**
+Sent Date descending (most-recently-sent first).
+
+**FR-OUTSTANDING-003 — Row click expands inline.**
+Clicking a row (anywhere except the Box ID link or Action column) expands the row inline via `TableExpandedRow`. Only one row expanded at a time; clicking another row collapses the previous.
+
+**FR-OUTSTANDING-004 — Row write actions.**
+The primary action — **"Enter result"** — surfaces as a visible **two-line Carbon Button** in a dedicated Actions column at the right of every Outstanding row. The button is sized to wrap the text "Enter result" across two lines (≈88px wide, kind=`tertiary`, size=`sm`) so the action is one-click-obvious without an overflow menu. The deployed Sample Shipment surface uses overflow menus; this surface deliberately deviates because manual-entry is the single most common action by far (most reference labs are not on OpenELIS).
+A secondary action — "Mark Lost" — lives only in the expand panel (FR-EXPAND-006). It's a less-frequent path and benefits from the friction of a row click.
+Auto-driven FHIR state transitions on Outstanding rows continue to fire from inbound peer messages.
+
+**FR-OUTSTANDING-005 — Manually enter result action.**
+
+The realistic case: most reference labs do not run OpenELIS and return results by phone / fax / paper / email. The validator needs to post the result against the original referred Analysis without leaving the Reference Lab Results context.
+
+Behavior:
+- Every Outstanding row renders a visible **two-line Carbon Button** labeled `t('referral.action.enterResult', 'Enter result')` in a dedicated Actions column (kind=`tertiary`, size=`sm`, ≈88px wide so the text wraps cleanly).
+- The expand panel (Outstanding mode) renders the same action as a primary Button (size=`sm`, kind=`primary`).
+- Clicking deep-links to the existing Result Entry screen: `/result?sampleId=<labNumber>` (the existing "enter result by lab number" route — reuses every existing component, no new entry form).
+- Existing Result Entry already accepts manual capture of the result value AND the reported date/time. No changes to Result Entry UI in v1.
+- **Server-side hook:** the existing `ResultService.create` (or `LogbookResultsController` save handler) is wrapped to detect "the saved Result lands on an Analysis with an open Referral (`Task.status != completed`)". When detected, the hook:
+  - Advances Referral's `Task.status = completed`
+  - Sets `Referral.reconciled = true`, `reconciled_at = now`, `reconciled_by = current user`
+  - Sets new flag `Referral.manually_entered = true` (NEW column — see §5.1)
+  - Emits FHIR Task PUT with `status = completed` (peer will see the closure even though they didn't send a DiagnosticReport)
+  - Emits `audit_trail` row with verb `REFERRAL_RESULT_RECEIVED` and payload `{ source: "manual", entry_method: "result_entry" }`
+- After Result Entry save, the Referral row moves directly from Outstanding to History (NOT to Returned-needs-action — the user already entered the result, no Accept step needed).
+- In History, the row carries a `Manually entered` Tag (Carbon Tag kind `warm-gray`) so the audit trail makes the entry method legible.
+- Manual entry follows existing Result Entry validation-queue behavior (Analysis status → `not_validated`, enters local validation queue). This is intentional — the transcription itself benefits from local validation, even though the underlying result was peer-validated. The validation step here is "did the typist transcribe correctly?", not "is the result clinically correct."
+
+### 4.5 Returned — needs action view
+
+**FR-RETURNED-001 — DataTable columns.**
+| Column | Sortable | Default |
+|---|---|---|
+| Lab Number | yes | — |
+| Patient | yes | — |
+| Test(s) | no | comma-separated, truncated |
+| Reference Lab | yes | — |
+| Result summary | no | First test result + units, with "+N more" if multi-test referral |
+| Returned Date | yes | descending — DEFAULT SORT |
+| Original requestor | yes | Provider name from local order |
+| Actions | no | Two visible buttons: **Accept** (primary) and **Reject…** (danger--ghost). Open in Result Entry lives in the expand panel only. |
+
+**FR-RETURNED-002 — Accept action (reception model).**
+
+**Important:** The reference lab has already validated and released the result on its end. The local Accept action is **reception**, not revalidation. The local lab is responsible for posting the result to the right Analysis and capturing the local "received by + timestamp" audit point — NOT for re-reviewing the result clinically.
+
+Selecting Accept commits the returned result(s) into the original `Analysis`(es). For each test on the Referral:
+- Create/update the corresponding `Result` row tied to the original `Analysis` by mapping `DiagnosticReport.Observation` → `Result` via existing `ResultService.create`
+- **Set Analysis status to `validated`/released** (NOT to `not_validated` — no local validation queue step for reference-lab returns)
+- Set Referral row's `Task.status = completed` (confirming write)
+- Set local flag `Referral.reconciled = true`, `reconciled_at = now`, `reconciled_by = current user`
+- Emit `audit_trail` row with verb `REFERRAL_RESULT_RECEIVED`
+- Row is removed from the Returned view, appears in History
+- If this was the last unreconciled Referral in the containing Box, surface a notification on the Box detail page: "All referrals reconciled — ready to close box."
+
+**Multi-test referrals.** When the DiagnosticReport carries multiple Observations (e.g. a HBV+HCV combined referral), Accept is **per-test with an "Accept all results" shortcut**. The expand panel renders one result card per test with its own per-card Accept button; a primary "Accept all results" button at the top of the result section accepts every test at once. A validator MAY also Reject one test while accepting another (covered in FR-RETURNED-003.1).
+
+**FR-RETURNED-002.1 — Critical / Abnormal flag hook into Alerts feature.**
+If a returning DiagnosticReport.Observation carries `interpretation` flag `Critical` (or, by configuration, `Abnormal`), the Accept action MUST additionally write an entry into the existing **Alerts feature** (separate from this FRS — see `critical_result_ack_global_todo` and the Alerts module). The Referral feature does NOT design that surface; it only emits the trigger. Payload includes patient identifier, test code, returned value, reference range, and a deep link to the original Analysis. The local Accept action otherwise proceeds normally — receipt and posting are NOT blocked by the alert.
+
+**FR-RETURNED-002.2 — Identifier mismatch exception.**
+If the DiagnosticReport's `subject` reference cannot be resolved to a local Patient/Analysis (peer used an unknown identifier, lab number doesn't match), the Accept action MUST refuse and route the row to an exception state. Surfaces as a small "Exceptions" indicator on the Returned view. v1 keeps the exception handling lightweight: row stays in Returned with an exception tag, and reception staff manually reconciles via the existing patient-search workflow before the row can be Accepted. A dedicated exception queue UI is out of scope for v1 (could be revisited if exception volume warrants).
+
+**FR-RETURNED-003 — Reject action (terminal close + re-collection notification).**
+
+**Important:** Peer rejections are nearly always physical-sample problems (insufficient volume, wrong tube, hemolysis, damaged container, temperature deviation, clotted, mislabeled). In every realistic case the existing sample is gone or unusable, so the workflow is NOT "re-refer the same sample" — it's "patient needs to come back, new sample collected, new order created."
+
+Selecting Reject opens a confirmation modal (the only destructive modal in this feature). Modal contents:
+- Sample identifying info (Lab Number, Patient, Test)
+- Required TextArea: "Reason for rejection" (free text, min 1 char, max 500 char) — pre-populated from peer's `Task.statusReason.text` if present
+- Optional Select: pre-filled reason from existing OpenELIS non-conformity types (Insufficient volume, Wrong sample type, Damaged container, Temperature deviation, Hemolyzed, Clotted, Mislabeled, Other)
+- Carbon `InlineNotification kind="warning"`: "Rejecting closes the Analysis as terminal-rejected. The requesting clinician will be notified to arrange re-collection. A new order will be needed when a fresh sample is collected."
+- Confirm button (danger primary) labeled "Reject and notify clinician"
+- Cancel button (ghost)
+
+On confirm:
+- Set `Task.status = rejected`
+- Set Referral row's `cancelDate = now`, `cancelReason = reason`, `reject_reason_code = <selected>`, `reject_reason_text = <free text>`
+- **Close the original Analysis as terminal** with a new status `rejected_by_reference_lab` (NEW Analysis state value — Liquibase). The Analysis is NOT re-opened; re-collection produces a new order → new Analysis → new Lab Number per existing order-entry flow.
+- Emit FHIR Task PUT with `status = rejected` and reason in `Task.statusReason.text`
+- **Fire notification to requesting clinician** via existing OGC-589 notification infra (NEW event type `REFERRAL_REJECTED_NEEDS_RECOLLECTION` — registers with OGC-589's trigger registry). Payload: patient identifier, original Lab Number, test code(s), reject reason, deep link to the (now closed) Analysis for reference.
+- **Emit trigger into the existing Alerts feature** so the rejection appears on the lab-side Alerts screen with an acknowledgment step. The Alerts feature owns the ack UX; this story only emits the trigger.
+- Emit `audit_trail` row with verb `REFERRAL_RESULT_REJECTED`, payload includes reason code + text
+- No re-refer prompt and no re-open path — re-collection is the clinician's responsibility, captured via a fresh order.
+
+**FR-RETURNED-004 — Open in Result Entry action.**
+A ghost Button in the expand panel labeled "Open in Result Entry" navigates to the existing Logbook page (`/result?sampleId=<labNumber>`) with the sample pre-selected. The referral row remains in the Returned view until the validator acts on it (Accept or Reject) from there or from this surface. This is a context-only shortcut for validators who want to see the patient's surrounding result history before accepting; it is NOT a write action. Lives in the expand panel only (not on the row) since it's a secondary navigation, not a primary decision.
+
+**FR-RETURNED-005 — Default sort.**
+Returned Date descending.
+
+### 4.6 History view
+
+**FR-HISTORY-001 — DataTable columns.**
+| Column | Sortable | Default |
+|---|---|---|
+| Lab Number | yes | — |
+| Patient | yes | — |
+| Test(s) | no | comma-separated, truncated |
+| Reference Lab | yes | — |
+| Outcome | yes | Reconciled · Rejected · Cancelled · Lost (Carbon Tag) |
+| Closed date | yes | descending — DEFAULT SORT |
+| Box ID | no | Carbon Link |
+| Days total | yes | Closed date − Sent date |
+
+**FR-HISTORY-002 — Read-only.**
+No write actions. Inline expand shows the same panel as other views but with no action buttons; instead the activity log shows the full transition history.
+
+**FR-HISTORY-003 — Default sort.**
+Closed date descending.
+
+### 4.7 Per-row inline-expand detail panel
+
+**FR-EXPAND-001 — Layout.**
+Expanding a row reveals a `Tile` filling the row's `TableCell colSpan` with three columns of detail (Carbon `Grid`, 4-4-4 split on `lg`; stacked on `md` and below):
+- Left: **Original order context**
+- Center: **Reference lab transit**
+- Right: **Result** (Returned/History only) OR **Activity log** (Outstanding)
+
+Below the three columns, a single-row **Activity log** spans the full width (Carbon `StructuredList`).
+
+**FR-EXPAND-002 — Original order context fields.**
+- Local Lab Number (link to `/Patient/<id>` patient summary)
+- Original Analysis state at refer-out time
+- Requesting provider name + role
+- Specimen collection date/time
+- Original test code(s) and local test name(s)
+- Clinical notes (if present from order entry)
+
+**FR-EXPAND-003 — Reference lab transit fields.**
+- Reference lab name (link to existing Organization Management record, opens in new tab)
+- Box ID (link to Sample Shipment box detail)
+- Dispatched date/time (from `Box.sentDate`)
+- Received-at-reference-lab date/time (from `Box.receivedDate`)
+- FHIR Task UUID (small monospace, copyable)
+- Manifest version (from Box record)
+
+**FR-EXPAND-004 — Result fields (Returned and History views only).**
+For each test on the Referral:
+- Test name
+- Returned value + units
+- Reference range
+- Peer's interpretation flag (Normal · Abnormal · Critical) if present in DiagnosticReport
+- Peer's comments / notes
+
+If multi-test: stacked sub-tiles per test.
+
+**FR-EXPAND-005 — Activity log.**
+StructuredList rows, one per state transition, columns: Timestamp · Actor · From state · To state · Notes. Generated by joining `audit_trail` rows for this Referral.
+
+**FR-EXPAND-005.1 — Returned-result data source.**
+The result-card fields rendered in FR-EXPAND-004 (Returned and History views) are rendered **directly from the inbound `DiagnosticReport.Observation` resources** stored in the FHIR persistence layer. They are NOT persisted to a separate transient table. The Accept action (FR-RETURNED-002) is what persists into the standard `Result` entity by mapping each Observation to a `Result` row tied to the originating Analysis. This means:
+- Reference range, units, interpretation flag, and peer comments are read at render time from the FHIR resource; no schema additions for these fields.
+- Multi-test referrals carry multiple Observations under one DiagnosticReport; the mockup's stacked result cards reflect that.
+- Once Accepted, the persistent `Result.value`, `Result.units`, `Result.notes`, etc. carry forward via existing OpenELIS schema; the original DiagnosticReport remains in FHIR storage for audit.
+
+**FR-EXPAND-006 — Outstanding-view Mark Lost action.**
+On the Outstanding view, the expanded panel includes a "Mark Lost" Button (kind="ghost") in the bottom-right. Click opens a confirmation modal with required reason TextArea. On confirm: set `Referral.lostStatus = true`, `lostDate = now`, `lostReason = reason`. The FHIR Task remains in its current status (lost is a local-only side flag, not a FHIR Task transition). Row moves to History view with Outcome = Lost.
+
+### 4.8 Aging banner
+
+**FR-AGING-001 — Banner conditions.**
+Render a Carbon `InlineNotification kind="warning"` at the top of the page (below header, above metric tiles) when:
+- Active primary filter chip = Outstanding, AND
+- Count of Referrals with Days outstanding > threshold (default 7 days, see FR-AGING-003) ≥ 1
+
+**FR-AGING-002 — Banner content.**
+- Title: "Stuck referrals require attention"
+- Subtitle: "{N} referrals have been at a reference lab for more than {threshold} days. Consider contacting the reference lab or reassigning."
+- Action link in banner: "Filter to stuck only" — applies Days outstanding bucket filter to ">30" or ">7" matching the configured threshold
+
+**FR-AGING-003 — Threshold configuration.**
+Threshold is read from `unassigned_alert_config.referralStuckThresholdDays` (table added by Sample Shipment feature; reuse). Default value 7. Admin-configurable on the Settings page (out of scope for this FRS to design the admin UI, but a config row MUST be added).
+
+### 4.9 Sample Shipment integration
+
+**FR-INT-001 — Box-to-Referral back link.**
+On the Sample Shipment Box detail page (existing surface), add a section "Reference Lab Results" listing the count of Referrals contained in the box, grouped by Task status. Clicking a count navigates to Reference Lab Results pre-filtered to that Box ID. *Note: this is a small change to the existing Box detail page; flag in `/breakdown` as a dependency story.*
+
+**FR-INT-002 — Reconciliation gate on Box state.**
+When a user attempts to transition a Box from `Received` to `Reconciled` and any contained Referral has Task status ∉ {completed, rejected, cancelled} (or `lostStatus = true`), the transition is blocked with a Carbon `InlineNotification kind="error"`: "Cannot reconcile box — {N} samples still awaiting result reconciliation. See Reference Lab Results."
+
+**FR-INT-003 — Reverse link from Referral row.**
+The Box ID column in all three Referral views links to the Box detail page in Sample Shipment.
+
+### 4.10 Order Entry Step 3 hook (OGC-605)
+
+**FR-OE-001 — Refer Out at order time.**
+On Step 3 of the new 4-step Order Entry wizard (OGC-605 scope), a per-test Refer Out checkbox creates a `Referral` row immediately on Order Save with `Task.status = draft`. The created Referral appears in the Sample Shipment Unassigned Samples tab automatically (sample carries `referral_flag = true`).
+
+**FR-OE-002 — Dedupe with Result Entry path.**
+Both Order Entry and Result Entry create paths must dedupe on Analysis ID. A second click of Refer Out on either path against the same Analysis is a no-op if a Referral row exists for that Analysis in non-terminal state.
+
+### 4.11 FHIR integration
+
+**FR-FHIR-001 — Outbound state writes.**
+`FhirReferralServiceImpl` MUST emit FHIR Task PUTs on every state transition:
+| Local transition | FHIR Task.status |
+|---|---|
+| Referral created via Order Entry or Result Entry | `draft` (no PUT yet; Task not yet emitted to peer) |
+| Box containing referral transitions to Sent | `requested` (PUT emitted) |
+| Peer's Task PUT to received | `received` (local update only) |
+| Peer's Task PUT to in-progress | `in-progress` (local update only) |
+| DiagnosticReport arrives | `completed` (existing path; refine to confirm) |
+| **Local Result saved against an Analysis with active Referral (manual entry path)** | **`completed` (PUT emitted; see FR-OUTSTANDING-005)** |
+| Validator's Reject action | `rejected` (PUT emitted) |
+| User cancels referral | `cancelled` (PUT emitted; un-comment existing path) |
+
+**FR-FHIR-002 — Inbound state reads.**
+A new endpoint or extension of the existing FHIR Task receive handler accepts peer Task PUTs and updates local Referral state. Acceptance rules:
+- A PUT against a Referral in `draft` is rejected (peer should not see drafts)
+- A PUT to `received` is accepted against a Referral in `requested` (idempotent)
+- A PUT to `in-progress` is accepted against a Referral in `requested` or `received` (idempotent)
+- A PUT to `rejected` is accepted against any non-terminal Referral; triggers FR-RETURNED-003 effects (re-open Analysis, retain Refer Out flag)
+- Out-of-order PUTs (peer sends in-progress before received) are accepted by latching the most advanced state
+
+**FR-FHIR-003 — DiagnosticReport routing.**
+Incoming `DiagnosticReport` resources MUST be routed to the originating Referral by matching `DiagnosticReport.basedOn` to the stored ServiceRequest UUID (`Referral.fhirUuid`). On match:
+- Parse Observations into per-test result data
+- Set Referral's `Task.status = completed`
+- Set `Referral.diagnosticReportUuid` (NEW column)
+- Trigger Returned-needs-action surface
+
+**FR-FHIR-004 — No peer-lab distinction.**
+Per `/clarify` Q3 decision, no `OpenELISReferralTask` profile is introduced in v1. The FHIR IG remains as-is. Inbound Tasks from any source (EMR or peer lab) land in Incoming Orders as today.
+
+### 4.12 State-model migration
+
+**FR-MIG-001 — Liquibase changeset.**
+A Liquibase changeset renames `ReferralStatus` enum values to FHIR-aligned strings:
+| Old value | New value |
+|---|---|
+| `CREATED` | `draft` |
+| `SENT` | `requested` |
+| `RECEIVED` | `received` |
+| `FINISHED` | `completed` |
+| `CANCELED` | `cancelled` |
+
+Plus three new values: `in-progress`, `rejected`, `lost` (note: `lost` is the local side flag previously stored in `lostStatus` bool; the bool is retained for back-compat, but a derived view treats it as a pseudo-status for the History view).
+
+**FR-MIG-002 — Reversibility.**
+The Liquibase changeset MUST include a `rollback` block that restores the original enum values.
+
+**FR-MIG-003 — Pre-conditions.**
+The changeset MUST include a Liquibase `preConditions` block asserting that no rows currently hold values `SENT` or `FINISHED` (today these are dead per audit; assert before migration). If found, fail the migration with a clear error and require manual triage.
+
+**FR-MIG-004 — Backfill.**
+Existing rows migrate by direct rename. No row-level data transformation needed.
+
+**FR-MIG-005 — Application-layer enum.**
+The Java `ReferralStatus` enum in `org.openelisglobal.referral.valueholder` updates to match. References across `ReferralService`, `ReferredOutTestsRestController`, `FhirReferralServiceImpl` recompile against new values.
+
+### 4.13 OGC-624 reconciliation
+
+**FR-624-001 — Close state-field scope.**
+The OGC-624 proposed `subcontractStatus` field is NOT added. Any work-in-progress code referencing it is re-pointed at `ReferralStatus` (FHIR-aligned per FR-MIG-001). Coordinated with OGC-624's owner before the change; surgery handled in `/breakdown`.
+
+**FR-624-002 — Carry forward non-state scope.**
+OGC-624's other scope folds into this FRS:
+- Subcontract metadata panel → Sample Shipment's existing destination/notes fields (no new build)
+- Outbound WhatsApp/email notify → integrates with OGC-589's notification infra; lives in the expand panel as a "Notify reference lab" Button (NOT in scope for this FRS to spec the integration; flag as a dependency on OGC-589)
+- Inbound FHIR registration → already covered by existing Incoming Orders behavior
+
+---
+
+## 5. Data Model
+
+### 5.1 Existing tables — modifications
+
+**`referral` (existing — modify):**
+| Column | Type | Change | Notes |
+|---|---|---|---|
+| `status` | varchar(32) | **migrated values** (FR-MIG-001) | enum strings, FHIR-aligned |
+| `diagnostic_report_uuid` | uuid | **NEW** | nullable; set when DiagnosticReport routes in. Null when result was manually entered. |
+| `reconciled` | boolean | **NEW** | default false; set true on Accept action or manual Result save against open Referral |
+| `reconciled_at` | timestamp | **NEW** | nullable; set on Accept or manual entry |
+| `reconciled_by` | bigint | **NEW** | FK to user; set on Accept or manual entry |
+| `manually_entered` | boolean | **NEW** | default false; set true by FR-OUTSTANDING-005 server-side hook when a Result is saved against an Analysis with an open Referral. Drives the "Manually entered" Tag in History view. |
+| `reject_reason_code` | varchar(64) | **NEW** | nullable; from non-conformity types when Reject used pre-filled reason |
+| `reject_reason_text` | text | **NEW** | nullable; required when reject_reason_code is null |
+| `assigned_box_id` | bigint | existing (`assignedBox`) | unchanged |
+| `lost_status` | boolean | existing (`lostStatus`) | unchanged |
+| `lost_date`, `lost_reason` | existing | unchanged |
+| `priority` | varchar(16) | existing | unchanged; now surfaced in UI |
+| `fhir_uuid` | uuid | existing | unchanged |
+| `cancel_date`, `cancel_reason` | existing | unchanged |
+
+### 5.2 Existing tables — no schema change, new usage
+
+**`audit_trail` (existing — no schema change, new event verbs):**
+- `REFERRAL_RESULT_RECEIVED`
+- `REFERRAL_RESULT_REJECTED`
+- `REFERRAL_STATE_CHANGED`
+- `REFERRAL_MARKED_LOST`
+
+Payload format follows existing OpenELIS audit conventions: `{ entityType: "referral", entityId: <uuid>, before: <status>, after: <status>, actorId: <userId>, notes: <free text> }`.
+
+### 5.3 Entities NOT changing
+
+- `Box` / `Shipment` — owned by Sample Shipment; this FRS reads but does not write
+- `Sample` / `Analysis` / `Result` — existing; Accept action writes Result rows via the existing service layer (`ResultService.create`), not a new write path
+- `Organization` (reference labs) — read-only, from existing Organization Management
+
+### 5.4 Dependency — NEW data not yet built
+
+Two pieces of data are required by this FRS but do not exist today and must be flagged as named dependencies:
+
+| Dependency | Owned by | Required by FRs |
+|---|---|---|
+| `unassigned_alert_config.referralStuckThresholdDays` admin setting | This FRS or a co-shipping setting | FR-AGING-003 |
+| Sample Shipment Box detail page's "Reference Lab Results" section | Sample Shipment team (small UI change) | FR-INT-001 |
+
+Both are surfaced in `/breakdown` as dependency stories.
+
+---
+
+## 6. State machine — FHIR Task lifecycle
+
+### 6.1 Canonical states
+
+| State | Meaning |
+|---|---|
+| `draft` | Referral row exists locally; no FHIR Task emitted to peer yet |
+| `requested` | Box containing this referral has been Sent; FHIR Task PUT emitted |
+| `received` | Peer reference lab has acknowledged receipt of the sample |
+| `in-progress` | Peer reference lab is actively running the test |
+| `completed` | Result has been returned via DiagnosticReport |
+| `cancelled` | Sender (this lab) cancelled the referral |
+| `rejected` | Peer reference lab rejected the sample (insufficient volume, wrong type, etc.) |
+
+### 6.2 Local-only side flags
+
+- `lostStatus` (bool, existing) — sample lost in transit. Sample's FHIR Task remains in its current status; `lost` shows in History view as the Outcome via a derived render. Setting `lostStatus = true` is a sender-side action only; doesn't emit a FHIR Task PUT.
+
+### 6.3 Allowed transitions
+
+```
+draft → requested      (Box sent — automated)
+draft → cancelled      (user cancel)
+requested → received   (peer PUT or manual override)
+requested → cancelled  (user cancel)
+requested → rejected   (peer PUT)
+received → in-progress (peer PUT)
+received → rejected    (peer PUT)
+in-progress → completed (DiagnosticReport arrives)
+in-progress → rejected  (peer PUT)
+```
+
+All transitions emit an `audit_trail` row with verb `REFERRAL_STATE_CHANGED`.
+
+### 6.4 Carbon Tag mapping for Status column
+
+| State | Tag kind | Display label i18n key |
+|---|---|---|
+| draft | gray | `referral.status.draft` (default: "Draft") |
+| requested | blue | `referral.status.requested` (default: "Sent — awaiting acceptance") |
+| received | purple | `referral.status.received` (default: "At reference lab") |
+| in-progress | warm-gray | `referral.status.inProgress` (default: "In progress at reference lab") |
+| completed | teal | `referral.status.completed` (default: "Result returned") |
+| rejected | red | `referral.status.rejected` (default: "Rejected by reference lab") |
+| cancelled | gray | `referral.status.cancelled` (default: "Cancelled") |
+| lost (side flag) | red | `referral.status.lost` (default: "Lost in transit") |
+
+---
+
+## 7. Localization
+
+All visible strings in the UI MUST be wrapped via `t(key, fallback)`. New keys:
+
+| Key | Fallback (English) |
+|---|---|
+| `referral.page.title` | "Reference Lab Results" |
+| `referral.breadcrumb.referenceLabResults` | "Reference Lab Results" |
+| `referral.sidenav.referenceLabResults` | "Reference Lab Results" |
+| `referral.chip.outstanding` | "Outstanding" |
+| `referral.chip.returned` | "Returned — needs action" |
+| `referral.chip.history` | "History" |
+| `referral.metric.outstanding` | "Outstanding" |
+| `referral.metric.returnedNeedsAction` | "Returned — needs action" |
+| `referral.metric.reconciledToday` | "Reconciled today" |
+| `referral.metric.rejectedThisWeek` | "Rejected this week" |
+| `referral.column.labNumber` | "Lab Number" |
+| `referral.column.patient` | "Patient" |
+| `referral.column.tests` | "Test(s)" |
+| `referral.column.referenceLab` | "Reference Lab" |
+| `referral.column.boxId` | "Box ID" |
+| `referral.column.sentDate` | "Sent Date" |
+| `referral.column.status` | "Status" |
+| `referral.column.daysOutstanding` | "Days outstanding" |
+| `referral.column.priority` | "Priority" |
+| `referral.column.resultSummary` | "Result summary" |
+| `referral.column.returnedDate` | "Returned Date" |
+| `referral.column.originalRequestor` | "Original requestor" |
+| `referral.column.outcome` | "Outcome" |
+| `referral.column.closedDate` | "Closed date" |
+| `referral.column.daysTotal` | "Days total" |
+| `referral.action.accept` | "Accept" |
+| `referral.action.reject` | "Reject" |
+| `referral.action.openInResultEntry` | "Open in Result Entry" |
+| `referral.action.enterResult` | "Enter result" (rendered as two-line button on row) |
+| `referral.action.markLost` | "Mark Lost" |
+| `referral.tag.manuallyEntered` | "Manually entered" |
+| `referral.action.notifyReferenceLab` | "Notify reference lab" |
+| `referral.action.clearFilters` | "Clear filters" |
+| `referral.filter.referenceLab` | "Reference Lab" |
+| `referral.filter.dateRange` | "Date range" |
+| `referral.filter.priority` | "Priority" |
+| `referral.filter.daysOutstandingBucket` | "Days outstanding" |
+| `referral.filter.allDays` | "All" |
+| `referral.filter.days0to7` | "0-7" |
+| `referral.filter.days7to30` | "7-30" |
+| `referral.filter.daysOver30` | ">30" |
+| `referral.banner.stuckReferralsTitle` | "Stuck referrals require attention" |
+| `referral.banner.stuckReferralsSubtitle` | "{N} referrals have been at a reference lab for more than {threshold} days." |
+| `referral.banner.filterToStuck` | "Filter to stuck only" |
+| `referral.emptyState` | "No referrals found for the selected filters." |
+| `referral.table.outstanding.title` | "Outstanding referrals" |
+| `referral.table.outstanding.desc` | "{N} referrals at reference labs awaiting results" (ICU plural) |
+| `referral.table.returned.title` | "Returned — needs action" |
+| `referral.table.returned.desc` | "{N} results awaiting reconciliation to local Analysis" (ICU plural) |
+| `referral.table.history.title` | "History" |
+| `referral.table.history.desc` | "{N} closed referrals" (ICU plural) |
+| `referral.expand.statusDetail` | "Status detail" |
+| `referral.expand.outcomeDetail` | "Outcome detail" |
+| `referral.action.acceptToAnalysis` | "Accept to Analysis" |
+| `referral.action.more` | "More actions" |
+| `referral.result.referenceRange` | "Reference range:" |
+| `referral.result.testLabel` | "Test" |
+| `referral.result.valueLabel` | "Value" |
+| `referral.result.unitsLabel` | "Units" |
+| `referral.result.notesLabel` | "Notes" |
+| `referral.result.flagLabel` | "Flag" |
+| `referral.testsOverflow` | "more" (used in "+N more" overflow) |
+| `referral.daysUnit` | "{N, plural, one {# day} other {# days}}" (ICU plural) |
+| `referral.expand.criticalBadge` | "CRITICAL" |
+| `referral.stuck.title` | "Stuck" |
+| `referral.stuck.subtitle` | "Consider contacting the reference lab." |
+| `referral.expand.originalOrderContext` | "Original order context" |
+| `referral.expand.referenceLabTransit` | "Reference lab transit" |
+| `referral.expand.result` | "Result" |
+| `referral.expand.activityLog` | "Activity log" |
+| `referral.expand.fhirTaskUuid` | "FHIR Task UUID" |
+| `referral.expand.manifestVersion` | "Manifest version" |
+| `referral.reject.modalTitle` | "Reject referral" |
+| `referral.reject.reasonLabel` | "Reason for rejection" |
+| `referral.reject.reasonPlaceholder` | "Describe why this referral is being rejected" |
+| `referral.reject.preFilledReasonLabel` | "Common reason (optional)" |
+| `referral.reject.warning` | "Rejecting this referral will re-open the original Analysis. The Refer Out flag will remain set so you can re-refer to a different lab." |
+| `referral.reject.confirmButton` | "Reject and re-open Analysis" |
+| `referral.markLost.modalTitle` | "Mark referral lost in transit" |
+| `referral.markLost.reasonLabel` | "Reason" |
+| `referral.markLost.warning` | "Marking this referral as lost is reversible only by an administrator." |
+| `referral.outcome.reconciled` | "Reconciled" |
+| `referral.outcome.rejected` | "Rejected" |
+| `referral.outcome.cancelled` | "Cancelled" |
+| `referral.outcome.lost` | "Lost" |
+| Plus `referral.status.*` keys from §6.4 |
+| Plus `referral.audit.*` keys for audit log display |
+
+---
+
+## 8. Permissions & Audit
+
+### 8.1 Role attachment
+
+Per `references/permissions-and-audit.md`: no new permission keys. Access is granted via existing role bundles.
+
+| Role bundle | Read | Accept | Reject | Mark Lost | Reverse Lost |
+|---|---|---|---|---|---|
+| Validator | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Lab Manager | ✓ | ✓ | ✓ | ✓ | ✗ |
+| Analyst | ✓ | ✗ | ✗ | ✗ | ✗ |
+| Reception | ✓ (PHI-limited) | ✗ | ✗ | ✗ | ✗ |
+| Provider | ✓ (own referrals only) | ✗ | ✗ | ✗ | ✗ |
+| Admin | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+UI MUST hide action buttons for roles without write access. API endpoints MUST enforce same matrix via existing Spring Security annotations on the controller.
+
+### 8.2 Audit verbs
+
+| Verb | When | Target | Payload |
+|---|---|---|---|
+| `REFERRAL_STATE_CHANGED` | Any FHIR Task state transition | `Referral.id` | `{ from: <state>, to: <state>, source: peer\|user\|system }` |
+| `REFERRAL_RESULT_RECEIVED` | Validator Accepts | `Referral.id` | `{ analysisId: <id>, resultId: <id> }` |
+| `REFERRAL_RESULT_REJECTED` | Validator Rejects | `Referral.id` | `{ reasonCode: <code>, reasonText: <text> }` |
+| `REFERRAL_MARKED_LOST` | User marks Lost | `Referral.id` | `{ reason: <text> }` |
+| `REFERRAL_LOST_REVERSED` | Admin reverses Lost flag | `Referral.id` | `{ priorLostDate: <date>, priorReason: <text> }` |
+
+### 8.3 Envers coverage
+
+Existing `Referral` and `ReferralResult` entities already have `@Audited` (row-level history via Hibernate Envers). No new entities introduced. New columns (`diagnostic_report_uuid`, `reconciled`, `reconciled_at`, `reconciled_by`, `reject_reason_code`, `reject_reason_text`) are automatically captured by Envers via the existing class-level annotation.
+
+---
+
+## 9. Non-functional requirements
+
+**NFR-1 — Performance.** Page initial load < 2 seconds with up to 1000 Referrals across all states; DataTable filtering and sort are server-side and respond < 500ms for typical filter combinations. Aging banner count query MUST use the existing `referral.status` index plus a new index on `(status, sent_date)` if needed.
+
+**NFR-2 — Accessibility.** WCAG 2.1 AA. Color is never the sole indicator — Tag kinds also have text labels; days-outstanding cell color is paired with an icon when over threshold. Keyboard navigation: filter chips, secondary filters, table rows, and expand panels are all reachable by Tab; row expand toggles by Enter/Space. Screen reader announces row state change on expand. Modals trap focus per Carbon default.
+
+**NFR-3 — i18n.** All visible strings via `t(key, fallback)` per §7. Date and number formatting via existing `useLocale()` hook. Days-outstanding cell respects locale numeric formatting.
+
+**NFR-4 — Browser support.** Same matrix as current OpenELIS (Chrome, Firefox, Safari, Edge — last two stable versions).
+
+**NFR-5 — Concurrency.** Two validators racing to Accept the same Referral: optimistic locking via existing `Referral.version` column (already present). Second user gets a Carbon InlineNotification "Another user updated this referral; refresh to see the latest state."
+
+**NFR-6 — Idempotency on FHIR receive.** Peer Task PUTs to states behind current state are no-ops, not errors. Out-of-order PUTs latch to the most-advanced status.
+
+**NFR-7 — Migration safety.** Liquibase changeset includes a backup table (`referral_status_migration_backup`) populated before the rename; rollback restores from backup.
+
+---
+
+## 10. Dependencies (named)
+
+| Dependency | Required by | Status | Owner |
+|---|---|---|---|
+| Order Entry Step 3 Refer Out hook | FR-OE-001 | Backlog as OGC-605 | Order Entry team |
+| Sample Shipment Box detail "Reference Lab Results" section | FR-INT-001 | Not yet built | Sample Shipment team |
+| OGC-589 Referral-Out Notification infra | FR-624-002 | In progress | Notifications team |
+| `unassigned_alert_config.referralStuckThresholdDays` row | FR-AGING-003 | Not yet seeded | This FRS adds via Liquibase |
+| OGC-624 owner sign-off on state-model surgery | FR-624-001 | Coordination needed | TBD — confirm in `/breakdown` |
+
+---
+
+## 11. Open questions
+
+These don't block FRS approval but should be tracked during build:
+
+1. **What's the exact semantics of "Provider sees only their own referrals" (§2.5)?** Owned by the requesting provider's `accountId`? By the ordering session? Confirm in build kickoff.
+2. ~~**Multi-test referrals on Accept**~~ **Resolved 2026-05-28**: per-test Accept with an "Accept all results" shortcut. See FR-RETURNED-002.
+3. ~~**Re-refer UX after Reject**~~ **Resolved 2026-05-28**: no re-refer prompt. Reject closes the Analysis as terminal (`rejected_by_reference_lab`); requesting clinician is notified via OGC-589 to arrange re-collection; rejection also emits a trigger into the existing Alerts feature for lab-side acknowledgment; a new order with a fresh sample is created through the existing order-entry flow.
+4. **Reception model resolved 2026-05-28**: returning DiagnosticReports are reception (not revalidation). Critical/Abnormal-flagged results emit a trigger into the existing Alerts feature, which owns the acknowledgment UX. Identifier-mismatch routes to a lightweight exception state in v1.
+
+---
+
+## 12. Acceptance criteria
+
+The FRS is ready for `/breakdown` when:
+- ✅ Lab Context covers Current State, Pain, What Changes in plain English
+- ✅ IA placement is declared (SideNav, breadcrumb, URL)
+- ✅ Permissions & Audit declared (existing role bundles; no invented keys)
+- ✅ Every FR has a Carbon component or service implementation called out
+- ✅ State machine fully mapped to FHIR Task with Tag kinds and i18n keys
+- ✅ Data model changes listed with column types and rationale
+- ✅ Localization table covers every visible string
+- ✅ Dependencies named and owned
+- ✅ Constitution alignment: no new permission keys, no multitenancy UI, no invented data fields (every column traces to existing schema or is declared NEW)

--- a/mockup-viewer/public/designs/sample-collection/reference-lab-results.html
+++ b/mockup-viewer/public/designs/sample-collection/reference-lab-results.html
@@ -1,0 +1,785 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reference Lab Results — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body { background: #f4f4f4; margin: 0; font-family: 'IBM Plex Sans', sans-serif; color: #161616; }
+    .preview-banner {
+      background: #0f62fe; color: #fff;
+      padding: 6px 1rem; font-size: 12px; font-family: monospace;
+    }
+    .preview-content { padding: 1rem 2rem; max-width: 1440px; margin: 0 auto; background: white; min-height: 100vh; }
+
+    .breadcrumb { font-size: 0.875rem; color: #525252; margin-bottom: 0.25rem; }
+    .breadcrumb a { color: #0f62fe; text-decoration: none; }
+    .breadcrumb a:hover { text-decoration: underline; }
+    .breadcrumb .sep { margin: 0 0.5rem; }
+    .breadcrumb .current { color: #161616; }
+
+    h1 { font-weight: 300; margin: 0.5rem 0 1.5rem 0; font-size: 2rem; }
+    h5 { font-size: 0.875rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #525252; margin: 0 0 0.75rem 0; }
+
+    .banner-warning {
+      background: #fcf4d6; border-left: 3px solid #f1c21b; padding: 1rem 1.25rem; margin-bottom: 1rem;
+      display: flex; align-items: flex-start; justify-content: space-between;
+    }
+    .banner-warning .body { flex: 1; }
+    .banner-warning .title { font-weight: 600; margin-bottom: 0.25rem; }
+    .banner-warning .subtitle { font-size: 0.875rem; color: #525252; }
+    .banner-warning .action { padding-left: 1rem; }
+
+    .metric-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 1.5rem; }
+    .metric-tile {
+      background: white; padding: 1.25rem 1rem; cursor: pointer;
+      border: 1px solid #e0e0e0; text-align: left; width: 100%; font-family: inherit;
+    }
+    .metric-tile.active { box-shadow: 0 0 0 1px #0f62fe inset; }
+    .metric-tile .count { font-size: 2.5rem; font-weight: 300; line-height: 1; color: #161616; }
+    .metric-tile .label { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.05em; color: #525252; margin-top: 0.5rem; }
+    .metric-tile.green { border-left: 6px solid #24a148; }
+    .metric-tile.red { border-left: 6px solid #da1e28; }
+    .metric-tile.teal { border-left: 6px solid #005d5d; }
+    .metric-tile.purple { border-left: 6px solid #8a3ffc; }
+
+    .chip-row { display: flex; gap: 0.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
+    .chip {
+      background: white; color: #161616; border: 1px solid #8d8d8d;
+      border-radius: 999px; padding: 0.375rem 1rem; font-size: 0.875rem; cursor: pointer;
+      font-family: inherit;
+    }
+    .chip.active { background: #0f62fe; color: white; border-color: #0f62fe; }
+    .chip:hover:not(.active) { background: #e8e8e8; }
+
+    .filter-row {
+      background: #f4f4f4; padding: 1rem; margin-bottom: 1rem;
+      display: grid; grid-template-columns: 1fr 1.5fr 1fr 0.8fr auto; gap: 1rem;
+      align-items: end;
+    }
+    .filter-row label { display: block; font-size: 0.75rem; color: #525252; margin-bottom: 0.25rem; font-weight: 600; }
+    .filter-row select, .filter-row input {
+      width: 100%; padding: 0.5rem; border: 1px solid #8d8d8d; background: white; font-family: inherit;
+      font-size: 0.875rem; color: #161616;
+    }
+    .filter-row .clear { white-space: nowrap; }
+
+    .table-container { background: white; border: 1px solid #e0e0e0; margin-bottom: 2rem; }
+    .table-header { padding: 1rem; border-bottom: 1px solid #e0e0e0; }
+    .table-header .title { font-size: 1.125rem; font-weight: 400; margin-bottom: 0.25rem; }
+    .table-header .desc { font-size: 0.875rem; color: #525252; }
+
+    table { width: 100%; border-collapse: collapse; }
+    th { text-align: left; padding: 0.75rem 1rem; font-weight: 600; font-size: 0.875rem; background: #f4f4f4; border-bottom: 1px solid #e0e0e0; color: #161616; }
+    td { padding: 0.75rem 1rem; font-size: 0.875rem; border-bottom: 1px solid #e0e0e0; vertical-align: middle; }
+    tr.expandable-row { cursor: pointer; }
+    tr.expandable-row:hover { background: #f4f4f4; }
+    .expand-toggle { width: 32px; padding: 0; text-align: center; user-select: none; }
+    .expand-icon { display: inline-block; transition: transform 0.15s; }
+    .expand-icon.open { transform: rotate(90deg); }
+
+    .tag {
+      display: inline-block; padding: 0.125rem 0.625rem; border-radius: 999px;
+      font-size: 0.75rem; font-weight: 500; line-height: 1.25rem; white-space: nowrap;
+    }
+    .tag-gray { background: #e0e0e0; color: #161616; }
+    .tag-red { background: #ffd7d9; color: #750e13; }
+    .tag-blue { background: #d0e2ff; color: #0043ce; }
+    .tag-purple { background: #e8daff; color: #491d8b; }
+    .tag-teal { background: #9ef0f0; color: #004144; }
+    .tag-green { background: #a7f0ba; color: #044317; }
+    .tag-warm-gray { background: #e5e0df; color: #43413e; }
+
+    .empty-state { text-align: center; padding: 3rem 1rem; color: #525252; }
+
+    .days-warn { color: #f1c21b; font-weight: 600; }
+    .days-alert { color: #da1e28; font-weight: 600; }
+
+    .expand-panel { background: #f4f4f4; padding: 1.5rem; border-top: 1px solid #e0e0e0; }
+    .expand-grid { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1.5rem; }
+    .detail-row { display: flex; justify-content: space-between; padding: 0.375rem 0; border-bottom: 1px solid #e0e0e0; font-size: 0.875rem; gap: 0.5rem; }
+    .detail-row .label { color: #525252; flex-shrink: 0; }
+    .detail-row .value { text-align: right; max-width: 60%; word-break: break-word; }
+
+    .result-card { background: white; border: 1px solid #e0e0e0; padding: 0.75rem; margin-bottom: 0.5rem; }
+    .result-card .test { font-weight: 600; }
+    .result-card .value { font-size: 1.25rem; margin: 0.25rem 0; }
+    .result-card .units { color: #525252; font-size: 0.875rem; }
+    .result-card .range { font-size: 0.75rem; color: #525252; }
+    .result-card .notes { font-size: 0.75rem; font-style: italic; margin-top: 4px; color: #525252; }
+
+    .btn {
+      display: inline-block; padding: 0.5rem 1rem; font-size: 0.875rem; cursor: pointer;
+      border: 1px solid transparent; font-family: inherit; font-weight: 400;
+    }
+    .btn-sm { padding: 0.375rem 0.75rem; font-size: 0.75rem; }
+    .btn-primary { background: #0f62fe; color: white; }
+    .btn-primary:hover { background: #0353e9; }
+    .btn-ghost { background: transparent; color: #0f62fe; }
+    .btn-ghost:hover { background: #e8e8e8; }
+    .btn-danger { background: white; color: #da1e28; border-color: #da1e28; }
+    .btn-danger:hover { background: #fff1f1; }
+    .btn-danger-primary { background: #da1e28; color: white; }
+
+    .action-cell { display: flex; gap: 0.5rem; align-items: center; }
+    .overflow-menu {
+      position: relative; display: inline-block;
+    }
+    .overflow-menu-btn {
+      width: 32px; height: 32px; background: transparent; border: none; cursor: pointer; font-size: 1.25rem;
+    }
+    .overflow-menu-btn:hover { background: #e8e8e8; }
+
+    .btn-enter-result {
+      width: 88px; min-height: 40px; padding: 4px 8px;
+      background: white; color: #0f62fe; border: 1px solid #0f62fe;
+      font-family: inherit; font-size: 0.75rem; font-weight: 400; line-height: 1.15;
+      cursor: pointer; text-align: center; white-space: normal;
+    }
+    .btn-enter-result:hover { background: #e8e8e8; }
+
+    .activity-table { background: white; border: 1px solid #e0e0e0; margin-top: 0.5rem; }
+    .activity-table th { background: white; font-size: 0.75rem; padding: 0.5rem 0.75rem; }
+    .activity-table td { font-size: 0.75rem; padding: 0.5rem 0.75rem; }
+
+    .modal-backdrop {
+      position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+      background: rgba(22, 22, 22, 0.5); display: flex; align-items: center; justify-content: center;
+      z-index: 100;
+    }
+    .modal {
+      background: white; max-width: 560px; width: 90%; padding: 0;
+    }
+    .modal-header { padding: 1.5rem 1.5rem 0.5rem 1.5rem; }
+    .modal-title { font-size: 1.25rem; font-weight: 400; margin: 0; }
+    .modal-body { padding: 1rem 1.5rem; }
+    .modal-footer {
+      padding: 1rem 1.5rem; display: flex; justify-content: flex-end; gap: 0.5rem;
+      background: #f4f4f4; border-top: 1px solid #e0e0e0;
+    }
+    .form-field { margin-bottom: 1rem; }
+    .form-field label { display: block; font-size: 0.75rem; font-weight: 600; color: #525252; margin-bottom: 0.25rem; }
+    .form-field input, .form-field select, .form-field textarea {
+      width: 100%; padding: 0.5rem; border: 1px solid #8d8d8d; background: white; font-family: inherit; font-size: 0.875rem;
+    }
+
+    a { color: #0f62fe; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+
+    .crit-badge { background: #da1e28; color: white; padding: 0.125rem 0.5rem; font-size: 0.625rem; font-weight: 700; letter-spacing: 0.05em; margin-right: 0.5rem; border-radius: 2px; }
+    .stuck-icon { color: #f1c21b; vertical-align: middle; margin-right: 4px; font-size: 1rem; }
+    .stuck-alert-icon { color: #da1e28; }
+    .uuid { font-family: monospace; font-size: 0.75rem; }
+  </style>
+</head>
+<body class="cds--white">
+
+  <div class="preview-banner">
+    ⚡ Visual Preview — Reference Lab Results &nbsp;|&nbsp; Route: /SampleShipment/reference-lab-results &nbsp;|&nbsp; OpenELIS Design Mockup
+  </div>
+
+  <div class="preview-content" id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useMemo, useCallback, Fragment } = React;
+
+    // ───── Mock data ─────
+    const REFERENCE_LABS = [
+      { id: 'org-cedres', name: 'CEDRES Reference Laboratory' },
+      { id: 'org-ihrip', name: 'IHRIP Microbiology Centre' },
+      { id: 'org-cphl', name: 'Central Public Health Laboratory' },
+      { id: 'org-pasteur', name: 'Institut Pasteur Antananarivo' },
+    ];
+
+    const REFERRALS = [
+      { id:'R-7001', labNumber:'L-2026-04123', patient:'Rakoto, Jean (M, 42)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0312', sentDate:'2026-05-26T08:14:00Z', daysOut:2, status:'requested', priority:'Routine', requestor:'Dr. Andrianasolo, M.', fhirTaskUuid:'urn:uuid:a2c4-7b9d-...-3f12', boxReceivedDate:null,
+        activity:[
+          { ts:'2026-05-26T08:14:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+          { ts:'2026-05-26T07:55:00Z', actor:'A. Razafy (Tech)', from:'created', to:'draft', notes:'Refer Out flagged at Result Entry' },
+        ]},
+      { id:'R-7002', labNumber:'L-2026-04124', patient:'Voahangy, Lalao (F, 28)', tests:['HBV DNA Quantitative','HCV RNA Quantitative'], referenceLab:'org-cedres', boxId:'BOX-2026-0312', sentDate:'2026-05-26T08:14:00Z', daysOut:2, status:'received', priority:'Routine', requestor:'Dr. Andrianasolo, M.', fhirTaskUuid:'urn:uuid:b8d1-3e72-...-91f4', boxReceivedDate:'2026-05-27T14:02:00Z',
+        activity:[
+          { ts:'2026-05-27T14:02:00Z', actor:'CEDRES (peer)', from:'requested', to:'received', notes:'Box scanned in at CEDRES receiving' },
+          { ts:'2026-05-26T08:14:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7003', labNumber:'L-2026-04098', patient:'Andriamasy, Pierre (M, 67)', tests:['M. tuberculosis culture + AST'], referenceLab:'org-ihrip', boxId:'BOX-2026-0309', sentDate:'2026-05-22T09:30:00Z', daysOut:6, status:'in-progress', priority:'Urgent', requestor:'Dr. Rakotonirina, S.', fhirTaskUuid:'urn:uuid:c1f9-2a4e-...-7b08', boxReceivedDate:'2026-05-23T11:45:00Z',
+        activity:[
+          { ts:'2026-05-24T08:30:00Z', actor:'IHRIP (peer)', from:'received', to:'in-progress', notes:'Culture set up' },
+          { ts:'2026-05-23T11:45:00Z', actor:'IHRIP (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-22T09:30:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7004', labNumber:'L-2026-03891', patient:'Razanamparany, Marie (F, 35)', tests:['Karyotyping — peripheral blood'], referenceLab:'org-pasteur', boxId:'BOX-2026-0297', sentDate:'2026-05-09T10:00:00Z', daysOut:19, status:'in-progress', priority:'Routine', requestor:'Dr. Ratsimbazafy, H.', fhirTaskUuid:'urn:uuid:d4e2-9f81-...-4c93', boxReceivedDate:'2026-05-11T15:20:00Z', stuck:true,
+        activity:[
+          { ts:'2026-05-12T09:00:00Z', actor:'Pasteur (peer)', from:'received', to:'in-progress', notes:'Culture initiated' },
+          { ts:'2026-05-11T15:20:00Z', actor:'Pasteur (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-09T10:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7005', labNumber:'L-2026-02156', patient:'Ramaroson, Henri (M, 58)', tests:['Whole Exome Sequencing'], referenceLab:'org-pasteur', boxId:'BOX-2026-0214', sentDate:'2026-04-15T11:20:00Z', daysOut:43, status:'in-progress', priority:'Urgent', requestor:'Dr. Rajaonarivelo, T.', fhirTaskUuid:'urn:uuid:e7a3-1b5c-...-2d68', boxReceivedDate:'2026-04-18T09:15:00Z', stuck:true, criticallyStuck:true,
+        activity:[
+          { ts:'2026-04-20T14:00:00Z', actor:'Pasteur (peer)', from:'received', to:'in-progress', notes:'Library prep started' },
+          { ts:'2026-04-18T09:15:00Z', actor:'Pasteur (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-04-15T11:20:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+
+      // Returned — needs action
+      { id:'R-7006', labNumber:'L-2026-04201', patient:'Razafindrakoto, Aina (F, 31)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0314', sentDate:'2026-05-23T08:00:00Z', daysOut:5, status:'completed', priority:'Routine', requestor:'Dr. Andrianasolo, M.', returnedDate:'2026-05-28T07:42:00Z', fhirTaskUuid:'urn:uuid:f9c2-4d8a-...-5e17', boxReceivedDate:'2026-05-24T10:30:00Z',
+        resultSummary:'< 20 copies/mL (undetectable)',
+        results:[{ test:'HIV-1 RNA Viral Load', value:'< 20', units:'copies/mL', range:'Undetectable: < 20', flag:'Normal', notes:'Below limit of quantification.' }],
+        activity:[
+          { ts:'2026-05-28T07:42:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received' },
+          { ts:'2026-05-24T11:00:00Z', actor:'CEDRES (peer)', from:'received', to:'in-progress', notes:'' },
+          { ts:'2026-05-24T10:30:00Z', actor:'CEDRES (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-23T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7007', labNumber:'L-2026-04156', patient:'Andriamampianina, Bako (M, 24)', tests:['HBV DNA Quantitative','HCV RNA Quantitative'], referenceLab:'org-cedres', boxId:'BOX-2026-0314', sentDate:'2026-05-23T08:00:00Z', daysOut:5, status:'completed', priority:'Routine', requestor:'Dr. Rakotonirina, S.', returnedDate:'2026-05-28T07:55:00Z', fhirTaskUuid:'urn:uuid:h2k4-...-7d12', boxReceivedDate:'2026-05-24T10:30:00Z',
+        resultSummary:'HBV: 2.1 × 10⁴ IU/mL · HCV: not detected',
+        results:[
+          { test:'HBV DNA Quantitative', value:'2.1 × 10⁴', units:'IU/mL', range:'< 20 IU/mL undetectable', flag:'Abnormal', notes:'Active replication.' },
+          { test:'HCV RNA Quantitative', value:'Not detected', units:'IU/mL', range:'< 15 IU/mL', flag:'Normal', notes:'' },
+        ],
+        activity:[
+          { ts:'2026-05-28T07:55:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received' },
+          { ts:'2026-05-23T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      { id:'R-7008', labNumber:'L-2026-04188', patient:'Rabearisoa, Olivier (M, 51)', tests:['Cryptococcal antigen (CrAg)'], referenceLab:'org-cphl', boxId:'BOX-2026-0311', sentDate:'2026-05-25T09:15:00Z', daysOut:3, status:'completed', priority:'STAT', requestor:'Dr. Ratsimbazafy, H.', returnedDate:'2026-05-27T18:20:00Z', fhirTaskUuid:'urn:uuid:l5m6-...-9c87', boxReceivedDate:'2026-05-26T08:00:00Z',
+        resultSummary:'POSITIVE — titer 1:80',
+        results:[{ test:'Cryptococcal antigen (CrAg)', value:'POSITIVE', units:'— (titer 1:80)', range:'Negative', flag:'Critical', notes:'Consistent with disseminated cryptococcosis. Recommend LP.' }],
+        activity:[
+          { ts:'2026-05-27T18:20:00Z', actor:'CPHL (peer)', from:'in-progress', to:'completed', notes:'DiagnosticReport received — CRITICAL' },
+          { ts:'2026-05-25T09:15:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+
+      // History — manually entered (reference lab not on OpenELIS, called result by phone)
+      { id:'R-7013', labNumber:'L-2026-03654', patient:'Rafanomezantsoa, Lova (F, 44)', tests:['CD4 absolute count'], referenceLab:'org-cphl', boxId:'BOX-2026-0265', sentDate:'2026-04-23T09:00:00Z', status:'reconciled', outcome:'Reconciled', priority:'Routine', closedDate:'2026-05-01T14:22:00Z', daysTotal:8, manuallyEntered:true, requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-01T14:22:00Z', actor:'P. Rasoanirina (Validator)', from:'requested', to:'reconciled', notes:'Result phoned in by CPHL — manually entered via Result Entry' },
+          { ts:'2026-04-23T09:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'Box dispatched' },
+        ]},
+      // History — reconciled (auto via DiagnosticReport)
+      { id:'R-7009', labNumber:'L-2026-03997', patient:'Razanadrakoto, Felana (F, 39)', tests:['HIV-1 RNA Viral Load'], referenceLab:'org-cedres', boxId:'BOX-2026-0301', sentDate:'2026-05-18T08:30:00Z', status:'reconciled', outcome:'Reconciled', priority:'Routine', closedDate:'2026-05-25T11:14:00Z', daysTotal:7, requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-25T11:14:00Z', actor:'P. Rasoanirina (Validator)', from:'completed', to:'reconciled', notes:'Result accepted into local Analysis' },
+          { ts:'2026-05-24T15:30:00Z', actor:'CEDRES (peer)', from:'in-progress', to:'completed', notes:'' },
+          { ts:'2026-05-18T08:30:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+      // History — rejected
+      { id:'R-7010', labNumber:'L-2026-03812', patient:'Andriantsoa, Tahina (M, 19)', tests:['Mycobacterium spp. molecular ID'], referenceLab:'org-ihrip', boxId:'BOX-2026-0286', sentDate:'2026-05-04T07:45:00Z', status:'rejected', outcome:'Rejected', priority:'Routine', closedDate:'2026-05-09T13:00:00Z', daysTotal:5, rejectReason:'Insufficient volume (received 0.4 mL, need ≥ 2 mL). Resubmit with larger draw.', requestor:'Dr. Rakotonirina, S.',
+        activity:[
+          { ts:'2026-05-09T13:00:00Z', actor:'IHRIP (peer)', from:'received', to:'rejected', notes:'Insufficient volume — 0.4 mL' },
+          { ts:'2026-05-05T10:00:00Z', actor:'IHRIP (peer)', from:'requested', to:'received', notes:'' },
+          { ts:'2026-05-04T07:45:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+      // History — cancelled
+      { id:'R-7011', labNumber:'L-2026-03734', patient:'Rakotomalala, Hery (M, 47)', tests:['Karyotyping — peripheral blood'], referenceLab:'org-pasteur', boxId:'BOX-2026-0273', sentDate:'2026-04-27T09:00:00Z', status:'cancelled', outcome:'Cancelled', priority:'Routine', closedDate:'2026-04-27T16:30:00Z', daysTotal:0, cancelReason:'Clinician withdrew request (treatment changed).', requestor:'Dr. Rajaonarivelo, T.',
+        activity:[
+          { ts:'2026-04-27T16:30:00Z', actor:'P. Rasoanirina (Validator)', from:'draft', to:'cancelled', notes:'Clinician withdrew request' },
+        ]},
+      // History — lost
+      { id:'R-7012', labNumber:'L-2026-03551', patient:'Razafindramanana, Soa (F, 62)', tests:['HBsAg confirmatory'], referenceLab:'org-cphl', boxId:'BOX-2026-0258', sentDate:'2026-04-19T08:00:00Z', status:'requested', outcome:'Lost', priority:'Routine', closedDate:'2026-05-02T10:00:00Z', daysTotal:13, lostStatus:true, lostReason:'Box never arrived at CPHL — courier confirmed loss. Sample re-collected and re-referred under L-2026-04201.', requestor:'Dr. Andrianasolo, M.',
+        activity:[
+          { ts:'2026-05-02T10:00:00Z', actor:'P. Rasoanirina (Validator)', from:'requested', to:'(lost flag set)', notes:'Marked lost — courier confirmed' },
+          { ts:'2026-04-19T08:00:00Z', actor:'A. Razafy (Tech)', from:'draft', to:'requested', notes:'' },
+        ]},
+    ];
+
+    const refLabName = (id) => REFERENCE_LABS.find(r => r.id === id)?.name || id;
+
+    const STATUS_KIND = {
+      draft:'gray', requested:'blue', received:'purple', 'in-progress':'warm-gray',
+      completed:'teal', rejected:'red', cancelled:'gray', reconciled:'teal',
+    };
+    const STATUS_LABEL = {
+      draft:'Draft', requested:'Sent — awaiting acceptance', received:'At reference lab',
+      'in-progress':'In progress at reference lab', completed:'Result returned',
+      rejected:'Rejected by reference lab', cancelled:'Cancelled', reconciled:'Reconciled',
+    };
+    const PRIORITY_KIND = { Routine:'gray', Urgent:'warm-gray', STAT:'red' };
+    const OUTCOME_KIND = { Reconciled:'teal', Rejected:'red', Cancelled:'gray', Lost:'red' };
+
+    const formatDate = (iso) => {
+      if (!iso) return '—';
+      const d = new Date(iso);
+      return `${d.toLocaleDateString()} ${d.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'})}`;
+    };
+
+    function Tag({ kind, children }) {
+      return <span className={`tag tag-${kind}`}>{children}</span>;
+    }
+
+    function MetricTile({ color, label, count, onClick, active }) {
+      return (
+        <button className={`metric-tile ${color} ${active ? 'active' : ''}`} onClick={onClick}>
+          <div className="count">{count}</div>
+          <div className="label">{label}</div>
+        </button>
+      );
+    }
+
+    function Chip({ active, onClick, children }) {
+      return <button className={`chip ${active ? 'active' : ''}`} onClick={onClick}>{children}</button>;
+    }
+
+    function DetailRow({ label, value }) {
+      return (
+        <div className="detail-row">
+          <span className="label">{label}</span>
+          <span className="value">{value}</span>
+        </div>
+      );
+    }
+
+    function ActivityLog({ activity }) {
+      return (
+        <table className="activity-table">
+          <thead><tr><th>Timestamp</th><th>Actor</th><th>From</th><th>To</th><th>Notes</th></tr></thead>
+          <tbody>
+            {activity.map((a, i) => (
+              <tr key={i}>
+                <td>{formatDate(a.ts)}</td>
+                <td>{a.actor}</td>
+                <td>{a.from}</td>
+                <td>{a.to}</td>
+                <td>{a.notes || '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      );
+    }
+
+    function ExpandPanel({ row, mode, onMarkLost, onReject }) {
+      return (
+        <div className="expand-panel">
+          <div className="expand-grid">
+            <div>
+              <h5>Original order context</h5>
+              <DetailRow label="Lab Number" value={<a href={`/Patient/${row.labNumber}`}>{row.labNumber}</a>} />
+              <DetailRow label="Patient" value={row.patient} />
+              <DetailRow label="Tests" value={row.tests.join(', ')} />
+              <DetailRow label="Original requestor" value={row.requestor} />
+              <DetailRow label="Priority" value={<Tag kind={PRIORITY_KIND[row.priority]}>{row.priority}</Tag>} />
+            </div>
+
+            <div>
+              <h5>Reference lab transit</h5>
+              <DetailRow label="Reference Lab" value={refLabName(row.referenceLab)} />
+              <DetailRow label="Box ID" value={<a href={`/SampleShipment/box/${row.boxId}`}>{row.boxId}</a>} />
+              <DetailRow label="Dispatched" value={formatDate(row.sentDate)} />
+              <DetailRow label="Received at lab" value={formatDate(row.boxReceivedDate)} />
+              <DetailRow label="FHIR Task" value={<span className="uuid">{row.fhirTaskUuid}</span>} />
+            </div>
+
+            <div>
+              {mode === 'outstanding' && (
+                <Fragment>
+                  <h5>Status detail</h5>
+                  <DetailRow label="Current status" value={<Tag kind={STATUS_KIND[row.status]}>{STATUS_LABEL[row.status]}</Tag>} />
+                  <DetailRow label="Days outstanding" value={`${row.daysOut} days`} />
+                  {row.stuck && (
+                    <div className="banner-warning" style={{ marginTop:'0.75rem' }}>
+                      <div className="body">
+                        <div className="title">Stuck</div>
+                        <div className="subtitle">Consider contacting the reference lab.</div>
+                      </div>
+                    </div>
+                  )}
+                  <div style={{ marginTop:'1rem', display:'flex', gap:'0.5rem' }}>
+                    <button className="btn btn-sm btn-primary" onClick={() => alert(`Would deep-link to /result?sampleId=${row.labNumber}`)}>Enter result</button>
+                    <button className="btn btn-sm btn-ghost" onClick={() => onMarkLost(row)}>⚠ Mark Lost</button>
+                  </div>
+                </Fragment>
+              )}
+
+              {mode === 'returned' && (
+                <Fragment>
+                  <h5>Result</h5>
+                  {row.results?.map((res, i) => (
+                    <div key={i} className="result-card">
+                      <div className="test">{res.test}</div>
+                      <div className="value">{res.value} <span className="units">{res.units}</span></div>
+                      <div className="range">Reference range: {res.range}</div>
+                      {res.flag && <span className="tag" style={{
+                        background: res.flag === 'Critical' ? '#ffd7d9' : res.flag === 'Abnormal' ? '#e5e0df' : '#a7f0ba',
+                        color: res.flag === 'Critical' ? '#750e13' : res.flag === 'Abnormal' ? '#43413e' : '#044317',
+                        marginTop: 4, display:'inline-block',
+                      }}>{res.flag}</span>}
+                      {res.notes && <div className="notes">{res.notes}</div>}
+                    </div>
+                  ))}
+                  <div style={{ marginTop:'0.5rem', display:'flex', gap:'0.5rem', flexWrap:'wrap' }}>
+                    <button className="btn btn-sm btn-primary">✓ Accept to Analysis</button>
+                    <button className="btn btn-sm btn-danger" onClick={() => onReject(row)}>Reject…</button>
+                    <button className="btn btn-sm btn-ghost" onClick={() => alert(`Would navigate to /result?sampleId=${row.labNumber}`)}>Open in Result Entry</button>
+                  </div>
+                </Fragment>
+              )}
+
+              {mode === 'history' && (
+                <Fragment>
+                  <h5>Outcome detail</h5>
+                  <DetailRow label="Outcome" value={<Tag kind={OUTCOME_KIND[row.outcome]}>{row.outcome}</Tag>} />
+                  <DetailRow label="Closed" value={formatDate(row.closedDate)} />
+                  <DetailRow label="Total days" value={`${row.daysTotal} days`} />
+                  {row.rejectReason && <DetailRow label="Rejection reason" value={row.rejectReason} />}
+                  {row.cancelReason && <DetailRow label="Cancellation reason" value={row.cancelReason} />}
+                  {row.lostReason && <DetailRow label="Lost reason" value={row.lostReason} />}
+                </Fragment>
+              )}
+            </div>
+          </div>
+
+          <div style={{ marginTop:'1.5rem' }}>
+            <h5>Activity log</h5>
+            <ActivityLog activity={row.activity || []} />
+          </div>
+        </div>
+      );
+    }
+
+    function OutstandingTable({ rows, expanded, toggle, onMarkLost }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">Outstanding referrals</div>
+            <div className="desc">{rows.length} referrals at reference labs awaiting results</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Box ID</th><th>Sent Date</th><th>Status</th><th>Days outstanding</th><th>Priority</th><th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="11" className="empty-state">No referrals found for the selected filters.</td></tr>}
+              {rows.map(row => (
+                <Fragment key={row.id}>
+                  <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                    <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                    <td>{row.labNumber}</td>
+                    <td>{row.patient}</td>
+                    <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                    <td>{refLabName(row.referenceLab)}</td>
+                    <td><a href={`/SampleShipment/box/${row.boxId}`} onClick={(e) => e.stopPropagation()}>{row.boxId}</a></td>
+                    <td>{formatDate(row.sentDate)}</td>
+                    <td><Tag kind={STATUS_KIND[row.status]}>{STATUS_LABEL[row.status]}</Tag></td>
+                    <td>
+                      <span className={row.daysOut > 30 ? 'days-alert' : row.daysOut > 7 ? 'days-warn' : ''}>
+                        {row.stuck && <span className={`stuck-icon ${row.criticallyStuck ? 'stuck-alert-icon' : ''}`}>⚠</span>}
+                        {row.daysOut} {row.daysOut === 1 ? 'day' : 'days'}
+                      </span>
+                    </td>
+                    <td><Tag kind={PRIORITY_KIND[row.priority]}>{row.priority}</Tag></td>
+                    <td onClick={(e) => e.stopPropagation()}>
+                      <button
+                        className="btn-enter-result"
+                        onClick={() => alert(`Would deep-link to /result?sampleId=${row.labNumber}`)}
+                      >Enter<br/>result</button>
+                    </td>
+                  </tr>
+                  {expanded === row.id && <tr><td colSpan="11" style={{ padding: 0 }}><ExpandPanel row={row} mode="outstanding" onMarkLost={onMarkLost} /></td></tr>}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function ReturnedTable({ rows, expanded, toggle, onReject }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">Returned — needs action</div>
+            <div className="desc">{rows.length} results awaiting reconciliation to local Analysis</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Result summary</th><th>Returned Date</th><th>Original requestor</th><th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="9" className="empty-state">No returned results awaiting action.</td></tr>}
+              {rows.map(row => {
+                const hasCrit = row.results?.some(r => r.flag === 'Critical');
+                return (
+                  <Fragment key={row.id}>
+                    <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                      <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                      <td>{row.labNumber}</td>
+                      <td>{row.patient}</td>
+                      <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                      <td>{refLabName(row.referenceLab)}</td>
+                      <td>{hasCrit && <span className="crit-badge">CRITICAL</span>}{row.resultSummary}</td>
+                      <td>{formatDate(row.returnedDate)}</td>
+                      <td>{row.requestor}</td>
+                      <td onClick={(e) => e.stopPropagation()}>
+                        <div className="action-cell">
+                          <button className="btn btn-sm btn-primary">Accept</button>
+                          <button className="btn btn-sm btn-danger" onClick={() => onReject(row)}>Reject…</button>
+                        </div>
+                      </td>
+                    </tr>
+                    {expanded === row.id && <tr><td colSpan="9" style={{ padding: 0 }}><ExpandPanel row={row} mode="returned" onReject={onReject} /></td></tr>}
+                  </Fragment>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function HistoryTable({ rows, expanded, toggle }) {
+      return (
+        <div className="table-container">
+          <div className="table-header">
+            <div className="title">History</div>
+            <div className="desc">{rows.length} closed referrals</div>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th className="expand-toggle"></th>
+                <th>Lab Number</th><th>Patient</th><th>Test(s)</th><th>Reference Lab</th>
+                <th>Outcome</th><th>Closed date</th><th>Box ID</th><th>Days total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.length === 0 && <tr><td colSpan="9" className="empty-state">No closed referrals match the selected filters.</td></tr>}
+              {rows.map(row => (
+                <Fragment key={row.id}>
+                  <tr className="expandable-row" onClick={() => toggle(row.id)}>
+                    <td className="expand-toggle"><span className={`expand-icon ${expanded === row.id ? 'open' : ''}`}>▸</span></td>
+                    <td>{row.labNumber}</td>
+                    <td>{row.patient}</td>
+                    <td>{row.tests.slice(0,2).join(', ')}{row.tests.length > 2 ? ` +${row.tests.length - 2} more` : ''}</td>
+                    <td>{refLabName(row.referenceLab)}</td>
+                    <td>
+                      <Tag kind={OUTCOME_KIND[row.outcome]}>{row.outcome}</Tag>
+                      {row.manuallyEntered && <span style={{ marginLeft: 4 }}><Tag kind="warm-gray">Manually entered</Tag></span>}
+                    </td>
+                    <td>{formatDate(row.closedDate)}</td>
+                    <td><a href={`/SampleShipment/box/${row.boxId}`} onClick={(e) => e.stopPropagation()}>{row.boxId}</a></td>
+                    <td>{row.daysTotal} {row.daysTotal === 1 ? 'day' : 'days'}</td>
+                  </tr>
+                  {expanded === row.id && <tr><td colSpan="9" style={{ padding: 0 }}><ExpandPanel row={row} mode="history" /></td></tr>}
+                </Fragment>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      );
+    }
+
+    function RejectModal({ row, onClose }) {
+      const [code, setCode] = useState('');
+      const [text, setText] = useState('');
+      return (
+        <div className="modal-backdrop" onClick={onClose}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header"><h3 className="modal-title">Reject referral</h3></div>
+            <div className="modal-body">
+              <div style={{ marginBottom:'1rem' }}>
+                <strong>{row.labNumber}</strong> — {row.patient}<br/>
+                <span style={{ color:'#525252' }}>{row.tests.join(', ')} → {refLabName(row.referenceLab)}</span>
+              </div>
+              <div className="form-field">
+                <label>Common reason (optional)</label>
+                <select value={code} onChange={(e) => setCode(e.target.value)}>
+                  <option value="">— Select reason —</option>
+                  <option value="insufficientVolume">Insufficient volume</option>
+                  <option value="wrongSampleType">Wrong sample type</option>
+                  <option value="damagedContainer">Damaged container</option>
+                  <option value="temperatureDeviation">Temperature deviation</option>
+                  <option value="hemolyzed">Hemolyzed</option>
+                  <option value="clotted">Clotted</option>
+                  <option value="mislabeled">Mislabeled</option>
+                  <option value="other">Other</option>
+                </select>
+              </div>
+              <div className="form-field">
+                <label>Reason for rejection</label>
+                <textarea rows="3" maxLength="500" value={text} onChange={(e) => setText(e.target.value)} placeholder="Describe why this referral is being rejected"></textarea>
+              </div>
+              <div className="banner-warning" style={{ marginTop:'1rem' }}>
+                <div className="body">
+                  <div className="title">This closes the Analysis as rejected</div>
+                  <div className="subtitle">Rejecting closes the Analysis as terminal-rejected. The requesting clinician will be notified to arrange re-collection. A new order will be needed when a fresh sample is collected.</div>
+                </div>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+              <button className="btn btn-danger-primary">Reject and notify clinician</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function MarkLostModal({ row, onClose }) {
+      const [reason, setReason] = useState('');
+      return (
+        <div className="modal-backdrop" onClick={onClose}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header"><h3 className="modal-title">Mark referral lost in transit</h3></div>
+            <div className="modal-body">
+              <div style={{ marginBottom:'1rem' }}>
+                <strong>{row.labNumber}</strong> — {row.patient}<br/>
+                <span style={{ color:'#525252' }}>Box {row.boxId} → {refLabName(row.referenceLab)}</span>
+              </div>
+              <div className="form-field">
+                <label>Reason</label>
+                <textarea rows="3" value={reason} onChange={(e) => setReason(e.target.value)} placeholder="What happened to the sample?"></textarea>
+              </div>
+              <div className="banner-warning" style={{ marginTop:'1rem' }}>
+                <div className="body">
+                  <div className="title">Reversible only by an administrator</div>
+                  <div className="subtitle">Marking this referral as lost is reversible only by an administrator.</div>
+                </div>
+              </div>
+            </div>
+            <div className="modal-footer">
+              <button className="btn btn-ghost" onClick={onClose}>Cancel</button>
+              <button className="btn btn-danger-primary">Mark Lost</button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    function App() {
+      const [view, setView] = useState('outstanding');
+      const [refLab, setRefLab] = useState('');
+      const [priority, setPriority] = useState('');
+      const [bucket, setBucket] = useState('all');
+      const [expanded, setExpanded] = useState(null);
+      const [rejectRow, setRejectRow] = useState(null);
+      const [lostRow, setLostRow] = useState(null);
+
+      const filtered = useMemo(() => {
+        let rows = REFERRALS;
+        if (view === 'outstanding') rows = rows.filter(r => ['requested','received','in-progress'].includes(r.status));
+        else if (view === 'returned') rows = rows.filter(r => r.status === 'completed');
+        else rows = rows.filter(r => ['reconciled','rejected','cancelled'].includes(r.status) || r.lostStatus);
+
+        if (refLab) rows = rows.filter(r => r.referenceLab === refLab);
+        if (priority) rows = rows.filter(r => r.priority === priority);
+        if (view === 'outstanding' && bucket !== 'all') {
+          rows = rows.filter(r => {
+            if (bucket === '0-7') return r.daysOut <= 7;
+            if (bucket === '7-30') return r.daysOut > 7 && r.daysOut <= 30;
+            if (bucket === '>30') return r.daysOut > 30;
+            return true;
+          });
+        }
+        return rows;
+      }, [view, refLab, priority, bucket]);
+
+      const stuckCount = REFERRALS.filter(r => r.stuck).length;
+
+      const counts = {
+        outstanding: REFERRALS.filter(r => ['requested','received','in-progress'].includes(r.status)).length,
+        returned: REFERRALS.filter(r => r.status === 'completed').length,
+        reconciledToday: 1,
+        rejectedThisWeek: REFERRALS.filter(r => r.status === 'rejected').length,
+      };
+
+      const toggle = (id) => setExpanded(expanded === id ? null : id);
+      const clear = () => { setRefLab(''); setPriority(''); setBucket('all'); };
+
+      return (
+        <Fragment>
+          <div className="breadcrumb">
+            <a href="/">Home</a><span className="sep">/</span>
+            <a href="/SampleShipment/dashboard">Sample Shipment</a><span className="sep">/</span>
+            <span className="current">Reference Lab Results</span>
+          </div>
+
+          <h1>Reference Lab Results</h1>
+
+          {stuckCount > 0 && view === 'outstanding' && (
+            <div className="banner-warning">
+              <div className="body">
+                <div className="title">Stuck referrals require attention</div>
+                <div className="subtitle">{stuckCount} referrals have been at a reference lab for more than 7 days. Consider contacting the reference lab or reassigning.</div>
+              </div>
+              <div className="action">
+                <button className="btn btn-sm btn-ghost" onClick={() => { setView('outstanding'); setBucket('>30'); }}>Filter to stuck only</button>
+              </div>
+            </div>
+          )}
+
+          <div className="metric-row">
+            <MetricTile color="green" label="OUTSTANDING" count={counts.outstanding} onClick={() => { setView('outstanding'); clear(); }} active={view === 'outstanding'} />
+            <MetricTile color="red" label="RETURNED — NEEDS ACTION" count={counts.returned} onClick={() => { setView('returned'); clear(); }} active={view === 'returned'} />
+            <MetricTile color="teal" label="RECONCILED TODAY" count={counts.reconciledToday} onClick={() => { setView('history'); clear(); }} />
+            <MetricTile color="purple" label="REJECTED THIS WEEK" count={counts.rejectedThisWeek} onClick={() => { setView('history'); clear(); }} />
+          </div>
+
+          <div className="chip-row">
+            <Chip active={view === 'outstanding'} onClick={() => setView('outstanding')}>Outstanding ({counts.outstanding})</Chip>
+            <Chip active={view === 'returned'} onClick={() => setView('returned')}>Returned — needs action ({counts.returned})</Chip>
+            <Chip active={view === 'history'} onClick={() => setView('history')}>History</Chip>
+          </div>
+
+          <div className="filter-row">
+            <div>
+              <label>Reference Lab</label>
+              <select value={refLab} onChange={(e) => setRefLab(e.target.value)}>
+                <option value="">All reference labs</option>
+                {REFERENCE_LABS.map(r => <option key={r.id} value={r.id}>{r.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label>Date range</label>
+              <input type="text" placeholder="mm/dd/yyyy – mm/dd/yyyy" />
+            </div>
+            <div>
+              <label>Priority</label>
+              <select value={priority} onChange={(e) => setPriority(e.target.value)}>
+                <option value="">All priorities</option>
+                <option value="Routine">Routine</option>
+                <option value="Urgent">Urgent</option>
+                <option value="STAT">STAT</option>
+              </select>
+            </div>
+            {view === 'outstanding' && (
+              <div>
+                <label>Days outstanding</label>
+                <select value={bucket} onChange={(e) => setBucket(e.target.value)}>
+                  <option value="all">All</option>
+                  <option value="0-7">0-7</option>
+                  <option value="7-30">7-30</option>
+                  <option value=">30">&gt;30</option>
+                </select>
+              </div>
+            )}
+            <div className="clear">
+              <button className="btn btn-sm btn-ghost" onClick={clear}>Clear filters</button>
+            </div>
+          </div>
+
+          {view === 'outstanding' && <OutstandingTable rows={filtered} expanded={expanded} toggle={toggle} onMarkLost={setLostRow} />}
+          {view === 'returned' && <ReturnedTable rows={filtered} expanded={expanded} toggle={toggle} onReject={setRejectRow} />}
+          {view === 'history' && <HistoryTable rows={filtered} expanded={expanded} toggle={toggle} />}
+
+          {rejectRow && <RejectModal row={rejectRow} onClose={() => setRejectRow(null)} />}
+          {lostRow && <MarkLostModal row={lostRow} onClose={() => setLostRow(null)} />}
+        </Fragment>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -1592,6 +1592,20 @@ export const MOCKUP_REGISTRY = [
   },
 
   {
+    name: 'Reference Lab Results',
+    category: 'sample-collection',
+    component: React.lazy(() => import('@designs/sample-collection/reference-lab-results.jsx')),
+    description: 'New SideNav item under Sample Shipment. Outstanding / Returned-needs-action / History views for tracking the data lifecycle of referrals after physical shipment. Migrates ReferralStatus enum to FHIR Task states; adds manual-entry path for non-OpenELIS reference labs; Accept/Reject with terminal close + re-collection notification; Box.Reconciled gate. Supersedes OGC-624 state-model scope.',
+    specPath: 'designs/sample-collection/reference-lab-results.md',
+    htmlUrl: 'designs/sample-collection/reference-lab-results.html',
+    added: '2026-05-28',
+    status: 'draft',
+    relatedTo: ['Inter-Lab Transfer'],
+    jira: ['OGC-796'],
+    tags: ['referral', 'reference-lab', 'FHIR', 'sample-shipment', 'Madagascar', 'global', 'reconciliation', 'inter-lab'],
+  },
+
+  {
     name: 'Pre-Analytical Eligibility Gate',
     category: 'sample-collection',
     component: React.lazy(() => import('@designs/sample-collection/pre-analytical-eligibility-gate.jsx')),

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -1586,7 +1586,7 @@ export const MOCKUP_REGISTRY = [
     htmlUrl: 'designs/sample-collection/inter-lab-transfer.html',
     added: '2026-04-27',
     status: 'draft',
-    relatedTo: ['Subcontract Management'],
+    relatedTo: ['Subcontract Management', 'Reference Lab Results'],
     jira: ['OGC-527'],
     tags: ['referral', 'inter-lab', 'subcontract', 'environmental', 'vector', 'clinical', 'chain-of-custody', 'ISO-17025'],
   },


### PR DESCRIPTION
New SideNav item under Sample Shipment at /SampleShipment/reference-lab-results that tracks the data lifecycle of referrals after physical shipment. Three views (Outstanding / Returned-needs-action / History) with inline expand for detail. Visible two-line "Enter result" button on every Outstanding row deep-links to existing Result Entry for manual posting from non-OpenELIS reference labs. Accept follows reception model (peer-validated results post as validated); Reject closes Analysis as terminal and notifies clinician via OGC-589 + Alerts feature. Box.Reconciled gate blocks closing a Box until all contained referrals reach terminal state.

Includes:
- FRS, mockup JSX, HTML preview
- Dev primer (narrative walkthrough grounded in a realistic case)
- Breakdown plan (1 Epic + 14 stories across 3 sprints)
- Brainstorm and /analyze report

Epic: OGC-796. Stories: OGC-797 through OGC-810 (all assigned to Samuel Male, absorbing OGC-605 and OGC-589, superseding OGC-624's state-model scope).

Note: Test suite was not run locally in this session due to /tmp disk constraints on the workspace; CI will run on the PR. Brace count in App.jsx was verified balanced (no JSX syntax breakage from the inserted entry).

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
