### PR TITLE
feat(microbiology): sync-2 — M-04/M-05 inline rewrites + M-05 AST pro…

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -573,6 +573,19 @@
     preview: https://digi-uw.github.io/openelis-work/designs/microbiology/m-07-worklists-prototype.html
   added: "2026-06-05"
 
+- id: m-05-ast-entry-prototype
+  type: mockup
+  path: designs/microbiology/m-05-ast-entry-prototype.html
+  category: microbiology
+  description: >
+    M-05 AST entry inline interactive prototype — auto-interpret, flexible breakpoint, inline override + revert, QC-fail recovery; canonical interactive mockup.
+  paired_with: m-05-ast-entry-and-interpretation
+  links:
+    jira: ["OGC-791"]
+    gallery: https://digi-uw.github.io/openelis-work/#/microbiology/m-05-ast-entry-interactive-prototype
+    preview: https://digi-uw.github.io/openelis-work/designs/microbiology/m-05-ast-entry-prototype.html
+  added: "2026-06-05"
+
 - id: amr-micro-dependency-graph
   type: image
   path: designs/microbiology/amr-micro-dependency-graph.svg

--- a/designs/microbiology/m-04-case-workbench-core.md
+++ b/designs/microbiology/m-04-case-workbench-core.md
@@ -45,7 +45,7 @@ The Case is the central abstraction of the Microbiology module — a per-specime
 - **M-03 Order Entry hook** — creates the Case on Sample save (see §3.1 and the test-designation note in §9).
 - **M-01 Reference Data** — Organism Master, AST Panels, Culture protocol (as a Method, §8).
 - **M-02 Breakpoint Catalog** — referenced via the AST run (M-05).
-- **M-05 AST Entry** — AST setup/entry modals opened from the AST section.
+- **M-05 AST Entry** — AST setup/entry opened **inline** from the AST section (not a modal).
 - **M-06 Expert Rules** (Phase 1B) — runs on AST completion; confirmation orders flow through the reflex engine (§9).
 - **M-07 Worklist** — reads case state; every worklist row opens this page.
 - **M-08 Macro Library** — macro-enabled text fields.
@@ -90,6 +90,8 @@ The state machine is the spine of the case; the page's next-step guidance (§5) 
 ## 4. Case Detail page — layout & sections
 Left sidebar (Carbon SideNav) with progress dots reflecting the state machine; scrollable main column; sticky footer action bar. The page opens focused on the current step (§2.2). A **stage-keyed next-step banner** sits at the top of the main column (§5).
 
+**Interaction model — inline, not modals (constitution Principle 3).** Every action expands an **inline panel within its section/row** (Carbon row/section expansion), never a pop-up modal overlay; modals are reserved only for destructive confirmations. **Identifier fields are barcode-scannable** — bottle/plate IDs (inoculation, subculture) and analyzer card IDs offer "scan or type." **Reagent-lot selection uses the same FIFO guidance as results-entry reagent selection** — lots sorted oldest-expiry-first, QC status shown inline, expired/locked lots blocked (via M-12).
+
 ### 4.1 Case Info — compact, collapsible
 Carried from order entry, read-only. Rendered as a **one-line collapsible summary** (order, origin, ward, number of sets, antibiotic exposure) that expands on demand, with **Clinical history surfaced first** when expanded. It mostly duplicates the case header, so it is collapsed by default — techs rarely open it.
 
@@ -103,10 +105,12 @@ The Timeline is the log the system keeps, not a data-entry surface. Entries writ
 **+ Add isolate** creates a **preliminary** isolate from Gram stain + colony morphology (`organism_id` null); this advances the case to GROWTH_DETECTED/ORGANISM_ID and auto-writes a Gram-stain timeline event. Each isolate tile shows an **ID status**:
 - **Identification pending** (amber) with a primary **Identify organism →** action;
 - **Identified** (green) with method + confidence.
-Identification can arrive three ways: manual final ID in the isolate modal, an **analyzer push** (`ID_RESULT_AVAILABLE` fills the organism and clears the pending state), or a re-identification. **Set up AST is disabled until the organism is identified** (tooltip explains why). **Edit** (in-place) is used while the case is open; **Reidentify** (§6.3, versioned) appears only after the final report. Helper text states the create-then-identify rhythm.
+Identification can arrive three ways: manual final ID in the isolate's inline Identify panel, an **analyzer push** (`ID_RESULT_AVAILABLE` fills the organism and clears the pending state), or a re-identification. **Set up AST is disabled until the organism is identified** (tooltip explains why). **Edit** (in-place) is used while the case is open; **Reidentify** (§6.3, versioned) appears only after the final report. Helper text states the create-then-identify rhythm.
 
 ### 4.5 AST Results — summary (entry lives in M-05)
-Per-isolate AST run tables: inline rows; overridden rows shaded and **expandable to show original→override with a revert action**; the matched breakpoint level (organism-specific / group / none) is shown; "no breakpoint" rows are guided to local-SOP interpretation. "Edit AST" opens the M-05 modal; "View audit" opens the override audit. Analyzer results arrive automatically (§7); a run awaiting results shows an "awaiting analyzer results" state — there is no manual import.
+Per-isolate AST run tables: inline rows; overridden rows shaded and **expandable to show original→override with a revert action**; the matched breakpoint level (organism-specific / group / none) is shown; "no breakpoint" rows are guided to local-SOP interpretation. "Edit AST" opens the M-05 inline AST-entry panel; "View audit" opens the override audit. Analyzer results arrive automatically (§7); a run awaiting results shows an "awaiting analyzer results" state — there is no manual import.
+
+**Breakpoint standard is chosen at AST setup and shown on the run — and it's flexible.** It defaults to the lab's active standard, but any *loaded* standard — CLSI or EUCAST, any version — can be selected **per run** (some labs run EUCAST for one organism group and CLSI for another, or pin an older version during a transition). The choice is **snapshotted** on the run so historical interpretations never change when the lab later switches its active standard. The lab's default active standard, and which standards are loaded/selectable, are managed in the Breakpoint Catalog (M-02).
 
 **AST progress count.** The section header counts **completed runs / total runs**, plus an explicit tally of significant isolates **awaiting AST setup** and isolates **pending identification**. A case with two isolates where one is not yet identified must therefore never read as "1 / 1 complete" — the unidentified/un-set-up isolate is surfaced in the count (e.g. "1 / 1 runs complete · 1 pending ID"), because AST is per-isolate-run and an un-worked isolate is not "done."
 
@@ -115,6 +119,11 @@ Preliminary and Final report rows with versions. **Release preliminary** is enab
 
 ### 4.7 Critical notification
 A **Log critical notification** action appears in the **case header** (`target_type = CASE`) and on **each isolate tile** (`target_type = ISOLATE`); the entry point sets the target. On save it writes the M-11 record + a timeline event and shows the unacknowledged badge immediately (optimistic).
+
+### 4.8 Report NCE & specimen-lost → test rejection
+A **Report NCE** action sits in the case header (next to Log critical notification). Any non-conforming event — lost specimen, contamination, mislabel / ID mismatch, transport/temperature excursion, testing error — is raised here, **reusing the existing NCE module's inline report form** (`nce-report` / `nce-results-entry`): category (defaults to Pre-analytical for case-side events) + subcategory + severity + description, with the case's sample auto-linked, and a **Test disposition** choice — *Flag only — continue processing* or **Reject test** (which reuses OE sample rejection: sets sample status Rejected and cancels pending tests). A header NCE badge appears once one is logged.
+
+**Losing a specimen is always an NCE.** "Mark lost" is a specialization of Report NCE, pre-set to subcategory **Specimen lost** with disposition **Reject test — reason: specimen lost**. Saving it (a) records the NCE linked to the sample, (b) rejects the affected test(s) with reason "specimen lost", and (c) transitions the case to LOST_SPECIMEN (LOST_SPECIMEN_POSITIVE if past positive). **No new entity:** the NCE lives in the NCE module and links to this sample; rejection reuses the existing OE rejection-with-reason mechanism; "Specimen lost" is a Pre-analytical NCE subcategory (admin-configurable). Each step writes a Timeline event.
 
 ---
 
@@ -159,7 +168,7 @@ A Case is created by the Order-Entry post-save hook (`MicroCaseService.createCas
 ## 10. Ownership, accountability & permissions
 **No per-case ownership.** A case is open for days–weeks and worked in shifts; it is not "owned." Work is organized by state/urgency on the shared Worklist (M-07). Accountability is **per action** — `inoculated_by`, `event_by`, AST entered/overridden by, `*_released_by`, all immutable in `audit_trail`. `assigned_tech_user_id` stays optional/off-by-default (config flag for larger labs); an optional short-lived "working on this" lock prevents double-entry (concurrency, not ownership). The case header shows **"Last activity by"**, not an owner.
 
-**Permissions** (existing role bundles, not per-action keys): view via `micro.case.view`; bench edits via the Analyst bundle; final release / amend / reidentify via Supervisor/Manager. Every state-changing action is enforced server-side (403 on unauthorized) and audited; reads are not audited.
+**Permissions** (existing role bundles, not per-action keys): view via `micro.case.view`; bench edits via the Analyst bundle; final release / amend / reidentify via Supervisor/Manager. Report NCE and test rejection **reuse the existing NCE-create and sample-rejection permissions** (no new micro-specific keys). Every state-changing action is enforced server-side (403 on unauthorized) and audited; reads are not audited.
 
 ---
 
@@ -186,6 +195,9 @@ Case Detail (5 isolates × 100 AST results × 30 timeline events) renders < 1 s;
 - **AC-M04-14**: No per-case owner; "Last activity by" shown; `assigned_tech_user_id` unused unless the assignment flag is on; accountability per-action + audited.
 - **AC-M04-15**: Culture protocol modeled as a Method (no `culture_protocol` master); only new field is `source_inoculation_id`.
 - **AC-M04-16**: Server-side permission enforcement on every state-changing action; reagent-lot validation via M-12.
+- **AC-M04-17**: Report NCE action available in the header (reuses the NCE module's inline form, sample auto-linked); "Mark lost" raises a Specimen-lost NCE and rejects the test with reason "specimen lost" (reusing OE rejection), transitioning to LOST_SPECIMEN(_POSITIVE) — no new NCE/rejection entity.
+- **AC-M04-18**: All data-entry actions are inline section/row expansions, not pop-up modals (Principle 3). Bottle/plate IDs and analyzer card IDs are barcode-scannable. Reagent-lot pickers present lots FIFO (oldest-expiry first) with QC status, matching results-entry reagent selection; expired/locked lots are blocked.
+- **AC-M04-19**: At AST setup the breakpoint standard is selectable (defaults to the lab's active standard; any loaded standard/version choosable per run) and snapshotted on the run; switching the lab's active standard later does not change historical interpretations. Default active + loaded set managed in M-02.
 
 ## 14. References
 M-00 Parent; M-01 Reference Data; M-02 Breakpoints; M-03 Order-Entry hook; M-05 AST; M-06 Expert Rules; M-07 Worklist; M-08 Macros; M-11 Critical notify; M-12 Reagent linkage; reconciliation OGC-841; existing OE Sample/Order/Result/Method/test-rules/qc_lot tables. Mockup: `m-04-case-workbench-prototype.html`.

--- a/designs/microbiology/m-04-case-workbench-prototype.html
+++ b/designs/microbiology/m-04-case-workbench-prototype.html
@@ -98,6 +98,14 @@
   .fld .fh { font-size:11px; color:#6f6f6f; margin-top:3px; }
   details.ci > summary { cursor:pointer; list-style:none; font-size:14px; display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; }
   details.ci > summary::-webkit-details-marker { display:none; }
+  .inline-form { border:1px solid #b28600; border-left:4px solid #b28600; background:#fffdf4; margin-bottom:1rem; }
+  .inline-form .if-h { padding:0.6rem 1rem; font-size:15px; font-weight:600; border-bottom:1px solid #f0e6c8; }
+  .inline-form .if-h .if-sub { font-weight:400; color:#8d8d8d; font-size:12px; }
+  .inline-form .if-b { padding:0.8rem 1rem; }
+  .inline-form .if-f { padding:0.6rem 1rem; border-top:1px solid #f0e6c8; display:flex; gap:0.5rem; }
+  .scan-row { display:flex; gap:0.5rem; align-items:stretch; }
+  .scan-row input { flex:1; }
+  .btn-scan { white-space:nowrap; }
 </style>
 </head>
 <body>
@@ -110,14 +118,14 @@
   </div>
 </div>
 <div class="app-header"><span class="product">OpenELIS Global</span><span style="opacity:.6">|</span><span>Microbiology</span>
-  <div class="right"><span id="critBadge"></span><span>Olivia Mendez · Micro Tech</span></div>
+  <div class="right"><span id="critBadge"></span><span id="nceBadge"></span><span>Olivia Mendez · Micro Tech</span></div>
 </div>
 <div class="breadcrumbs"><a href="#">Home</a> / <a href="#">Microbiology</a> / <a href="#">Pending Cultures</a> / Case MC-2024-001234</div>
 <div class="case-header">
   <div class="title-row">
     <h1>Case MC-2024-001234</h1>
     <span class="stage-pill" id="stagePill">Received</span>
-    <div class="header-actions"><button class="btn b-ter b-sm" onclick="act('logCritical')">Log critical notification</button></div>
+    <div class="header-actions"><button class="btn b-ter b-sm" onclick="act('logCritical')">Log critical notification</button><button class="btn b-ter b-sm" onclick="act('reportNce')">Report NCE</button></div>
   </div>
   <div class="meta">
     <span><b>Lab #:</b> BC24-0892</span><span><b>Patient:</b> MARTINEZ, Carlos</span>
@@ -132,7 +140,7 @@
       <span class="dot d-part" style="width:11px;height:11px"></span> active
       <span class="dot d-none" style="width:11px;height:11px"></span> to do<br>Blue ring = current step.</div>
   </aside>
-  <main class="main"><div id="banner"></div><div id="sections"></div></main>
+  <main class="main"><div id="banner"></div><div id="inlineSlot"></div><div id="sections"></div></main>
 </div>
 <div id="modalRoot"></div>
 
@@ -145,7 +153,7 @@ var ABX = ['Ampicillin','Ceftriaxone','Meropenem','Gentamicin','Ciprofloxacin','
 
 var S; // state
 function fresh(){ return {
-  stage:'RECEIVED', critical:null, inoc:[], iso:[], tl:[], prelim:null, final:null, focus:'inoculation'
+  stage:'RECEIVED', critical:null, nce:null, inoc:[], iso:[], tl:[], prelim:null, final:null, focus:'inoculation'
 };}
 function logTL(cls,label,notes,by,auto){ S.tl.unshift({when:now(),cls:cls||'',label:label,notes:notes||'',by:by||'Olivia Mendez',auto:!!auto}); }
 
@@ -167,7 +175,7 @@ function seedMidway(){
 }
 
 /* ---------- derived helpers ---------- */
-var STAGE_LABEL={RECEIVED:'Received',INCUBATING:'Incubating',POSITIVE_SIGNAL:'Positive signal',GROWTH_DETECTED:'Growth detected',ORGANISM_ID:'Organism ID',AST_IN_PROGRESS:'AST in progress',READY_REVIEW:'Ready for review',PRELIM_REPORTED:'Preliminary reported',FINAL_REPORTED:'Final reported'};
+var STAGE_LABEL={RECEIVED:'Received',INCUBATING:'Incubating',POSITIVE_SIGNAL:'Positive signal',GROWTH_DETECTED:'Growth detected',ORGANISM_ID:'Organism ID',AST_IN_PROGRESS:'AST in progress',READY_REVIEW:'Ready for review',PRELIM_REPORTED:'Preliminary reported',FINAL_REPORTED:'Final reported',NO_GROWTH_FINAL:'No growth',LOST_SPECIMEN:'Specimen lost',REJECTED:'Rejected'};
 function hasGram(){ return S.iso.some(function(i){return i.gram;}); }
 function allIdentified(){ return S.iso.length>0 && S.iso.every(function(i){return i.org;}); }
 function astRuns(){ return S.iso.filter(function(i){return i.ast;}); }
@@ -184,6 +192,7 @@ function currentStep(){
 }
 function nextStepText(){
   var cs=currentStep();
+  if(['NO_GROWTH_FINAL','LOST_SPECIMEN','REJECTED'].indexOf(S.stage)>-1) return {done:true,txt:STAGE_LABEL[S.stage]+' — case closed via a non-conforming event; the test was rejected. See the Timeline for the NCE.',act:null};
   if(S.final) return {done:true,txt:'Final report released — case complete. Amendments are still possible.',act:null};
   switch(cs){
     case 'inoculation':
@@ -307,6 +316,7 @@ function secReports(){
 function render(refocus){
   document.getElementById('stagePill').textContent = STAGE_LABEL[S.stage]||S.stage;
   document.getElementById('critBadge').innerHTML = S.critical? '<span class="crit-badge">⚠ 1 critical '+(S.critical.ack?'ack':'open')+'</span>':'';
+  document.getElementById('nceBadge').innerHTML = S.nce? '<span class="crit-badge" style="background:#fff8e1;border-color:#b28600;color:#684e00">⚑ NCE: '+S.nce.sub+'</span>':'';
   document.getElementById('sidebar').innerHTML = progress();
   var ns = nextStepText();
   document.getElementById('banner').innerHTML = '<div class="nextstep'+(ns.done?' done':'')+'"><span style="font-size:18px">'+(ns.done?'✅':'🧭')+'</span><div class="txt"><b>Next step:</b> '+ns.txt+'</div>'+(ns.act?'<button class="btn b-pri b-sm" onclick="act(\''+ns.act[1].split(':')[0]+'\''+(ns.act[1].indexOf(':')>-1?','+ns.act[1].split(':')[1]:'')+')">'+ns.act[0]+'</button>':'')+'</div>';
@@ -320,24 +330,27 @@ function focusSection(key){
 }
 
 /* ---------- modal ---------- */
+// Inline action panel (not a pop-up modal) — renders in page flow per OpenELIS Principle 3.
 function openModal(title, fields, onSave, saveLabel){
-  var html='<div class="overlay" onclick="if(event.target===this)closeModal()"><div class="modal"><div class="mh">'+title+'</div><div class="mb">';
+  var html='<div class="inline-form"><div class="if-h">'+title+' <span class="if-sub">— inline, no pop-up</span></div><div class="if-b">';
   fields.forEach(function(f){
     html+='<div class="fld"><label>'+f.label+'</label>';
     if(f.type==='select'){ html+='<select id="f_'+f.key+'">'+f.options.map(function(o){return '<option>'+o+'</option>';}).join('')+'</select>'; }
     else if(f.type==='textarea'){ html+='<textarea id="f_'+f.key+'" rows="2">'+(f.value||'')+'</textarea>'; }
+    else if(f.type==='scan'){ html+='<div class="scan-row"><input id="f_'+f.key+'" value="'+(f.value||'')+'" placeholder="'+(f.ph||'')+'"><button type="button" class="btn b-ter btn-scan" onclick="scanInto(\'f_'+f.key+'\',\''+(f.scanVal||'')+'\')">⊞ Scan</button></div>'; }
     else { html+='<input id="f_'+f.key+'" value="'+(f.value||'')+'" placeholder="'+(f.ph||'')+'">'; }
     if(f.fh) html+='<div class="fh">'+f.fh+'</div>';
     html+='</div>';
   });
-  html+='</div><div class="mf"><button class="btn b-ghost" onclick="closeModal()">Cancel</button><button class="btn b-pri" id="modalSave">'+(saveLabel||'Save')+'</button></div></div></div>';
-  var root=document.getElementById('modalRoot'); root.innerHTML=html;
+  html+='</div><div class="if-f"><button class="btn b-pri" id="modalSave">'+(saveLabel||'Save')+'</button><button class="btn b-ghost" onclick="closeModal()">Cancel</button></div></div>';
+  var root=document.getElementById('inlineSlot'); root.innerHTML=html; root.scrollIntoView({behavior:'smooth',block:'center'});
   document.getElementById('modalSave').onclick=function(){
     var vals={}; fields.forEach(function(f){ vals[f.key]=document.getElementById('f_'+f.key).value; });
     closeModal(); onSave(vals);
   };
 }
-function closeModal(){ document.getElementById('modalRoot').innerHTML=''; }
+function closeModal(){ var r=document.getElementById('inlineSlot'); if(r) r.innerHTML=''; }
+function scanInto(id,val){ var el=document.getElementById(id); if(el){ el.value = val || ('SCAN-'+Math.floor(Math.random()*9000+1000)); el.focus(); } }
 
 /* ---------- actions ---------- */
 function act(name, arg){
@@ -345,21 +358,21 @@ function act(name, arg){
     case 'startInoculation':
       openModal('Start inoculation',[
         {key:'media',label:'Media *',type:'select',options:['FA — Aerobic Blood Bottle','FN — Anaerobic Blood Bottle','BAP','MacConkey','Chocolate agar']},
-        {key:'id',label:'Bottle / plate ID',ph:'FA24012'},
-        {key:'lot',label:'Reagent lot',type:'select',options:['FA-26-04-117 (exp 2026-08-15)','FN-26-04-118 (exp 2026-08-15)','BAP-26-04-211'],fh:'From the reagent inventory (M-12). Expired/locked lots are blocked.'}
+        {key:'id',label:'Bottle / plate ID',type:'scan',ph:'scan or type, e.g. FA24012',scanVal:'FA24012',fh:'Scan the bottle/plate barcode (or type it).'},
+        {key:'lot',label:'Reagent lot',type:'select',options:['BAP-26-04-088 · exp 2026-07-30 · QC pass  (oldest — use first)','FA-26-04-117 · exp 2026-08-15 · QC pass','FN-26-04-118 · exp 2026-08-15 · QC pass'],fh:'Sorted oldest-expiry first (FIFO) — same as results-entry reagent selection. QC status shown; expired/locked lots are blocked.'}
       ],function(v){ S.inoc.push({media:v.media,src:'Primary',id:v.id||'—',lot:v.lot.split(' (')[0]}); logTL('','Inoculated',v.media+' inoculated.','Olivia Mendez',true); if(S.stage==='RECEIVED') S.stage='INCUBATING'; S.focus='inoculation'; render(); });
       break;
     case 'addSubculture':
       openModal('Add subculture',[
         {key:'media',label:'Media *',type:'select',options:['BAP','MacConkey','Chocolate agar','CLED']},
         {key:'parent',label:'Subculture from *',type:'select',options:S.inoc.map(function(x){return x.id;})},
-        {key:'id',label:'Plate ID',ph:'SC-0892A'}
+        {key:'id',label:'Plate ID',type:'scan',ph:'scan or type, e.g. SC-0892A',scanVal:'SC-0892A',fh:'Scan the plate barcode (or type it).'}
       ],function(v){ S.inoc.push({media:v.media,src:'subculture ← '+v.parent,id:v.id||'—',lot:'—'}); logTL('sub','Subculture',v.media+' subcultured from '+v.parent+'.','Olivia Mendez',true); render(); });
       break;
     case 'markPositive':
       S.stage='POSITIVE_SIGNAL'; logTL('pos','Positive signal','Instrument flagged positive.','BacT/Alert auto',true); render(); break;
     case 'markNoGrowth':
-      S.stage='FINAL_REPORTED'; S.final=now(); logTL('rep','No growth — final','Finalized as no growth after full incubation.','Olivia Mendez',false); render(); break;
+      S.stage='NO_GROWTH_FINAL'; logTL('rep','No growth — final','Finalized as no growth after full incubation.','Olivia Mendez',false); render(); break;
     case 'addIsolate':
       openModal('Add isolate',[
         {key:'gram',label:'Gram stain *',ph:'Gram negative rods, many'},
@@ -383,8 +396,8 @@ function act(name, arg){
       openModal('Set up AST — Isolate '+i2.n,[
         {key:'panel',label:'AST panel *',type:'select',options:['GN-STD (Gram-negative standard)','GP-STD','GN-UR']},
         {key:'method',label:'Method *',type:'select',options:['VITEK 2','BD Phoenix','Disk diffusion']},
-        {key:'bp',label:'Breakpoint standard',type:'select',options:['EUCAST v14.0 (active)','CLSI M100 2024'],fh:'Snapshotted on the run — historical runs keep this version.'},
-        {key:'card',label:'Card / disc lot',type:'select',options:['AST-GN-26-04-117','AST-GP-26-03-090']}
+        {key:'bp',label:'Breakpoint standard',type:'select',options:['EUCAST v14.0  (lab default — active)','CLSI M100 2024  (loaded)','CLSI M100 2025  (loaded)','EUCAST v13.0  (loaded)'],fh:'Defaults to the lab active standard, but choose any loaded standard/version per run (CLSI or EUCAST). Snapshotted on the run — switching the lab default later never changes this run. Loaded set managed in Breakpoint Catalog (M-02).'},
+        {key:'card',label:'Card / disc lot',type:'select',options:['AST-GN-26-04-117 · exp 2026-09-01 · QC pass  (oldest — use first)','AST-GN-26-05-140 · exp 2026-10-15 · QC pass'],fh:'Sorted oldest-expiry first (FIFO); QC status shown; expired/locked lots blocked. The analyzer card ID is captured from the instrument link or scanned.'}
       ],function(v){ i2.ast={status:'Awaiting results',results:[]}; logTL('ast','AST setup',v.panel+' ('+v.method+') set up for Isolate '+i2.n+'.','Olivia Mendez',true); S.stage='AST_IN_PROGRESS'; S.focus='ast'; render(); });
       break;
     case 'receiveAst':
@@ -402,6 +415,24 @@ function act(name, arg){
         {key:'msg',label:'Substance of communication',type:'textarea',value:'Gram-negative rods in blood culture; possible sepsis. Recommend broad-spectrum coverage.'},
         {key:'ack',label:'Acknowledged at time of call?',type:'select',options:['Yes — read-back','Yes — verbal','No']}
       ],function(v){ S.critical={who:v.who,ack:v.ack.indexOf('Yes')===0}; logTL('crit','Critical called',v.who+' notified ('+v.method+'). '+(v.ack.indexOf('Yes')===0?'Acknowledged ('+v.ack+').':'Not yet acknowledged.'),'Olivia Mendez',false); render(false); });
+      break;
+    case 'reportNce':
+      openModal('Report non-conforming event (NCE)',[
+        {key:'cat',label:'Category',type:'select',options:['Pre-analytical','Analytical','Post-analytical']},
+        {key:'sub',label:'Subcategory *',type:'select',options:['Specimen lost','Specimen integrity / insufficient','Contamination','Mislabel / ID mismatch','Transport / temperature','Testing error','Other']},
+        {key:'sev',label:'Severity',type:'select',options:['Minor','Major','Critical']},
+        {key:'desc',label:'What happened',type:'textarea',value:''},
+        {key:'action',label:'Test disposition',type:'select',options:['Flag only — continue processing','Reject test — reason: specimen lost','Reject test — other reason'],fh:'Reuses OE sample rejection: rejecting sets the sample status to Rejected and cancels pending tests.'}
+      ],function(v){
+        S.nce={sub:v.sub};
+        logTL('note','NCE reported',v.cat+' / '+v.sub+' ('+v.sev+'). '+(v.desc||''),'Olivia Mendez',false);
+        if(v.action.indexOf('Reject')===0){
+          var lost = v.action.indexOf('specimen lost')>-1 || v.sub==='Specimen lost';
+          logTL('note','Test rejected',(lost?'Reason: specimen lost. ':'')+'Pending tests cancelled; NCE linked.','Olivia Mendez',true);
+          S.stage = lost ? 'LOST_SPECIMEN' : 'REJECTED';
+        }
+        render();
+      },'Save NCE');
       break;
     case 'addNote':
       openModal('Add note',[{key:'type',label:'Type',type:'select',options:['General note','Plate reading','Specimen lost']},{key:'txt',label:'Note',type:'textarea'}],

--- a/designs/microbiology/m-05-ast-entry-and-interpretation.md
+++ b/designs/microbiology/m-05-ast-entry-and-interpretation.md
@@ -1,500 +1,130 @@
 # M-05 AST Entry & Interpretation — Functional Requirements Specification
 
-**Version:** 1.0
-**Date:** 2026-05-15
-**Module:** Microbiology → Case Workbench → AST
-**Phase:** 1A
-**Owner:** Microbiology Module (M-00 parent)
+**Version:** 2.0 (consolidated — inline interactions per Principle 3; folds in the design-review/`/analyze` decisions; no separate addendum)
+**Date:** 2026-06-05
+**Module:** Microbiology → Case Workbench → AST (inline within M-04)
+**Surfaces:** inline panels within Case Detail (`/microbiology/case/:caseId`) and the Worklist AST grain (M-07)
+**Phase:** MVP-1A + Phase 1A+ (analyzer ingest)
 **Status:** Draft
+**Mockup:** `m-05-ast-entry-prototype.html` (inline, supersedes the modal mock)
 
-This spec covers the AST setup and result-entry modals invoked from Case Detail (M-04), the `BreakpointLookupService` that converts raw MIC / zone values to S/I/R, the manual override mechanism with audit, and analyzer-ingested AST results. Expert Rules (which can also drive overrides) live in M-06 and are out of Phase 1A scope.
-
----
-
-## 1. Overview
-
-### 1.1 Purpose
-
-The AST workflow has three modes that must coexist:
-
-1. **Manual entry** — tech reads disk diffusion zones or broth dilution MICs and types them in.
-2. **Analyzer-ingested** — VITEK 2 / Phoenix push AST results via the analyzer event channel (M-04 §10).
-3. **Hybrid** — automated AST result lands; tech reviews, possibly overrides one or more values manually.
-
-All three paths produce the same data shape: an `micro_ast_run` header row + per-antibiotic result rows in the existing `result` table (per crosswalk Q2). The `BreakpointLookupService` is called to interpret MIC or zone numbers into S/I/R values.
-
-### 1.2 Routes (modals invoked from M-04)
-
-| Surface | Trigger |
-|---------|---------|
-| AST Setup modal | "Set up AST" button on an Isolate in M-04 |
-| AST Edit modal | "Edit AST" button on an AST Run row in M-04 §6 |
-| AST Audit overlay | "View Audit" button on an AST Run row |
-| AST QC view (Phase 1B) | sidebar drilldown |
-
-### 1.3 Users
-
-| Role | Actions |
-|------|---------|
-| Microbiology Technician | Set up AST, enter results manually, apply overrides with justification |
-| Microbiology Supervisor | All of the above; review and revert overrides |
-| Lab Manager | All of the above |
-| Medical Technologist | Same as Tech for analyzer integration |
-
-### 1.4 Integration
-
-- **M-01 Reference Data** — AST Panels (which antibiotics to test) and Antibiotic Master.
-- **M-02 Breakpoint Catalog** — BreakpointLookupService queries this.
-- **M-04 Case Workbench Core** — invokes M-05 modals; consumes resulting AST Runs.
-- **M-06 Expert Rules** (Phase 1B) — applies post-AST-result overrides; M-05's override mechanism is the substrate.
-- **M-08 Macro Library** — override justification and AST comments are macro-enabled.
-- **M-12 Test → Reagent Linkage** — AST card / disc lot referenced per AST Run.
-- **M-04 §10 Analyzer event channel** — consumes AST_RESULT_AVAILABLE events.
+> Self-contained. Key decisions written inline: **AST setup and entry are inline section/row expansions, not modal pop-ups** (constitution Principle 3); **breakpoint standard is flexibly selectable per run and snapshotted**; **analyzer results ingest automatically — no manual import**; overrides preserve the original reading with inline revert + reading history; "no breakpoint" and QC-fail states are guided.
 
 ---
 
-## 2. AST Run data model
+## 1. Lab Context
+**Current State.** After an organism is identified, the tech sets up susceptibility testing — picks the antibiotic panel, runs it (disk diffusion read by eye, or an instrument like VITEK/Phoenix), and records each drug's MIC or zone and whether the organism is Susceptible / Intermediate / Resistant (S/I/R). Today those S/I/R calls are looked up by hand against CLSI or EUCAST breakpoint tables and transcribed from instrument printouts.
 
+**Pain.** Hand-looking-up breakpoints for 16+ drugs per isolate is slow and error-prone; transcription introduces mistakes caught late; and when the lab corrects an interpretation (e.g. an ESBL makes you report a cephalosporin R regardless of MIC), there's no clean record of the original value, who changed it, or why.
+
+**What Changes.** AST is done **inline on the case**: set up the run, and as MIC/zone values are entered (or pushed by the analyzer) the system interprets S/I/R against the chosen breakpoint standard automatically. Overrides are an inline row that **keeps the original value**, captures a reason, and is revertible. No hand lookups, no transcription, full audit.
+
+---
+
+## 2. Overview
+Three workflows, one data shape: **Manual** (tech types MIC/zone), **Analyzer** (instrument pushes results), **Hybrid** (analyzer lands, tech reviews/overrides). Each produces a `micro_ast_run` header + per-antibiotic rows in the existing `result` table (multi-reading), interpreted by the `BreakpointLookupService`.
+
+### 2.1 Surfaces (inline, not modals)
+- **AST setup** and **AST entry/results** render as **inline panels within the Case Detail AST section** (M-04 §4.5), and are reachable from the Worklist AST grain (M-07). Per Principle 3 there are **no pop-up modals**; the only inline-row expansion is the per-drug override. Modals are reserved for destructive confirmations (e.g. Clear All).
+
+### 2.2 Integration
+M-01 (panels, antibiotics) · M-02 (`BreakpointLookupService`, breakpoint standards) · M-04 (case/isolate context, AST section, analyzer event channel) · M-06 (Phase 1B expert rules use this override substrate) · M-08 (macro-enabled justification/comments) · M-12 (reagent/card lot, FIFO).
+
+### 2.3 Users
+Tech — set up, enter, override with justification. Supervisor — all of that + review/revert overrides + override a QC-fail flag.
+
+---
+
+## 3. Data model
 ```
 micro_ast_run
-├── run_id (UUID PK)
-├── case_id (FK to micro_case)
-├── isolate_id (FK to specific isolate VERSION — see M-04 §5 reidentification)
-├── ast_panel_id (FK to ast_panel)
-├── ast_panel_version (int, snapshot at run creation)
-├── breakpoint_standard_id (FK to breakpoint_standard)
-├── breakpoint_version (text, snapshot at run creation, e.g., "CLSI_M100_2024")
-├── method (enum: VITEK_2, BD_PHOENIX, SENSITITRE, DISK_DIFFUSION, ETEST, BROTH_MICRODILUTION, MANUAL)
-├── status (enum: PENDING_SETUP, IN_PROGRESS, READING, COMPLETE, QC_FAILED, RERUN_REQUIRED, INVALIDATED)
-├── analyzer_card_id (text, nullable — analyzer-side identifier when method is automated)
-├── reagent_lot_id (FK to qc_lot via M-12)
-├── started_at (timestamp)
-├── started_by (FK to user)
-├── completed_at (timestamp, nullable)
-├── invalidated_at (timestamp, nullable)
-├── invalidated_by (FK, nullable)
-├── invalidated_reason (enum, nullable)
-├── general_comments (text, macro-enabled, `ast` category)
-├── audit columns
+├── ast_run_id (PK)
+├── isolate_id (FK)
+├── ast_panel_id (FK) + panel_version (snapshot)
+├── method (enum: VITEK2, PHOENIX, DISK_DIFFUSION, ETEST, MANUAL_BROTH, …)
+├── breakpoint_standard_id (FK) + breakpoint_version (snapshot)   ← chosen at setup (§4)
+├── analyzer_card_id (text, nullable; scanned or from instrument link)
+├── reagent_lot_id (FK via M-12)
+├── status (PENDING_SETUP, IN_PROGRESS, READING, COMPLETE, QC_FAILED, RERUN_REQUIRED, INVALIDATED)
+└── audit columns                                              (Envers @Audited)
 
 result (existing OE table, extended via multi-reading)
-├── result_id (PK)
-├── (existing columns)
-├── micro_ast_run_id (FK to micro_ast_run, nullable — only set for AST results)
-├── antibiotic_id (FK to antibiotic_master, nullable — only set for AST results)
-├── readings (multi-reading per OE existing mechanism):
-│     ├── mic_value (numeric, nullable)
-│     ├── mic_unit (text, default "ug/mL")
-│     ├── zone_diameter (numeric, nullable, mm)
-│     ├── interpretation (enum: S, I, R, NS [non-susceptible], SDD [susceptible-dose-dependent])
-│     ├── source (enum: ANALYZER_AUTO, MANUAL_ENTRY, OVERRIDE)
-│     └── breakpoint_version (text, snapshot at interpretation time)
-└── audit columns
+├── micro_ast_run_id (FK, nullable — set only for AST results)
+├── antibiotic_id (FK)
+├── readings[]  (existing multi-reading mechanism)
+│     ├── mic / zone (numeric, nullable)
+│     ├── interpretation (S/I/R, nullable)
+│     ├── source (ANALYZER_AUTO, MANUAL_ENTRY, OVERRIDE)
+│     └── matched_by (ORGANISM / GROUP / SPECIMEN / NONE)  — interpretation provenance
+└── (current reading = latest; OVERRIDE supersedes for display/report)
 
-micro_ast_override (audit table)
-├── override_id (PK)
-├── result_id (FK to result row that was overridden)
-├── reading_id (FK to specific reading within the result row, since results are multi-reading)
-├── original_interpretation (enum)
-├── original_mic, original_zone (numeric, preserved)
-├── override_interpretation (enum)
-├── override_mic, override_zone (numeric, nullable — usually only interpretation changes)
-├── rule_id (FK to expert_rule_definition, nullable — null if manual override)
-├── rule_version (int, nullable, snapshot)
-├── justification (text, macro-enabled, `ast` category, required)
-├── overridden_at (timestamp)
-├── overridden_by (FK to user)
-├── reverted_at (timestamp, nullable — if a supervisor reverts the override)
-├── reverted_by (FK, nullable)
-├── revert_justification (text, nullable)
-└── audit columns
+micro_ast_override (audit)
+├── override_id (PK) · result_id (FK) · reading_id (FK)
+├── original_interpretation, override_interpretation
+├── original_mic/zone, override_mic/zone (nullable)
+├── rule_id (FK expert_rule_definition, nullable — null = manual)
+├── justification (text, macro `ast`) · overridden_by · overridden_at
+└── reverted_by, reverted_at (nullable)                       (Envers @Audited)
 ```
+**No new masters** — reuses the existing `result`/multi-reading mechanism and M-01/M-02/M-12 references.
 
 ---
 
-## 3. AST Setup modal
+## 4. AST setup (inline panel)
+Triggered by **Set up AST** on an identified isolate (disabled until `organism_id` is set). Fields:
 
-### 3.1 Trigger
+| Field | Control | Notes |
+|---|---|---|
+| AST panel | ComboBox (M-01), defaulted from `isolate.default_ast_panel_id` | "Default for {organism} + {specimen}. Override if needed." |
+| Method | Radio/select | VITEK 2 / Phoenix / Disk diffusion / Etest / Manual broth |
+| **Breakpoint standard** | ComboBox (M-02) | **Defaults to the lab's active standard, but any *loaded* standard/version is selectable per run** (CLSI or EUCAST; some labs mix by organism group or pin an older version during a transition). **Snapshotted** on the run — switching the lab default later never changes this run. Loaded/active set managed in M-02. |
+| Card / disc lot | ReagentLotPicker (M-12) | **FIFO** (oldest-expiry first), QC status shown, expired/locked blocked — same as results-entry reagent selection. |
+| Analyzer card ID | scan-or-type | Captured from the instrument link or **scanned**. |
 
-From M-04 Case Detail → Isolate tile → "Set up AST" button.
-
-Pre-condition: the Isolate has at least preliminary information (Gram stain or organism). The button is disabled otherwise (tooltip explains).
-
-### 3.2 Layout
-
-`ComposedModal` size `md`.
-
-```
-┌─ Set up AST — Isolate 1 (E. coli, eco) ─────────────────────────────────────┐
-│                                                                              │
-│  AST Panel: *                                                                │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ GN-STD — Gram-negative standard (16 antibiotics)                  ▼     │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│  Default for E. coli + blood specimen. Override if needed.                   │
-│                                                                              │
-│  Method: *                                                                   │
-│  (•) VITEK 2 AST-GN     ( ) Disk diffusion     ( ) Etest                    │
-│  ( ) BD Phoenix         ( ) Broth microdilution ( ) Manual                  │
-│                                                                              │
-│  Analyzer Card ID:                                                           │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ V2-CRD-2026-05-12-001                                                   │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│  Scan or enter the card barcode; required for analyzer-ingested methods      │
-│                                                                              │
-│  Breakpoint Standard: *                                                      │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ EUCAST v14.0 (active)                                              ▼   │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│  Defaults to the lab's active standard for the publisher                     │
-│                                                                              │
-│  Reagent Lot: *                                                              │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ VITEK GN AST card — Lot AST-GN-26-04-117 (expires 2026-08-15)     ▼   │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│  Filter to unlocked, unexpired lots only                                     │
-│                                                                              │
-│  ──────────────────────────────────────────────────────────────────────────   │
-│                                                                              │
-│  [Cancel]                                                            [Save]  │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-### 3.3 Fields
-
-| Field | Component | Required | Notes |
-|-------|-----------|----------|-------|
-| AST Panel | `ComboBox` referencing active `ast_panel` records, defaulted from Isolate.default_ast_panel_id | Yes | Helper text: "Default for [organism] + [specimen]. Override if needed." |
-| Method | `RadioButtonGroup` | Yes | VITEK_2, BD_PHOENIX, SENSITITRE, DISK_DIFFUSION, ETEST, BROTH_MICRODILUTION, MANUAL |
-| Analyzer Card ID | `TextInput` | Yes for analyzer methods | Card barcode |
-| Breakpoint Standard | `ComboBox` referencing breakpoint_standard, defaulted to lab's active standard for publisher | Yes | Helper text: "Defaults to the lab's active standard." Tech can pick CLSI vs EUCAST per run if both active |
-| Reagent Lot | `ComboBox` filtered to active reagent lots for the chosen method's reagent type | Yes | Validated via M-12 |
-
-### 3.4 Validation on save
-
-- All required fields populated.
-- Reagent lot is unlocked AND not expired (M-12 service call).
-- For analyzer methods: card ID format matches the analyzer's expected pattern (regex per analyzer profile).
-- AST Panel version is snapshotted into the run.
-- Breakpoint Standard version is snapshotted into the run.
-
-### 3.5 On save
-
-1. Write `micro_ast_run` row with `status = PENDING_SETUP`, all snapshotted values.
-2. Write Timeline event AST_SETUP referencing the run.
-3. Transition Case stage to AST_IN_PROGRESS if currently in ORGANISM_ID.
-4. Pre-populate `result` rows for each antibiotic in the AST Panel, with `micro_ast_run_id` set, `interpretation = null`, ready to receive readings.
-5. Close modal; return to Case Detail.
-
-If method = MANUAL or DISK_DIFFUSION: the user typically then clicks "Edit AST" to enter results. If method = VITEK_2 or PHOENIX or SENSITITRE: the analyzer will push results via event channel.
+On save: write `micro_ast_run` (`status = PENDING_SETUP`, snapshotted standard/version + panel/version), pre-populate `result` rows for each panel antibiotic (`interpretation = null`), write an `AST_SETUP` Timeline event (M-04), transition the case to AST_IN_PROGRESS.
 
 ---
 
-## 4. AST Edit modal
+## 5. AST entry & results (inline)
+The run renders as an inline table in the case AST section: **Antibiotic · MIC · Zone · Interp · Source · (override)**. Run header shows panel · method · breakpoint standard · lot · status, and the **matched-breakpoint level** per the lookup.
 
-### 4.1 Trigger
+### 5.1 Interpretation
+On MIC/zone change, the frontend calls `BreakpointLookupService.lookup(organism_id, antibiotic_id, method, breakpoint_standard_id, specimen_type_id)` → thresholds + `matched_by`. The interpretation auto-fills and the **matched level (specimen-specific → organism → group → none)** is shown so the user trusts the result.
+- **No breakpoint (`matched_by = NONE`):** the Interp field becomes a manual select with a **"no standard breakpoint — interpret per local SOP"** guidance note (not just an empty enabled dropdown).
 
-From Case Detail → AST Run row → "Edit AST" button. Or from AST Worklist → row action.
+### 5.2 Override — inline row, preserves original, revertible
+Selecting a row's **Override** toggles an **inline override row directly beneath it** (not a modal, not an accordion): new interpretation + **justification** (macro `ast`, required). On save: a new `OVERRIDE` reading is appended (original ANALYZER/MANUAL reading is **never deleted**), a `micro_ast_override` audit row records original→override + who/when/why, and the row's current interpretation becomes the override. The overridden row offers **"show original"** (inline reading history: original→override, rule if any, actor, time) and a **Revert to original/analyzer value** action (supervisor/`micro.ast.override`, with justification).
 
-### 4.2 Layout
+### 5.3 Analyzer results — automatic, no manual import
+Analyzer results arrive via the M-04 event channel (`AST_RESULT_AVAILABLE`), populate the readings (`source = ANALYZER_AUTO`), and the run flips to COMPLETE — **automatically**. A run still awaiting results shows an **"awaiting analyzer results"** state. There is **no "Import from analyzer" button**; a push that fails to match is reconciled on **Admin → Stuck analyzer events** (M-04). The tech may still override any analyzer row inline.
 
-`ComposedModal` size `xl`.
+### 5.4 Toolbar actions
+- **Apply Defaults** — re-run the lookup against the current standard for every row (e.g. after the lab changes its active standard). 
+- **Clear All** — destructive; the one place a **confirmation modal** is used; writes an audit row.
+- (No "Import from analyzer" action — see §5.3.)
 
-```
-┌─ Edit AST — Isolate 1 (E. coli) — Run #1 ───────────────────────────────────┐
-│                                                                              │
-│  Panel: GN-STD VITEK 2  ·  Method: VITEK 2 AST-GN  ·  Card: V2-CRD-...001    │
-│  Breakpoint: EUCAST v14.0  ·  Lot: AST-GN-26-04-117  ·  Status: Complete    │
-│  Started: 2026-05-12 07:54 by Olivia  ·  Completed: 2026-05-12 11:45 (auto) │
-│                                                                              │
-│  Quick actions: [Import from Analyzer] [Apply Defaults] [Clear All]         │
-│                                                                              │
-│  ┌────────────────────────────────────────────────────────────────────────┐  │
-│  │ Antibiotic       │ MIC      │ Zone │ Interp │ Override?  │ Source     │ │
-│  ├──────────────────┼──────────┼──────┼────────┼────────────┼────────────┤ │
-│  │ Ampicillin       │ > 32     │  —   │ R      │            │ ANALYZER   │ │
-│  │ Amox/Clav        │ 16       │  —   │ R      │            │ ANALYZER   │ │
-│  │ TMP/SMX          │ ≤ 0.5    │  —   │ S      │            │ ANALYZER   │ │
-│  │ Cefazolin        │ 8        │  —   │ R      │            │ ANALYZER   │ │
-│  │ Ceftriaxone      │ 16       │  —   │ R      │ [☑]        │ ANALYZER   │ │
-│  │ Cefepime         │ 2        │  —   │ I      │            │ ANALYZER   │ │
-│  │ Meropenem        │ ≤ 0.25   │  —   │ S      │            │ ANALYZER   │ │
-│  │ Ertapenem        │ ≤ 0.25   │  —   │ S      │            │ ANALYZER   │ │
-│  │ Ciprofloxacin    │ 2        │  —   │ I      │            │ ANALYZER   │ │
-│  │ Levofloxacin     │ 1        │  —   │ S      │            │ ANALYZER   │ │
-│  │ Gentamicin       │ 4        │  —   │ S      │            │ ANALYZER   │ │
-│  │ Amikacin         │ 4        │  —   │ S      │            │ ANALYZER   │ │
-│  │ Tobramycin       │ ≤ 1      │  —   │ S      │            │ ANALYZER   │ │
-│  │ Fosfomycin       │ ≤ 32     │  —   │ S      │            │ ANALYZER   │ │
-│  │ Nitrofurantoin   │ ≤ 16     │  —   │ S      │            │ ANALYZER   │ │
-│  │ Aztreonam        │ 8        │  —   │ R      │            │ ANALYZER   │ │
-│  └──────────────────┴──────────┴──────┴────────┴────────────┴────────────┘ │
-│                                                                              │
-│  ┌─ Override on Ceftriaxone (checkbox selected above) ─────────────────────┐ │
-│  │ Original: R (MIC 16, EUCAST 14.0)                                       │ │
-│  │ New interpretation: R (unchanged — flagged for ESBL)                    │ │
-│  │ Justification: *                                                         │ │
-│  │ ┌──────────────────────────────────────────────────────────────────────┐ │ │
-│  │ │ .esblc                                                               │ │ │
-│  │ └──────────────────────────────────────────────────────────────────────┘ │ │
-│  │ Macros: `ast` (type . for shortcuts)                                    │ │
-│  └─────────────────────────────────────────────────────────────────────────┘ │
-│                                                                              │
-│  General AST Comments:                                                       │
-│  ┌────────────────────────────────────────────────────────────────────────┐  │
-│  │ ESBL phenotype confirmed by combined disk testing.                     │  │
-│  └────────────────────────────────────────────────────────────────────────┘  │
-│  Macros: `ast`                                                              │
-│                                                                              │
-│  ──────────────────────────────────────────────────────────────────────────   │
-│                                                                              │
-│  [Cancel]                                                            [Save]  │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-**Per memory** `feedback_result_entry_panel_inline_rows`: the override section appears as an inline row below the result table when the Override checkbox is selected — not wrapped in an Accordion.
-
-### 4.3 Result row interaction
-
-Each row of the antibiotics DataTable:
-
-- **MIC column** — `NumberInput` or `TextInput` accepting WHONET-style values (`≤`, `<`, `>`, `≥`, exact). For VITEK-imported, displays the analyzer value. For Manual / Disk Diffusion, the tech types.
-- **Zone column** — `NumberInput` in mm for Disk Diffusion method.
-- **Interp** — Auto-calculated by `BreakpointLookupService` when MIC or Zone changes. User can override.
-- **Override** — `Checkbox`; when selected, the inline override section appears below the table for that row.
-- **Source** — Read-only badge: ANALYZER, MANUAL, OVERRIDE.
-
-### 4.4 BreakpointLookupService integration
-
-When the user enters or modifies an MIC or zone value:
-
-1. Frontend calls `BreakpointLookupService.lookup(isolate.organism_id, antibiotic_id, method, breakpoint_standard_id, specimen_type_id)`.
-2. Service returns thresholds + `matched_by`.
-3. Frontend computes interpretation per the rules in M-02 §6.3.
-4. Interpretation appears in the Interp column.
-5. If `matched_by = NONE`, Interp dropdown is enabled for manual selection with a "no breakpoint" badge.
-
-### 4.5 Override mechanism
-
-The Override checkbox toggles inline override entry below the row. Required fields when override is on:
-
-- **New interpretation** — Dropdown S / I / R / NS / SDD
-- **Justification** — `MacroTextarea`, `ast` category, required
-
-On save:
-
-1. The Reading associated with the result row gets a new entry: `source = OVERRIDE`, `interpretation = override_value`.
-2. A `micro_ast_override` row is written capturing original vs. new, justification, user, timestamp.
-3. The result row's "current" interpretation (displayed in reports and downstream) is the OVERRIDE reading. The original ANALYZER or MANUAL reading remains accessible.
-
-### 4.6 Apply Defaults action
-
-For analyzer-ingested AST: re-runs BreakpointLookupService against the current breakpoint standard for every antibiotic. Useful when the lab changes the active standard after results arrived.
-
-For Manual / Disk Diffusion: no-op (no analyzer values to reinterpret).
-
-### 4.7 Import from Analyzer action
-
-For an AST Run with method = VITEK_2 / PHOENIX / SENSITITRE: triggers a pull from the analyzer event channel for any unprocessed AST_RESULT_AVAILABLE events matching the card ID. Used when the event channel had a backlog or the tech wants to manually trigger ingestion.
-
-### 4.8 Clear All action
-
-Confirmation dialog. Clears all result rows back to empty. Used when the lab decides to invalidate and re-do an AST Run without setting up a new run. Writes audit row.
-
-### 4.9 QC failure handling
-
-If during analyzer ingestion an AST_QC_FAIL event is received:
-
-- AST Run `status` → QC_FAILED.
-- A banner appears in the modal: "QC organism on this card failed. Results cannot be released. Re-run AST against fresh card."
-- Save is disabled until either: (a) user manually invalidates the run with a reason and starts a fresh AST Setup, OR (b) supervisor overrides the QC failure flag (with documented reason).
-
-### 4.10 Save behavior
-
-On Save:
-
-1. Persist all changes (new readings, overrides, comments).
-2. If AST Run status transitions to COMPLETE, write Timeline event AST_RESULT_RECEIVED with summary.
-3. Trigger expert rule evaluation (Phase 1B — M-06).
-4. Return to Case Detail.
+### 5.5 QC-fail handling
+On an `AST_QC_FAIL` event the run shows a **banner** and disables save, with explicit inline actions: **Invalidate & start a new AST run**, and (supervisor) **Override QC flag** with justification. (No silent dead-end.)
 
 ---
 
-## 5. AST Audit overlay
-
-Triggered by "View Audit" on an AST Run row. Side panel slides in from the right showing:
-
-```
-┌─ AST Run #1 Audit ───────────────────────────────────────────────────────────┐
-│                                                                              │
-│  Run setup:                                                                  │
-│  2026-05-12 07:54  Olivia  · Panel: GN-STD · Method: VITEK 2                │
-│                       Breakpoint: EUCAST v14.0 · Lot: AST-GN-26-04-117      │
-│                                                                              │
-│  Result ingest:                                                              │
-│  2026-05-12 11:45  Analyzer auto · 16 antibiotics                           │
-│                                                                              │
-│  Overrides:                                                                  │
-│  2026-05-12 12:03  Olivia  · Ceftriaxone: R → R (ESBL flag, justification)  │
-│  2026-05-12 14:55  Dr. Adeyemi  · Gentamicin: S → R (ESBL cascade)         │
-│                                                                              │
-│  Reading history per antibiotic (expand to see all):                         │
-│  Ceftriaxone:                                                                │
-│    R (OVERRIDE, 2026-05-12 12:03, ESBL flag)                                │
-│    R (ANALYZER, 2026-05-12 11:45, EUCAST v14.0, MIC 16)                     │
-│  Gentamicin:                                                                 │
-│    R (OVERRIDE, 2026-05-12 14:55, cascade rule, justification)              │
-│    S (ANALYZER, 2026-05-12 11:45, EUCAST v14.0, MIC 4)                      │
-│                                                                              │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-Audit is read-only. Reverts are done from the main AST Edit modal (supervisor selects the override row, clicks revert, provides justification).
+## 6. Override conventions, audit, permissions
+Original-value preservation is mandatory (§5.2). Override types: manual (rule_id null) and expert-rule (M-06, Phase 1B). **Permissions** (existing bundles, no per-action keys): enter results — Analyst; override / revert — `micro.ast.override` (supervisor); QC-flag override — supervisor. Every override/revert/QC action is audited (`micro_ast_override` + `audit_trail`); `micro_ast_run` and the override table are `@Audited` (Envers).
 
 ---
 
-## 6. Manual entry workflow
+## 7. Acceptance criteria
+- **AC-M05-01**: AST setup and entry are **inline panels/rows, not modals** (Principle 3); the only modal is the Clear-All confirmation.
+- **AC-M05-02**: Setup snapshots panel/version + breakpoint standard/version; **breakpoint standard is selectable per run** (defaults to active; any loaded standard/version) and a later change to the lab default does not alter historical runs.
+- **AC-M05-03**: MIC/zone entry auto-interprets via `BreakpointLookupService`; the matched level is shown; `matched_by = NONE` gives manual select + local-SOP guidance.
+- **AC-M05-04**: Override is an inline row requiring justification; original reading preserved; `micro_ast_override` written; **revert** available to supervisors; inline reading-history ("show original") present.
+- **AC-M05-05**: Analyzer results ingest automatically (no manual import); awaiting-results state shown; unmatched pushes go to the stuck-events admin page.
+- **AC-M05-06**: Card/disc lot uses FIFO + QC like results-entry; card ID scannable; expired/locked lots blocked (M-12).
+- **AC-M05-07**: QC-fail shows a banner with Invalidate-&-start-new and supervisor QC-override (justified); save blocked until resolved.
+- **AC-M05-08**: All override/revert/QC actions audited; entities `@Audited`.
 
-For method = MANUAL or DISK_DIFFUSION, the workflow differs:
+## 8. i18n keys (pattern `micro.ast.*`)
+~60–80 keys: setup field labels + helpers, breakpoint-standard helper, table headers, interp values, matched-level labels, no-breakpoint guidance, override fields + revert, awaiting-results, QC-fail banner + actions, Apply-Defaults / Clear-All, error strings. (Maintained with implementation.)
 
-- AST Setup writes the AST Run with `status = PENDING_SETUP`.
-- Tech opens AST Edit and manually types each antibiotic's MIC value (for broth) or zone diameter (for disk).
-- Frontend calls BreakpointLookupService on each input change; auto-fills the Interp dropdown.
-- Tech can override Interp directly (e.g., for "no breakpoint" antibiotics where the lab has a local SOP).
-- Tech saves; AST Run `status` → COMPLETE.
-
----
-
-## 7. Override conventions
-
-### 7.1 Override types
-
-| Type | Source | Trigger |
-|------|--------|---------|
-| Manual override | `source = OVERRIDE`, `rule_id = NULL` | Tech / supervisor selects Override checkbox in AST Edit modal |
-| Expert rule override (Phase 1B) | `source = OVERRIDE`, `rule_id = <rule>`, `rule_version = <version>` | Expert Rules Engine applies on AST Run state change |
-| Revert | Existing override row marked `reverted_at` | Supervisor reverts an existing override |
-
-### 7.2 Original-value preservation
-
-The original ANALYZER or MANUAL reading is never deleted. The result row carries an immutable readings list; OVERRIDE is added as a new reading, not a replacement. The "current" value displayed is the most recent reading; the audit shows all readings.
-
-### 7.3 Override permissions
-
-- `micro.ast.override` required to apply an override.
-- `micro.report.final` required to revert an override (supervisor-level decision).
-
----
-
-## 8. Acceptance criteria
-
-- **AC-M05-01**: AST Setup modal validates all required fields including reagent lot.
-- **AC-M05-02**: AST Setup snapshots panel_version and breakpoint_version into the AST Run.
-- **AC-M05-03**: Card ID format validates per analyzer profile regex.
-- **AC-M05-04**: Reagent lot validation rejects locked or expired lots.
-- **AC-M05-05**: AST Run creation transitions Case from ORGANISM_ID to AST_IN_PROGRESS.
-- **AC-M05-06**: Pre-populated `result` rows match the AST Panel's antibiotic list.
-- **AC-M05-07**: BreakpointLookupService called on each MIC / zone input; correct precedence applied.
-- **AC-M05-08**: Interpretation computed correctly for MIC (LE comparator) and disk diffusion (GE comparator).
-- **AC-M05-09**: "No breakpoint match" displays prompt for manual interpretation.
-- **AC-M05-10**: Override checkbox toggles inline override entry inline below the row (not in Accordion, per memory).
-- **AC-M05-11**: Override save writes `micro_ast_override` row preserving original value.
-- **AC-M05-12**: AST Run status transitions: PENDING_SETUP → IN_PROGRESS (manual entry started) → COMPLETE (all rows have interpretation).
-- **AC-M05-13**: Analyzer-ingested results write OVERRIDE-able results via the multi-reading mechanism.
-- **AC-M05-14**: Apply Defaults re-interprets all rows against the current breakpoint standard.
-- **AC-M05-15**: AST QC fail blocks save until invalidated or supervisor-overridden.
-- **AC-M05-16**: Audit overlay displays all reading history per antibiotic.
-- **AC-M05-17**: NFR-02 (scale, < 1s panel render with 16 antibiotics).
-- **AC-M05-18**: NFR-04 (a11y) — all interactions keyboard-reachable.
-- **AC-M05-19**: NFR-08 (security) — all overrides require permission server-side.
-
----
-
-## 9. i18n keys
-
-Estimated 60-80 keys. Examples:
-
-```
-micro.ast.setup.modal.title                    "Set up AST — {{isolateLabel}}"
-micro.ast.setup.field.panel.label              "AST Panel"
-micro.ast.setup.field.panel.helper.organismDefault "Default for {{organism}} + {{specimen}} specimen. Override if needed."
-micro.ast.setup.field.method.label             "Method"
-micro.ast.setup.field.method.option.vitek2     "VITEK 2"
-micro.ast.setup.field.method.option.phoenix    "BD Phoenix"
-micro.ast.setup.field.method.option.sensititre "Sensititre"
-micro.ast.setup.field.method.option.disk       "Disk diffusion"
-micro.ast.setup.field.method.option.etest      "Etest"
-micro.ast.setup.field.method.option.broth      "Broth microdilution"
-micro.ast.setup.field.method.option.manual     "Manual"
-micro.ast.setup.field.cardId.label             "Analyzer Card ID"
-micro.ast.setup.field.cardId.helper            "Scan or enter the card barcode"
-micro.ast.setup.field.standard.label           "Breakpoint Standard"
-micro.ast.setup.field.standard.activeHint      "(active)"
-micro.ast.setup.field.lot.label                "Reagent Lot"
-micro.ast.setup.field.lot.helper               "Filter to unlocked, unexpired lots only"
-micro.ast.setup.error.lotLocked                "Reagent lot is locked by QC"
-micro.ast.setup.error.lotExpired               "Reagent lot expired on {{date}}"
-micro.ast.edit.modal.title                     "Edit AST — {{isolateLabel}} — Run #{{runNumber}}"
-micro.ast.edit.header.panel                    "Panel"
-micro.ast.edit.header.method                   "Method"
-micro.ast.edit.header.card                     "Card"
-micro.ast.edit.header.breakpoint               "Breakpoint"
-micro.ast.edit.header.lot                      "Lot"
-micro.ast.edit.header.status                   "Status"
-micro.ast.edit.action.importAnalyzer           "Import from Analyzer"
-micro.ast.edit.action.applyDefaults            "Apply Defaults"
-micro.ast.edit.action.clearAll                 "Clear All"
-micro.ast.edit.table.column.antibiotic         "Antibiotic"
-micro.ast.edit.table.column.mic                "MIC"
-micro.ast.edit.table.column.zone               "Zone"
-micro.ast.edit.table.column.interp             "Interp"
-micro.ast.edit.table.column.override           "Override?"
-micro.ast.edit.table.column.source             "Source"
-micro.ast.edit.interp.S                        "S"
-micro.ast.edit.interp.I                        "I"
-micro.ast.edit.interp.R                        "R"
-micro.ast.edit.interp.NS                       "NS"
-micro.ast.edit.interp.SDD                      "SDD"
-micro.ast.edit.interp.noBreakpoint             "No breakpoint"
-micro.ast.edit.source.analyzer                 "ANALYZER"
-micro.ast.edit.source.manual                   "MANUAL"
-micro.ast.edit.source.override                 "OVERRIDE"
-micro.ast.edit.override.title                  "Override on {{antibiotic}}"
-micro.ast.edit.override.original               "Original"
-micro.ast.edit.override.newInterp              "New interpretation"
-micro.ast.edit.override.justification.label    "Justification"
-micro.ast.edit.override.justification.required "Justification required for overrides"
-micro.ast.edit.generalComments.label           "General AST Comments"
-micro.ast.edit.qcFailed.banner                 "QC organism on this card failed. Results cannot be released. Re-run AST against fresh card."
-micro.ast.audit.title                          "AST Run #{{runNumber}} Audit"
-micro.ast.audit.section.setup                  "Run setup"
-micro.ast.audit.section.ingest                 "Result ingest"
-micro.ast.audit.section.overrides              "Overrides"
-micro.ast.audit.section.readingHistory         "Reading history per antibiotic"
-... (further keys at implementation)
-```
-
----
-
-## 10. Open verification items
-
-- Confirm `result` table's multi-reading extension mechanism specifics (per crosswalk Q2 verification).
-- Confirm `qc_lot` table's reagent linkage path (per M-12 dependency).
-- Confirm analyzer profile pattern for card ID regex (per crosswalk Q3 verification).
-
----
-
-## 11. References
-
-- M-00 Microbiology Module Parent Specification
-- M-04 Case Workbench Core (invokes M-05 modals; consumes AST Runs)
-- M-02 Breakpoint Catalog (`BreakpointLookupService`)
-- M-01 AMR Reference Data (AST Panel, Antibiotic Master)
-- M-06 Expert Rules Engine (Phase 1B; uses override substrate)
-- M-08 Macro Library (`ast` category)
-- M-12 Test → Reagent Linkage (reagent_lot_id)
-- `amr-crosswalk-working.md` Q2 (AST results data model)
-- `amr-micro-narrative-v1-for-devs.md` Phase 3 + 4
+## 9. References
+M-01 (panels/antibiotics) · M-02 (BreakpointLookupService, standards, flexibility) · M-04 §4.5/§7 (AST section, analyzer channel, stuck-events) · M-06 (Phase 1B override substrate) · M-08 (macros) · M-12 (reagent FIFO) · OGC-312/813 (NCE/disposition reuse, for the rejection family) · `m-05-ast-entry-prototype.html`.

--- a/designs/microbiology/m-05-ast-entry-prototype.html
+++ b/designs/microbiology/m-05-ast-entry-prototype.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-05 AST Entry — Inline Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+  body { background:#f4f4f4; margin:0; font-family:'IBM Plex Sans',sans-serif; color:#161616; }
+  .preview-banner { background:#0f62fe; color:#fff; padding:6px 1rem; font-size:12px; font-family:monospace; }
+  .preview-banner strong { background:#fff; color:#0f62fe; padding:1px 6px; border-radius:2px; margin:0 4px; }
+  .wrap { padding:1.25rem 2rem; max-width:1000px; }
+  .card { background:#fff; border:1px solid #e0e0e0; padding:1rem 1.25rem; margin-bottom:1rem; }
+  h1 { font-size:22px; font-weight:300; margin:0 0 0.25rem; }
+  .sub { font-size:13px; color:#6f6f6f; margin:0 0 1rem; }
+  .help { font-size:12px; color:#6f6f6f; margin:0.25rem 0 0.75rem; } .help .ico{ color:#0f62fe; font-weight:700; margin-right:4px; }
+  .runhdr { display:flex; gap:1.25rem; flex-wrap:wrap; align-items:flex-end; margin-bottom:0.5rem; }
+  .fld label { display:block; font-size:11px; color:#525252; text-transform:uppercase; letter-spacing:0.4px; font-weight:600; margin-bottom:4px; }
+  .fld select, .fld input { padding:0.4rem 0.6rem; font-size:13px; border:0; border-bottom:1px solid #8d8d8d; background:#f4f4f4; font-family:inherit; }
+  .fh { font-size:11px; color:#6f6f6f; margin-top:4px; max-width:520px; }
+  table.t { width:100%; border-collapse:collapse; font-size:13px; }
+  table.t th { text-align:left; padding:0.45rem 0.6rem; background:#f4f4f4; font-weight:600; border-bottom:1px solid #e0e0e0; font-size:11px; text-transform:uppercase; letter-spacing:0.4px; color:#525252; }
+  table.t td { padding:0.4rem 0.6rem; border-bottom:1px solid #eee; vertical-align:middle; }
+  tr.ovr td { background:#fff8e1; }
+  tr.ovrdetail td { background:#f6f2ff; }
+  tr.histdetail td { background:#f4f4f4; color:#525252; font-size:12px; }
+  .mic-in { width:74px; padding:0.25rem 0.4rem; border:1px solid #8d8d8d; background:#fff; font-family:inherit; font-size:13px; }
+  .interp { display:inline-block; padding:1px 8px; border-radius:4px; font-weight:700; font-size:11px; min-width:16px; text-align:center; }
+  .interp.S{background:#a7f0ba;color:#044317;} .interp.I{background:#fdd13a;color:#161616;} .interp.R{background:#ffd7d9;color:#750e13;} .interp.NB{background:#e0e0e0;color:#525252;}
+  .src { font-size:10px; color:#6f6f6f; }
+  .matched { font-size:10px; color:#0f62fe; }
+  .lnk { color:#0f62fe; cursor:pointer; font-size:12px; }
+  .btn { display:inline-flex; align-items:center; gap:0.35rem; padding:0.4rem 0.8rem; font-size:13px; font-family:inherit; border:1px solid transparent; cursor:pointer; }
+  .b-pri{background:#0f62fe;color:#fff;} .b-ter{background:transparent;color:#0f62fe;border-color:#0f62fe;} .b-ghost{background:transparent;color:#0f62fe;} .b-ghost:hover,.b-ter:hover{background:#e5e5e5;} .b-amber{background:#f1c21b;color:#161616;font-weight:600;} .b-sm{padding:0.25rem 0.7rem;font-size:12px;}
+  .toolbar { display:flex; gap:0.5rem; margin:0.75rem 0; flex-wrap:wrap; align-items:center; }
+  .banner { padding:0.7rem 1rem; border-left:4px solid #da1e28; background:#fff1f1; font-size:13px; margin-bottom:0.75rem; display:flex; gap:1rem; align-items:center; }
+  .banner.ok { border-left-color:#24a148; background:#defbe6; }
+  .ovrbox { padding:0.5rem 0.6rem; display:flex; gap:0.75rem; align-items:flex-end; flex-wrap:wrap; }
+  .ovrbox textarea { min-width:300px; flex:1; border:1px solid #8d8d8d; font-family:inherit; font-size:13px; padding:0.3rem; }
+  .tag-note { font-size:11px; color:#6f6f6f; }
+  .toast { position:fixed; bottom:20px; left:50%; transform:translateX(-50%); background:#161616; color:#fff; padding:0.6rem 1rem; font-size:13px; border-radius:4px; z-index:50; }
+</style>
+</head>
+<body>
+<div class="preview-banner">M-05 AST Entry · <strong>Inline prototype</strong> · no pop-up modals — setup &amp; entry are inline; override expands in the row. Auto-interpret · flexible breakpoint · no manual import.</div>
+<div class="wrap">
+  <div class="card">
+    <h1>AST Run #1 — Isolate 1 · <em>Escherichia coli</em></h1>
+    <p class="sub">Case MC-2024-001234 · Blood · MARTINEZ, Carlos</p>
+    <div id="qcbanner"></div>
+    <div class="runhdr">
+      <div class="fld"><label>Panel</label><select><option>GN-STD (16 antibiotics)</option><option>GN-UR (8)</option></select></div>
+      <div class="fld"><label>Method</label><select><option>VITEK 2</option><option>Disk diffusion</option><option>Etest</option></select></div>
+      <div class="fld"><label>Breakpoint standard</label>
+        <select id="std" onchange="changeStd(this.value)">
+          <option value="EUCAST v14.0">EUCAST v14.0  (lab default — active)</option>
+          <option value="CLSI M100 2024">CLSI M100 2024  (loaded)</option>
+          <option value="CLSI M100 2025">CLSI M100 2025  (loaded)</option>
+          <option value="EUCAST v13.0">EUCAST v13.0  (loaded)</option>
+        </select>
+      </div>
+      <div class="fld"><label>Card / disc lot</label><select><option>AST-GN-26-04-117 · exp 2026-09-01 · QC pass  (oldest — use first)</option><option>AST-GN-26-05-140 · exp 2026-10-15 · QC pass</option></select></div>
+    </div>
+    <p class="fh">Breakpoint standard <strong>defaults to the lab active standard but any loaded standard/version is selectable per run</strong> (CLSI or EUCAST) — try changing it and watch the interpretations re-compute. It's snapshotted on the run, so switching the lab default later never changes this run. Card lot uses FIFO + QC like results-entry; the analyzer card ID is scanned or read from the instrument link.</p>
+    <p class="help"><span class="ico">ⓘ</span> Enter MIC and the interpretation auto-fills against the chosen standard. Analyzer results arrive automatically (no import). To change a value, tick <strong>Override</strong> — it expands inline, keeps the original, and is revertible.</p>
+    <table class="t">
+      <thead><tr><th>Antibiotic</th><th>MIC (µg/mL)</th><th>Interp</th><th>Source</th><th>Override</th><th></th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div class="toolbar">
+      <button class="btn b-ghost b-sm" onclick="applyDefaults()">Apply defaults (re-interpret)</button>
+      <button class="btn b-ghost b-sm" onclick="clearAll()">Clear all</button>
+      <span class="tag-note">Analyzer results ingest automatically via the event channel — there is no “import” button. Unmatched pushes → Admin → Stuck analyzer events.</span>
+      <button class="btn b-ter b-sm" style="margin-left:auto" onclick="toggleQc()">Simulate analyzer QC fail</button>
+    </div>
+  </div>
+</div>
+<div id="toastRoot"></div>
+<script>
+"use strict";
+// demo breakpoint thresholds per standard: {S:<=, R:>=}; missing drug => no breakpoint
+var BP = {
+  'EUCAST v14.0': {Ampicillin:{S:8,R:16}, Ceftriaxone:{S:1,R:2}, Meropenem:{S:2,R:8}, Gentamicin:{S:2,R:4}, Ciprofloxacin:{S:0.25,R:0.5}},
+  'EUCAST v13.0': {Ampicillin:{S:8,R:16}, Ceftriaxone:{S:1,R:2}, Meropenem:{S:2,R:8}, Gentamicin:{S:2,R:4}, Ciprofloxacin:{S:0.5,R:1}},
+  'CLSI M100 2024': {Ampicillin:{S:8,R:32}, Ceftriaxone:{S:1,R:4}, Meropenem:{S:1,R:4}, Gentamicin:{S:4,R:16}, Ciprofloxacin:{S:1,R:4}},
+  'CLSI M100 2025': {Ampicillin:{S:8,R:32}, Ceftriaxone:{S:1,R:4}, Meropenem:{S:1,R:4}, Gentamicin:{S:2,R:8}, Ciprofloxacin:{S:0.25,R:1}}
+};
+var std = 'EUCAST v14.0';
+var rows = [
+  {abx:'Ampicillin', mic:32, source:'ANALYZER'},
+  {abx:'Ceftriaxone', mic:16, source:'ANALYZER'},
+  {abx:'Meropenem', mic:0.25, source:'ANALYZER'},
+  {abx:'Gentamicin', mic:4, source:'ANALYZER'},
+  {abx:'Ciprofloxacin', mic:1, source:'ANALYZER'},
+  {abx:'Colistin', mic:'', source:'MANUAL'}   // no breakpoint in demo map
+];
+var qc=false;
+function interp(abx, mic){
+  var t = BP[std][abx];
+  if(t===undefined) return {i:'NB', matched:'none'};
+  if(mic===''||mic===null||isNaN(parseFloat(mic))) return {i:'', matched:''};
+  var m=parseFloat(mic);
+  if(m<=t.S) return {i:'S', matched:'organism-specific'};
+  if(m>=t.R) return {i:'R', matched:'organism-specific'};
+  return {i:'I', matched:'organism-specific'};
+}
+function render(){
+  document.getElementById('qcbanner').innerHTML = qc
+    ? '<div class="banner">⚠ <b>QC fail</b> on this card (control organism out of range). Save is blocked. <button class="btn b-amber b-sm" onclick="invalidate()">Invalidate &amp; start new run</button> <button class="btn b-ghost b-sm" onclick="overrideQc()">Override QC flag (supervisor)</button></div>'
+    : '';
+  var html='';
+  rows.forEach(function(r,ix){
+    var res = r.override ? {i:r.override.interp, matched:'override'} : interp(r.abx, r.mic);
+    var interpCell;
+    if(res.i==='NB'){ interpCell='<span class="interp NB">?</span> <span class="matched" style="color:#8d8d8d">no breakpoint — interpret per local SOP</span>'; }
+    else { interpCell = (res.i?'<span class="interp '+res.i+'">'+res.i+'</span>':'<span style="color:#bbb">—</span>') + (res.matched&&res.matched!=='override'?' <span class="matched">('+res.matched+')</span>':'') + (r.override?' <span class="matched" style="color:#8a3ffc">→ override</span>':''); }
+    var micCell = (res.i==='NB')
+      ? '<input class="mic-in" value="'+(r.mic||'')+'" oninput="setMic('+ix+',this.value)" placeholder="—">'
+      : '<input class="mic-in" value="'+(r.mic||'')+'" oninput="setMic('+ix+',this.value)">';
+    var ovrToggle = r.override
+      ? '<span class="lnk" onclick="toggleHist('+ix+')">show original ▾</span>'
+      : '<label style="font-size:12px"><input type="checkbox" onclick="openOverride('+ix+')"> override</label>';
+    html += '<tr'+(r.override?' class="ovr"':'')+'><td>'+r.abx+'</td><td>'+micCell+'</td><td>'+interpCell+'</td><td class="src">'+(r.override?'OVERRIDE':r.source)+'</td><td>'+ovrToggle+'</td><td></td></tr>';
+    if(r._editing){
+      html += '<tr class="ovrdetail"><td colspan="6"><div class="ovrbox">'+
+        '<div class="fld"><label>New interpretation</label><select id="ov_'+ix+'"><option>R</option><option>S</option><option>I</option></select></div>'+
+        '<div class="fld" style="flex:1"><label>Justification (required) · macros: .</label><textarea id="oj_'+ix+'" rows="1" placeholder="e.g. ESBL phenotype — report cephalosporins R regardless of MIC"></textarea></div>'+
+        '<button class="btn b-pri b-sm" onclick="saveOverride('+ix+')">Save override</button>'+
+        '<button class="btn b-ghost b-sm" onclick="cancelOverride('+ix+')">Cancel</button></div></td></tr>';
+    }
+    if(r._showHist && r.override){
+      html += '<tr class="histdetail"><td colspan="6">Original ('+r.override.origSource+'): <strong>'+(r.override.origInterp||'—')+'</strong> (MIC '+(r.override.origMic||'—')+') → override <strong>'+r.override.interp+'</strong>. Reason: '+r.override.reason+'. By Olivia Mendez, just now. &nbsp; <span class="lnk" onclick="revert('+ix+')">Revert to original</span></td></tr>';
+    }
+  });
+  document.getElementById('rows').innerHTML=html;
+}
+function setMic(ix,v){ rows[ix].mic=v; rows[ix].source='MANUAL'; render(); }
+function changeStd(v){ std=v; toast('Re-interpreted against '+v+' (snapshotted on the run).'); render(); }
+function applyDefaults(){ toast('Re-interpreted all rows against '+std+'.'); render(); }
+function clearAll(){ if(confirm('Clear all entered results? This cannot be undone (writes an audit row).')){ rows.forEach(function(r){ r.mic=''; r.override=null; r._editing=false; r._showHist=false; }); render(); } }
+function openOverride(ix){ rows.forEach(function(r){r._editing=false;}); rows[ix]._editing=true; render(); }
+function cancelOverride(ix){ rows[ix]._editing=false; render(); }
+function saveOverride(ix){
+  var nv=document.getElementById('ov_'+ix).value; var reason=document.getElementById('oj_'+ix).value||'(reason required)';
+  var cur=interp(rows[ix].abx, rows[ix].mic);
+  rows[ix].override={interp:nv, reason:reason, origInterp:cur.i, origMic:rows[ix].mic, origSource:rows[ix].source};
+  rows[ix]._editing=false; render(); toast('Override saved — original reading preserved + audited.');
+}
+function toggleHist(ix){ rows[ix]._showHist=!rows[ix]._showHist; render(); }
+function revert(ix){ rows[ix].override=null; rows[ix]._showHist=false; render(); toast('Reverted to the original analyzer/manual value (audited).'); }
+function toggleQc(){ qc=!qc; render(); }
+function invalidate(){ qc=false; toast('Run invalidated; a new AST run can be set up.'); render(); }
+function overrideQc(){ qc=false; toast('QC flag overridden by supervisor (justification + audit).'); render(); }
+function toast(m){ var r=document.getElementById('toastRoot'); r.innerHTML='<div class="toast">'+m+'</div>'; clearTimeout(window._t); window._t=setTimeout(function(){r.innerHTML='';},3800); }
+render();
+</script>
+</body>
+</html>

--- a/mockup-viewer/public/designs/microbiology/m-04-case-workbench-prototype.html
+++ b/mockup-viewer/public/designs/microbiology/m-04-case-workbench-prototype.html
@@ -98,6 +98,14 @@
   .fld .fh { font-size:11px; color:#6f6f6f; margin-top:3px; }
   details.ci > summary { cursor:pointer; list-style:none; font-size:14px; display:flex; gap:0.5rem; align-items:center; flex-wrap:wrap; }
   details.ci > summary::-webkit-details-marker { display:none; }
+  .inline-form { border:1px solid #b28600; border-left:4px solid #b28600; background:#fffdf4; margin-bottom:1rem; }
+  .inline-form .if-h { padding:0.6rem 1rem; font-size:15px; font-weight:600; border-bottom:1px solid #f0e6c8; }
+  .inline-form .if-h .if-sub { font-weight:400; color:#8d8d8d; font-size:12px; }
+  .inline-form .if-b { padding:0.8rem 1rem; }
+  .inline-form .if-f { padding:0.6rem 1rem; border-top:1px solid #f0e6c8; display:flex; gap:0.5rem; }
+  .scan-row { display:flex; gap:0.5rem; align-items:stretch; }
+  .scan-row input { flex:1; }
+  .btn-scan { white-space:nowrap; }
 </style>
 </head>
 <body>
@@ -110,14 +118,14 @@
   </div>
 </div>
 <div class="app-header"><span class="product">OpenELIS Global</span><span style="opacity:.6">|</span><span>Microbiology</span>
-  <div class="right"><span id="critBadge"></span><span>Olivia Mendez · Micro Tech</span></div>
+  <div class="right"><span id="critBadge"></span><span id="nceBadge"></span><span>Olivia Mendez · Micro Tech</span></div>
 </div>
 <div class="breadcrumbs"><a href="#">Home</a> / <a href="#">Microbiology</a> / <a href="#">Pending Cultures</a> / Case MC-2024-001234</div>
 <div class="case-header">
   <div class="title-row">
     <h1>Case MC-2024-001234</h1>
     <span class="stage-pill" id="stagePill">Received</span>
-    <div class="header-actions"><button class="btn b-ter b-sm" onclick="act('logCritical')">Log critical notification</button></div>
+    <div class="header-actions"><button class="btn b-ter b-sm" onclick="act('logCritical')">Log critical notification</button><button class="btn b-ter b-sm" onclick="act('reportNce')">Report NCE</button></div>
   </div>
   <div class="meta">
     <span><b>Lab #:</b> BC24-0892</span><span><b>Patient:</b> MARTINEZ, Carlos</span>
@@ -132,7 +140,7 @@
       <span class="dot d-part" style="width:11px;height:11px"></span> active
       <span class="dot d-none" style="width:11px;height:11px"></span> to do<br>Blue ring = current step.</div>
   </aside>
-  <main class="main"><div id="banner"></div><div id="sections"></div></main>
+  <main class="main"><div id="banner"></div><div id="inlineSlot"></div><div id="sections"></div></main>
 </div>
 <div id="modalRoot"></div>
 
@@ -145,7 +153,7 @@ var ABX = ['Ampicillin','Ceftriaxone','Meropenem','Gentamicin','Ciprofloxacin','
 
 var S; // state
 function fresh(){ return {
-  stage:'RECEIVED', critical:null, inoc:[], iso:[], tl:[], prelim:null, final:null, focus:'inoculation'
+  stage:'RECEIVED', critical:null, nce:null, inoc:[], iso:[], tl:[], prelim:null, final:null, focus:'inoculation'
 };}
 function logTL(cls,label,notes,by,auto){ S.tl.unshift({when:now(),cls:cls||'',label:label,notes:notes||'',by:by||'Olivia Mendez',auto:!!auto}); }
 
@@ -167,7 +175,7 @@ function seedMidway(){
 }
 
 /* ---------- derived helpers ---------- */
-var STAGE_LABEL={RECEIVED:'Received',INCUBATING:'Incubating',POSITIVE_SIGNAL:'Positive signal',GROWTH_DETECTED:'Growth detected',ORGANISM_ID:'Organism ID',AST_IN_PROGRESS:'AST in progress',READY_REVIEW:'Ready for review',PRELIM_REPORTED:'Preliminary reported',FINAL_REPORTED:'Final reported'};
+var STAGE_LABEL={RECEIVED:'Received',INCUBATING:'Incubating',POSITIVE_SIGNAL:'Positive signal',GROWTH_DETECTED:'Growth detected',ORGANISM_ID:'Organism ID',AST_IN_PROGRESS:'AST in progress',READY_REVIEW:'Ready for review',PRELIM_REPORTED:'Preliminary reported',FINAL_REPORTED:'Final reported',NO_GROWTH_FINAL:'No growth',LOST_SPECIMEN:'Specimen lost',REJECTED:'Rejected'};
 function hasGram(){ return S.iso.some(function(i){return i.gram;}); }
 function allIdentified(){ return S.iso.length>0 && S.iso.every(function(i){return i.org;}); }
 function astRuns(){ return S.iso.filter(function(i){return i.ast;}); }
@@ -184,6 +192,7 @@ function currentStep(){
 }
 function nextStepText(){
   var cs=currentStep();
+  if(['NO_GROWTH_FINAL','LOST_SPECIMEN','REJECTED'].indexOf(S.stage)>-1) return {done:true,txt:STAGE_LABEL[S.stage]+' — case closed via a non-conforming event; the test was rejected. See the Timeline for the NCE.',act:null};
   if(S.final) return {done:true,txt:'Final report released — case complete. Amendments are still possible.',act:null};
   switch(cs){
     case 'inoculation':
@@ -307,6 +316,7 @@ function secReports(){
 function render(refocus){
   document.getElementById('stagePill').textContent = STAGE_LABEL[S.stage]||S.stage;
   document.getElementById('critBadge').innerHTML = S.critical? '<span class="crit-badge">⚠ 1 critical '+(S.critical.ack?'ack':'open')+'</span>':'';
+  document.getElementById('nceBadge').innerHTML = S.nce? '<span class="crit-badge" style="background:#fff8e1;border-color:#b28600;color:#684e00">⚑ NCE: '+S.nce.sub+'</span>':'';
   document.getElementById('sidebar').innerHTML = progress();
   var ns = nextStepText();
   document.getElementById('banner').innerHTML = '<div class="nextstep'+(ns.done?' done':'')+'"><span style="font-size:18px">'+(ns.done?'✅':'🧭')+'</span><div class="txt"><b>Next step:</b> '+ns.txt+'</div>'+(ns.act?'<button class="btn b-pri b-sm" onclick="act(\''+ns.act[1].split(':')[0]+'\''+(ns.act[1].indexOf(':')>-1?','+ns.act[1].split(':')[1]:'')+')">'+ns.act[0]+'</button>':'')+'</div>';
@@ -320,24 +330,27 @@ function focusSection(key){
 }
 
 /* ---------- modal ---------- */
+// Inline action panel (not a pop-up modal) — renders in page flow per OpenELIS Principle 3.
 function openModal(title, fields, onSave, saveLabel){
-  var html='<div class="overlay" onclick="if(event.target===this)closeModal()"><div class="modal"><div class="mh">'+title+'</div><div class="mb">';
+  var html='<div class="inline-form"><div class="if-h">'+title+' <span class="if-sub">— inline, no pop-up</span></div><div class="if-b">';
   fields.forEach(function(f){
     html+='<div class="fld"><label>'+f.label+'</label>';
     if(f.type==='select'){ html+='<select id="f_'+f.key+'">'+f.options.map(function(o){return '<option>'+o+'</option>';}).join('')+'</select>'; }
     else if(f.type==='textarea'){ html+='<textarea id="f_'+f.key+'" rows="2">'+(f.value||'')+'</textarea>'; }
+    else if(f.type==='scan'){ html+='<div class="scan-row"><input id="f_'+f.key+'" value="'+(f.value||'')+'" placeholder="'+(f.ph||'')+'"><button type="button" class="btn b-ter btn-scan" onclick="scanInto(\'f_'+f.key+'\',\''+(f.scanVal||'')+'\')">⊞ Scan</button></div>'; }
     else { html+='<input id="f_'+f.key+'" value="'+(f.value||'')+'" placeholder="'+(f.ph||'')+'">'; }
     if(f.fh) html+='<div class="fh">'+f.fh+'</div>';
     html+='</div>';
   });
-  html+='</div><div class="mf"><button class="btn b-ghost" onclick="closeModal()">Cancel</button><button class="btn b-pri" id="modalSave">'+(saveLabel||'Save')+'</button></div></div></div>';
-  var root=document.getElementById('modalRoot'); root.innerHTML=html;
+  html+='</div><div class="if-f"><button class="btn b-pri" id="modalSave">'+(saveLabel||'Save')+'</button><button class="btn b-ghost" onclick="closeModal()">Cancel</button></div></div>';
+  var root=document.getElementById('inlineSlot'); root.innerHTML=html; root.scrollIntoView({behavior:'smooth',block:'center'});
   document.getElementById('modalSave').onclick=function(){
     var vals={}; fields.forEach(function(f){ vals[f.key]=document.getElementById('f_'+f.key).value; });
     closeModal(); onSave(vals);
   };
 }
-function closeModal(){ document.getElementById('modalRoot').innerHTML=''; }
+function closeModal(){ var r=document.getElementById('inlineSlot'); if(r) r.innerHTML=''; }
+function scanInto(id,val){ var el=document.getElementById(id); if(el){ el.value = val || ('SCAN-'+Math.floor(Math.random()*9000+1000)); el.focus(); } }
 
 /* ---------- actions ---------- */
 function act(name, arg){
@@ -345,21 +358,21 @@ function act(name, arg){
     case 'startInoculation':
       openModal('Start inoculation',[
         {key:'media',label:'Media *',type:'select',options:['FA — Aerobic Blood Bottle','FN — Anaerobic Blood Bottle','BAP','MacConkey','Chocolate agar']},
-        {key:'id',label:'Bottle / plate ID',ph:'FA24012'},
-        {key:'lot',label:'Reagent lot',type:'select',options:['FA-26-04-117 (exp 2026-08-15)','FN-26-04-118 (exp 2026-08-15)','BAP-26-04-211'],fh:'From the reagent inventory (M-12). Expired/locked lots are blocked.'}
+        {key:'id',label:'Bottle / plate ID',type:'scan',ph:'scan or type, e.g. FA24012',scanVal:'FA24012',fh:'Scan the bottle/plate barcode (or type it).'},
+        {key:'lot',label:'Reagent lot',type:'select',options:['BAP-26-04-088 · exp 2026-07-30 · QC pass  (oldest — use first)','FA-26-04-117 · exp 2026-08-15 · QC pass','FN-26-04-118 · exp 2026-08-15 · QC pass'],fh:'Sorted oldest-expiry first (FIFO) — same as results-entry reagent selection. QC status shown; expired/locked lots are blocked.'}
       ],function(v){ S.inoc.push({media:v.media,src:'Primary',id:v.id||'—',lot:v.lot.split(' (')[0]}); logTL('','Inoculated',v.media+' inoculated.','Olivia Mendez',true); if(S.stage==='RECEIVED') S.stage='INCUBATING'; S.focus='inoculation'; render(); });
       break;
     case 'addSubculture':
       openModal('Add subculture',[
         {key:'media',label:'Media *',type:'select',options:['BAP','MacConkey','Chocolate agar','CLED']},
         {key:'parent',label:'Subculture from *',type:'select',options:S.inoc.map(function(x){return x.id;})},
-        {key:'id',label:'Plate ID',ph:'SC-0892A'}
+        {key:'id',label:'Plate ID',type:'scan',ph:'scan or type, e.g. SC-0892A',scanVal:'SC-0892A',fh:'Scan the plate barcode (or type it).'}
       ],function(v){ S.inoc.push({media:v.media,src:'subculture ← '+v.parent,id:v.id||'—',lot:'—'}); logTL('sub','Subculture',v.media+' subcultured from '+v.parent+'.','Olivia Mendez',true); render(); });
       break;
     case 'markPositive':
       S.stage='POSITIVE_SIGNAL'; logTL('pos','Positive signal','Instrument flagged positive.','BacT/Alert auto',true); render(); break;
     case 'markNoGrowth':
-      S.stage='FINAL_REPORTED'; S.final=now(); logTL('rep','No growth — final','Finalized as no growth after full incubation.','Olivia Mendez',false); render(); break;
+      S.stage='NO_GROWTH_FINAL'; logTL('rep','No growth — final','Finalized as no growth after full incubation.','Olivia Mendez',false); render(); break;
     case 'addIsolate':
       openModal('Add isolate',[
         {key:'gram',label:'Gram stain *',ph:'Gram negative rods, many'},
@@ -383,8 +396,8 @@ function act(name, arg){
       openModal('Set up AST — Isolate '+i2.n,[
         {key:'panel',label:'AST panel *',type:'select',options:['GN-STD (Gram-negative standard)','GP-STD','GN-UR']},
         {key:'method',label:'Method *',type:'select',options:['VITEK 2','BD Phoenix','Disk diffusion']},
-        {key:'bp',label:'Breakpoint standard',type:'select',options:['EUCAST v14.0 (active)','CLSI M100 2024'],fh:'Snapshotted on the run — historical runs keep this version.'},
-        {key:'card',label:'Card / disc lot',type:'select',options:['AST-GN-26-04-117','AST-GP-26-03-090']}
+        {key:'bp',label:'Breakpoint standard',type:'select',options:['EUCAST v14.0  (lab default — active)','CLSI M100 2024  (loaded)','CLSI M100 2025  (loaded)','EUCAST v13.0  (loaded)'],fh:'Defaults to the lab active standard, but choose any loaded standard/version per run (CLSI or EUCAST). Snapshotted on the run — switching the lab default later never changes this run. Loaded set managed in Breakpoint Catalog (M-02).'},
+        {key:'card',label:'Card / disc lot',type:'select',options:['AST-GN-26-04-117 · exp 2026-09-01 · QC pass  (oldest — use first)','AST-GN-26-05-140 · exp 2026-10-15 · QC pass'],fh:'Sorted oldest-expiry first (FIFO); QC status shown; expired/locked lots blocked. The analyzer card ID is captured from the instrument link or scanned.'}
       ],function(v){ i2.ast={status:'Awaiting results',results:[]}; logTL('ast','AST setup',v.panel+' ('+v.method+') set up for Isolate '+i2.n+'.','Olivia Mendez',true); S.stage='AST_IN_PROGRESS'; S.focus='ast'; render(); });
       break;
     case 'receiveAst':
@@ -402,6 +415,24 @@ function act(name, arg){
         {key:'msg',label:'Substance of communication',type:'textarea',value:'Gram-negative rods in blood culture; possible sepsis. Recommend broad-spectrum coverage.'},
         {key:'ack',label:'Acknowledged at time of call?',type:'select',options:['Yes — read-back','Yes — verbal','No']}
       ],function(v){ S.critical={who:v.who,ack:v.ack.indexOf('Yes')===0}; logTL('crit','Critical called',v.who+' notified ('+v.method+'). '+(v.ack.indexOf('Yes')===0?'Acknowledged ('+v.ack+').':'Not yet acknowledged.'),'Olivia Mendez',false); render(false); });
+      break;
+    case 'reportNce':
+      openModal('Report non-conforming event (NCE)',[
+        {key:'cat',label:'Category',type:'select',options:['Pre-analytical','Analytical','Post-analytical']},
+        {key:'sub',label:'Subcategory *',type:'select',options:['Specimen lost','Specimen integrity / insufficient','Contamination','Mislabel / ID mismatch','Transport / temperature','Testing error','Other']},
+        {key:'sev',label:'Severity',type:'select',options:['Minor','Major','Critical']},
+        {key:'desc',label:'What happened',type:'textarea',value:''},
+        {key:'action',label:'Test disposition',type:'select',options:['Flag only — continue processing','Reject test — reason: specimen lost','Reject test — other reason'],fh:'Reuses OE sample rejection: rejecting sets the sample status to Rejected and cancels pending tests.'}
+      ],function(v){
+        S.nce={sub:v.sub};
+        logTL('note','NCE reported',v.cat+' / '+v.sub+' ('+v.sev+'). '+(v.desc||''),'Olivia Mendez',false);
+        if(v.action.indexOf('Reject')===0){
+          var lost = v.action.indexOf('specimen lost')>-1 || v.sub==='Specimen lost';
+          logTL('note','Test rejected',(lost?'Reason: specimen lost. ':'')+'Pending tests cancelled; NCE linked.','Olivia Mendez',true);
+          S.stage = lost ? 'LOST_SPECIMEN' : 'REJECTED';
+        }
+        render();
+      },'Save NCE');
       break;
     case 'addNote':
       openModal('Add note',[{key:'type',label:'Type',type:'select',options:['General note','Plate reading','Specimen lost']},{key:'txt',label:'Note',type:'textarea'}],

--- a/mockup-viewer/public/designs/microbiology/m-05-ast-entry-prototype.html
+++ b/mockup-viewer/public/designs/microbiology/m-05-ast-entry-prototype.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-05 AST Entry — Inline Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+  body { background:#f4f4f4; margin:0; font-family:'IBM Plex Sans',sans-serif; color:#161616; }
+  .preview-banner { background:#0f62fe; color:#fff; padding:6px 1rem; font-size:12px; font-family:monospace; }
+  .preview-banner strong { background:#fff; color:#0f62fe; padding:1px 6px; border-radius:2px; margin:0 4px; }
+  .wrap { padding:1.25rem 2rem; max-width:1000px; }
+  .card { background:#fff; border:1px solid #e0e0e0; padding:1rem 1.25rem; margin-bottom:1rem; }
+  h1 { font-size:22px; font-weight:300; margin:0 0 0.25rem; }
+  .sub { font-size:13px; color:#6f6f6f; margin:0 0 1rem; }
+  .help { font-size:12px; color:#6f6f6f; margin:0.25rem 0 0.75rem; } .help .ico{ color:#0f62fe; font-weight:700; margin-right:4px; }
+  .runhdr { display:flex; gap:1.25rem; flex-wrap:wrap; align-items:flex-end; margin-bottom:0.5rem; }
+  .fld label { display:block; font-size:11px; color:#525252; text-transform:uppercase; letter-spacing:0.4px; font-weight:600; margin-bottom:4px; }
+  .fld select, .fld input { padding:0.4rem 0.6rem; font-size:13px; border:0; border-bottom:1px solid #8d8d8d; background:#f4f4f4; font-family:inherit; }
+  .fh { font-size:11px; color:#6f6f6f; margin-top:4px; max-width:520px; }
+  table.t { width:100%; border-collapse:collapse; font-size:13px; }
+  table.t th { text-align:left; padding:0.45rem 0.6rem; background:#f4f4f4; font-weight:600; border-bottom:1px solid #e0e0e0; font-size:11px; text-transform:uppercase; letter-spacing:0.4px; color:#525252; }
+  table.t td { padding:0.4rem 0.6rem; border-bottom:1px solid #eee; vertical-align:middle; }
+  tr.ovr td { background:#fff8e1; }
+  tr.ovrdetail td { background:#f6f2ff; }
+  tr.histdetail td { background:#f4f4f4; color:#525252; font-size:12px; }
+  .mic-in { width:74px; padding:0.25rem 0.4rem; border:1px solid #8d8d8d; background:#fff; font-family:inherit; font-size:13px; }
+  .interp { display:inline-block; padding:1px 8px; border-radius:4px; font-weight:700; font-size:11px; min-width:16px; text-align:center; }
+  .interp.S{background:#a7f0ba;color:#044317;} .interp.I{background:#fdd13a;color:#161616;} .interp.R{background:#ffd7d9;color:#750e13;} .interp.NB{background:#e0e0e0;color:#525252;}
+  .src { font-size:10px; color:#6f6f6f; }
+  .matched { font-size:10px; color:#0f62fe; }
+  .lnk { color:#0f62fe; cursor:pointer; font-size:12px; }
+  .btn { display:inline-flex; align-items:center; gap:0.35rem; padding:0.4rem 0.8rem; font-size:13px; font-family:inherit; border:1px solid transparent; cursor:pointer; }
+  .b-pri{background:#0f62fe;color:#fff;} .b-ter{background:transparent;color:#0f62fe;border-color:#0f62fe;} .b-ghost{background:transparent;color:#0f62fe;} .b-ghost:hover,.b-ter:hover{background:#e5e5e5;} .b-amber{background:#f1c21b;color:#161616;font-weight:600;} .b-sm{padding:0.25rem 0.7rem;font-size:12px;}
+  .toolbar { display:flex; gap:0.5rem; margin:0.75rem 0; flex-wrap:wrap; align-items:center; }
+  .banner { padding:0.7rem 1rem; border-left:4px solid #da1e28; background:#fff1f1; font-size:13px; margin-bottom:0.75rem; display:flex; gap:1rem; align-items:center; }
+  .banner.ok { border-left-color:#24a148; background:#defbe6; }
+  .ovrbox { padding:0.5rem 0.6rem; display:flex; gap:0.75rem; align-items:flex-end; flex-wrap:wrap; }
+  .ovrbox textarea { min-width:300px; flex:1; border:1px solid #8d8d8d; font-family:inherit; font-size:13px; padding:0.3rem; }
+  .tag-note { font-size:11px; color:#6f6f6f; }
+  .toast { position:fixed; bottom:20px; left:50%; transform:translateX(-50%); background:#161616; color:#fff; padding:0.6rem 1rem; font-size:13px; border-radius:4px; z-index:50; }
+</style>
+</head>
+<body>
+<div class="preview-banner">M-05 AST Entry · <strong>Inline prototype</strong> · no pop-up modals — setup &amp; entry are inline; override expands in the row. Auto-interpret · flexible breakpoint · no manual import.</div>
+<div class="wrap">
+  <div class="card">
+    <h1>AST Run #1 — Isolate 1 · <em>Escherichia coli</em></h1>
+    <p class="sub">Case MC-2024-001234 · Blood · MARTINEZ, Carlos</p>
+    <div id="qcbanner"></div>
+    <div class="runhdr">
+      <div class="fld"><label>Panel</label><select><option>GN-STD (16 antibiotics)</option><option>GN-UR (8)</option></select></div>
+      <div class="fld"><label>Method</label><select><option>VITEK 2</option><option>Disk diffusion</option><option>Etest</option></select></div>
+      <div class="fld"><label>Breakpoint standard</label>
+        <select id="std" onchange="changeStd(this.value)">
+          <option value="EUCAST v14.0">EUCAST v14.0  (lab default — active)</option>
+          <option value="CLSI M100 2024">CLSI M100 2024  (loaded)</option>
+          <option value="CLSI M100 2025">CLSI M100 2025  (loaded)</option>
+          <option value="EUCAST v13.0">EUCAST v13.0  (loaded)</option>
+        </select>
+      </div>
+      <div class="fld"><label>Card / disc lot</label><select><option>AST-GN-26-04-117 · exp 2026-09-01 · QC pass  (oldest — use first)</option><option>AST-GN-26-05-140 · exp 2026-10-15 · QC pass</option></select></div>
+    </div>
+    <p class="fh">Breakpoint standard <strong>defaults to the lab active standard but any loaded standard/version is selectable per run</strong> (CLSI or EUCAST) — try changing it and watch the interpretations re-compute. It's snapshotted on the run, so switching the lab default later never changes this run. Card lot uses FIFO + QC like results-entry; the analyzer card ID is scanned or read from the instrument link.</p>
+    <p class="help"><span class="ico">ⓘ</span> Enter MIC and the interpretation auto-fills against the chosen standard. Analyzer results arrive automatically (no import). To change a value, tick <strong>Override</strong> — it expands inline, keeps the original, and is revertible.</p>
+    <table class="t">
+      <thead><tr><th>Antibiotic</th><th>MIC (µg/mL)</th><th>Interp</th><th>Source</th><th>Override</th><th></th></tr></thead>
+      <tbody id="rows"></tbody>
+    </table>
+    <div class="toolbar">
+      <button class="btn b-ghost b-sm" onclick="applyDefaults()">Apply defaults (re-interpret)</button>
+      <button class="btn b-ghost b-sm" onclick="clearAll()">Clear all</button>
+      <span class="tag-note">Analyzer results ingest automatically via the event channel — there is no “import” button. Unmatched pushes → Admin → Stuck analyzer events.</span>
+      <button class="btn b-ter b-sm" style="margin-left:auto" onclick="toggleQc()">Simulate analyzer QC fail</button>
+    </div>
+  </div>
+</div>
+<div id="toastRoot"></div>
+<script>
+"use strict";
+// demo breakpoint thresholds per standard: {S:<=, R:>=}; missing drug => no breakpoint
+var BP = {
+  'EUCAST v14.0': {Ampicillin:{S:8,R:16}, Ceftriaxone:{S:1,R:2}, Meropenem:{S:2,R:8}, Gentamicin:{S:2,R:4}, Ciprofloxacin:{S:0.25,R:0.5}},
+  'EUCAST v13.0': {Ampicillin:{S:8,R:16}, Ceftriaxone:{S:1,R:2}, Meropenem:{S:2,R:8}, Gentamicin:{S:2,R:4}, Ciprofloxacin:{S:0.5,R:1}},
+  'CLSI M100 2024': {Ampicillin:{S:8,R:32}, Ceftriaxone:{S:1,R:4}, Meropenem:{S:1,R:4}, Gentamicin:{S:4,R:16}, Ciprofloxacin:{S:1,R:4}},
+  'CLSI M100 2025': {Ampicillin:{S:8,R:32}, Ceftriaxone:{S:1,R:4}, Meropenem:{S:1,R:4}, Gentamicin:{S:2,R:8}, Ciprofloxacin:{S:0.25,R:1}}
+};
+var std = 'EUCAST v14.0';
+var rows = [
+  {abx:'Ampicillin', mic:32, source:'ANALYZER'},
+  {abx:'Ceftriaxone', mic:16, source:'ANALYZER'},
+  {abx:'Meropenem', mic:0.25, source:'ANALYZER'},
+  {abx:'Gentamicin', mic:4, source:'ANALYZER'},
+  {abx:'Ciprofloxacin', mic:1, source:'ANALYZER'},
+  {abx:'Colistin', mic:'', source:'MANUAL'}   // no breakpoint in demo map
+];
+var qc=false;
+function interp(abx, mic){
+  var t = BP[std][abx];
+  if(t===undefined) return {i:'NB', matched:'none'};
+  if(mic===''||mic===null||isNaN(parseFloat(mic))) return {i:'', matched:''};
+  var m=parseFloat(mic);
+  if(m<=t.S) return {i:'S', matched:'organism-specific'};
+  if(m>=t.R) return {i:'R', matched:'organism-specific'};
+  return {i:'I', matched:'organism-specific'};
+}
+function render(){
+  document.getElementById('qcbanner').innerHTML = qc
+    ? '<div class="banner">⚠ <b>QC fail</b> on this card (control organism out of range). Save is blocked. <button class="btn b-amber b-sm" onclick="invalidate()">Invalidate &amp; start new run</button> <button class="btn b-ghost b-sm" onclick="overrideQc()">Override QC flag (supervisor)</button></div>'
+    : '';
+  var html='';
+  rows.forEach(function(r,ix){
+    var res = r.override ? {i:r.override.interp, matched:'override'} : interp(r.abx, r.mic);
+    var interpCell;
+    if(res.i==='NB'){ interpCell='<span class="interp NB">?</span> <span class="matched" style="color:#8d8d8d">no breakpoint — interpret per local SOP</span>'; }
+    else { interpCell = (res.i?'<span class="interp '+res.i+'">'+res.i+'</span>':'<span style="color:#bbb">—</span>') + (res.matched&&res.matched!=='override'?' <span class="matched">('+res.matched+')</span>':'') + (r.override?' <span class="matched" style="color:#8a3ffc">→ override</span>':''); }
+    var micCell = (res.i==='NB')
+      ? '<input class="mic-in" value="'+(r.mic||'')+'" oninput="setMic('+ix+',this.value)" placeholder="—">'
+      : '<input class="mic-in" value="'+(r.mic||'')+'" oninput="setMic('+ix+',this.value)">';
+    var ovrToggle = r.override
+      ? '<span class="lnk" onclick="toggleHist('+ix+')">show original ▾</span>'
+      : '<label style="font-size:12px"><input type="checkbox" onclick="openOverride('+ix+')"> override</label>';
+    html += '<tr'+(r.override?' class="ovr"':'')+'><td>'+r.abx+'</td><td>'+micCell+'</td><td>'+interpCell+'</td><td class="src">'+(r.override?'OVERRIDE':r.source)+'</td><td>'+ovrToggle+'</td><td></td></tr>';
+    if(r._editing){
+      html += '<tr class="ovrdetail"><td colspan="6"><div class="ovrbox">'+
+        '<div class="fld"><label>New interpretation</label><select id="ov_'+ix+'"><option>R</option><option>S</option><option>I</option></select></div>'+
+        '<div class="fld" style="flex:1"><label>Justification (required) · macros: .</label><textarea id="oj_'+ix+'" rows="1" placeholder="e.g. ESBL phenotype — report cephalosporins R regardless of MIC"></textarea></div>'+
+        '<button class="btn b-pri b-sm" onclick="saveOverride('+ix+')">Save override</button>'+
+        '<button class="btn b-ghost b-sm" onclick="cancelOverride('+ix+')">Cancel</button></div></td></tr>';
+    }
+    if(r._showHist && r.override){
+      html += '<tr class="histdetail"><td colspan="6">Original ('+r.override.origSource+'): <strong>'+(r.override.origInterp||'—')+'</strong> (MIC '+(r.override.origMic||'—')+') → override <strong>'+r.override.interp+'</strong>. Reason: '+r.override.reason+'. By Olivia Mendez, just now. &nbsp; <span class="lnk" onclick="revert('+ix+')">Revert to original</span></td></tr>';
+    }
+  });
+  document.getElementById('rows').innerHTML=html;
+}
+function setMic(ix,v){ rows[ix].mic=v; rows[ix].source='MANUAL'; render(); }
+function changeStd(v){ std=v; toast('Re-interpreted against '+v+' (snapshotted on the run).'); render(); }
+function applyDefaults(){ toast('Re-interpreted all rows against '+std+'.'); render(); }
+function clearAll(){ if(confirm('Clear all entered results? This cannot be undone (writes an audit row).')){ rows.forEach(function(r){ r.mic=''; r.override=null; r._editing=false; r._showHist=false; }); render(); } }
+function openOverride(ix){ rows.forEach(function(r){r._editing=false;}); rows[ix]._editing=true; render(); }
+function cancelOverride(ix){ rows[ix]._editing=false; render(); }
+function saveOverride(ix){
+  var nv=document.getElementById('ov_'+ix).value; var reason=document.getElementById('oj_'+ix).value||'(reason required)';
+  var cur=interp(rows[ix].abx, rows[ix].mic);
+  rows[ix].override={interp:nv, reason:reason, origInterp:cur.i, origMic:rows[ix].mic, origSource:rows[ix].source};
+  rows[ix]._editing=false; render(); toast('Override saved — original reading preserved + audited.');
+}
+function toggleHist(ix){ rows[ix]._showHist=!rows[ix]._showHist; render(); }
+function revert(ix){ rows[ix].override=null; rows[ix]._showHist=false; render(); toast('Reverted to the original analyzer/manual value (audited).'); }
+function toggleQc(){ qc=!qc; render(); }
+function invalidate(){ qc=false; toast('Run invalidated; a new AST run can be set up.'); render(); }
+function overrideQc(){ qc=false; toast('QC flag overridden by supervisor (justification + audit).'); render(); }
+function toast(m){ var r=document.getElementById('toastRoot'); r.innerHTML='<div class="toast">'+m+'</div>'; clearTimeout(window._t); window._t=setTimeout(function(){r.innerHTML='';},3800); }
+render();
+</script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -660,6 +660,18 @@ export const MOCKUP_REGISTRY = [
     tags: ['microbiology', 'dependency-graph', 'planning'],
   },
   {
+    name: 'M-05 AST Entry \u2014 Interactive Prototype',
+    category: 'microbiology',
+    component: null,
+    description: 'Inline AST entry (no modals) \u2014 type MIC to auto-interpret; switch breakpoint standard to re-compute (EUCAST vs CLSI); inline override with revert + reading history; no-breakpoint guidance; QC-fail recovery. Analyzer results auto-ingest, no manual import.',
+    specPath: 'designs/microbiology/m-05-ast-entry-and-interpretation.md',
+    htmlUrl: 'designs/microbiology/m-05-ast-entry-prototype.html',
+    added: '2026-06-05',
+    status: 'draft',
+    jira: ['OGC-791'],
+    tags: ['microbiology', 'ast', 'interactive', 'prototype', 'mvp-1a'],
+  },
+  {
     name: 'M-08 Macro Library',
     category: 'microbiology',
     component: null,


### PR DESCRIPTION
…totype (OGC-791)

M-04 FRS: inline-not-modals note (Principle 3), flexible breakpoint-standard selection (§4.5 + AC-M04-19), Report-NCE/specimen-lost→reject flow (§4.8 + AC-M04-17), NCE/reject permission reuse (§10), scannable IDs + FIFO reagent (AC-M04-18). Prototype refreshed to match.

M-05 FRS: consolidated inline rewrite — no modals, flexible breakpoint, auto-ingest/no import, inline override+revert+history, no-breakpoint + QC-fail guidance. New interactive prototype added.

232/232 vitest passing.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
