### PR TITLE
feat(admin-config): register Test Catalog Microbiology Workflow Attri…

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -18,6 +18,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Range Editor | [range-editor.jsx](designs/admin-config/range-editor.jsx) | [range-editor.md](designs/admin-config/range-editor.md) |
 | Result Options | [result-options.jsx](designs/admin-config/result-options.jsx) | [result-options.md](designs/admin-config/result-options.md) |
 | Test Catalog | [test-catalog.jsx](designs/admin-config/test-catalog.jsx) · [preview](designs/admin-config/test-catalog.html) | [test-catalog.md](designs/admin-config/test-catalog.md) |
+| Test Catalog — Microbiology Workflow Attribute | [preview](designs/admin-config/test-catalog-microbiology-workflow-attribute.html) | [test-catalog-microbiology-workflow-attribute.md](designs/admin-config/test-catalog-microbiology-workflow-attribute.md) |
 | RBAC Management | [rbac-ui-mockup.html](designs/rbac/rbac-ui-mockup.html) | [rbac-revamp-prd.md](designs/rbac/rbac-revamp-prd.md) |
 | Password Policy Enhancements | [password-enhancements.jsx](designs/admin-config/password-enhancements.jsx) | [password-enhancements.md](designs/admin-config/password-enhancements.md) |
 | Catalog Subscription | [catalog-subscription-carbon.jsx](designs/admin-config/catalog-subscription-carbon.jsx) \| [preview](designs/admin-config/catalog-subscription.html) | [catalog-subscription.md](designs/admin-config/catalog-subscription.md) |

--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -217,6 +217,22 @@
     gallery: https://digi-uw.github.io/openelis-work/#/admin-config/test-catalog-frs-v2-5
   added: "2026-05-14"
 
+- id: test-catalog-microbiology-workflow-attribute
+  type: mockup
+  path: designs/admin-config/test-catalog-microbiology-workflow-attribute.html
+  spec: designs/admin-config/test-catalog-microbiology-workflow-attribute.md
+  preview: designs/admin-config/test-catalog-microbiology-workflow-attribute.html
+  category: admin-config
+  description: >
+    Test Catalog Basic Info microbiology workflow attribute: a nullable culture_workflow_type
+    enum (Bacteriology / Mycobacteriology-TB) orthogonal to Domain and the AMR flag; drives
+    micro case routing (M-03/M-04). Foldable into Test Catalog v2.5 section 2.1 Basic Info.
+  links:
+    jira: ["OGC-925"]
+    gallery: https://digi-uw.github.io/openelis-work/#/admin-config/test-catalog-microbiology-workflow-attribute
+    preview: https://digi-uw.github.io/openelis-work/designs/admin-config/test-catalog-microbiology-workflow-attribute.html
+  added: "2026-06-08"
+
 - id: test-catalog-v2-5-v1-preview
   type: mockup
   path: designs/admin-config/test-catalog/test-catalog-preview-v2.5-v1.html

--- a/designs/admin-config/test-catalog-microbiology-workflow-attribute.html
+++ b/designs/admin-config/test-catalog-microbiology-workflow-attribute.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Test Catalog — Microbiology Workflow Attribute — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+  body { background:#f4f4f4; margin:0; font-family:'IBM Plex Sans',sans-serif; color:#161616; }
+  .preview-banner { background:#0f62fe; color:#fff; padding:6px 1rem; font-size:12px; font-family:monospace; }
+  .preview-banner strong { background:#fff; color:#0f62fe; padding:1px 6px; border-radius:2px; margin:0 4px; }
+  .preview-banner .what { display:block; margin-top:4px; font-family:'IBM Plex Sans',sans-serif; font-size:12px; opacity:0.95; line-height:1.5; }
+  .demobar { background:#161616; color:#f4f4f4; font-size:12px; padding:0.5rem 1rem; display:flex; gap:0.6rem; align-items:center; flex-wrap:wrap; }
+  .demobar b { color:#78a9ff; }
+  .demobar button { font-size:12px; background:#393939; color:#f4f4f4; border:1px solid #6f6f6f; border-radius:3px; padding:3px 9px; cursor:pointer; }
+  .demobar button.on { background:#0f62fe; border-color:#0f62fe; }
+  .app-header { background:#161616; color:#f4f4f4; padding:0 1rem; height:48px; display:flex; align-items:center; gap:1rem; font-size:14px; }
+  .app-header .product { font-weight:600; }
+  .breadcrumbs { padding:0.6rem 2rem; background:#fff; border-bottom:1px solid #e0e0e0; font-size:13px; color:#525252; }
+  .breadcrumbs a { color:#0f62fe; text-decoration:none; }
+  .editor-head { background:#fff; padding:1rem 2rem 0; border-bottom:1px solid #e0e0e0; display:flex; align-items:flex-end; gap:1rem; }
+  .editor-head h1 { font-size:24px; font-weight:300; margin:0; }
+  .editor-head .code { font-size:13px; color:#6f6f6f; margin-bottom:5px; }
+  .editor-head .save { margin-left:auto; display:flex; gap:0.5rem; margin-bottom:0.6rem; }
+  .layout { display:grid; grid-template-columns:230px 1fr; }
+  .sidebar { background:#fff; border-right:1px solid #e0e0e0; min-height:calc(100vh - 200px); padding:0.5rem 0; }
+  .sidebar-group { padding:0.6rem 1rem 0.2rem; font-size:11px; color:#8d8d8d; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; }
+  .sidebar-item { padding:0.5rem 1rem; cursor:pointer; font-size:13px; border-left:3px solid transparent; }
+  .sidebar-item:hover { background:#e5e5e5; }
+  .sidebar-item.current { background:#e0e0e0; border-left-color:#0f62fe; font-weight:600; }
+  .sidebar-item.dim { color:#a8a8a8; }
+  .main { padding:1.5rem 2rem 5rem; max-width:760px; }
+  .section-title { font-size:18px; font-weight:400; margin:0 0 1.2rem; }
+  .fieldset { background:#fff; border:1px solid #e0e0e0; padding:1.2rem 1.4rem; margin-bottom:1.2rem; }
+  .fieldset h3 { font-size:11px; text-transform:uppercase; letter-spacing:0.5px; color:#525252; margin:0 0 0.9rem; font-weight:600; }
+  .fieldset h3 .new { background:#0f62fe; color:#fff; font-size:9px; padding:1px 6px; border-radius:3px; margin-left:8px; letter-spacing:0.5px; }
+  .frow { margin-bottom:1rem; }
+  label.lbl { display:block; font-size:12px; color:#525252; margin-bottom:0.3rem; }
+  input.txt, select.sel { font-family:inherit; font-size:14px; padding:0.55rem 0.7rem; border:none; border-bottom:1px solid #8d8d8d; background:#f4f4f4; width:100%; max-width:420px; }
+  select.sel { cursor:pointer; }
+  .help { font-size:12px; color:#6f6f6f; margin:0.3rem 0 0; max-width:520px; line-height:1.5; }
+  .radio-row, .flag-row { display:flex; gap:1.4rem; flex-wrap:wrap; }
+  .radio-row label, .flag-row label { font-size:14px; display:flex; align-items:center; gap:0.4rem; cursor:pointer; }
+  .hint { font-size:12.5px; padding:0.6rem 0.8rem; border-radius:2px; margin-top:0.7rem; display:flex; gap:0.5rem; align-items:flex-start; line-height:1.5; max-width:540px; }
+  .hint .x { margin-left:auto; cursor:pointer; color:#525252; font-weight:700; padding:0 4px; }
+  .hint.info { background:#edf5ff; border-left:3px solid #0f62fe; }
+  .hint.warn { background:#fff8e1; border-left:3px solid #f1c21b; }
+  .hint.amr  { background:#f6f2ff; border-left:3px solid #8a3ffc; }
+  .hint.confirm { background:#fff8e1; border-left:3px solid #ff832b; }
+  .pill { display:inline-block; padding:2px 9px; border-radius:12px; font-size:11px; font-weight:600; }
+  .pill.bact { background:#d0e2ff; color:#0043ce; } .pill.tb { background:#e8daff; color:#491d8b; } .pill.none { background:#e0e0e0; color:#525252; }
+  .btn { font-family:inherit; font-size:13px; padding:0.45rem 1rem; border-radius:2px; border:1px solid #0f62fe; cursor:pointer; }
+  .btn.primary { background:#0f62fe; color:#fff; } .btn.ghost { background:#fff; color:#0f62fe; }
+  .saved-note { font-size:12px; color:#24a148; margin-top:0.4rem; min-height:16px; font-weight:600; }
+  .axis-note { font-size:12px; color:#6f6f6f; background:#f4f4f4; padding:0.5rem 0.7rem; border-radius:2px; margin-top:0.4rem; }
+  code { background:#e8e8e8; padding:0 4px; border-radius:3px; font-size:12px; }
+</style>
+</head>
+<body>
+<div class="preview-banner">
+  PREVIEW MOCKUP <strong>Test Catalog v2.5</strong> Basic Info → <strong>Microbiology workflow</strong> (OGC-925)
+  <span class="what">Where an admin sets which micro workflow a culture test starts. One nullable <code>test.culture_workflow_type</code> enum, orthogonal to Domain and the AMR flag. Spec: test-catalog-micro-workflow-attribute.md.</span>
+</div>
+<div class="demobar">
+  <b>DEMO:</b> editing a&nbsp;
+  <button id="modeNew" class="on" onclick="setMode('new')">new test</button>
+  <button id="modeExisting" onclick="setMode('existing')">existing test (has open cases)</button>
+  <span style="margin-left:auto;opacity:0.8;">Change "Microbiology workflow" to see hints + (on an existing test) the reclassification notice.</span>
+</div>
+
+<div class="app-header"><span class="product">OpenELIS Global</span><span>· Admin · Test Catalog Management</span></div>
+<div class="breadcrumbs"><a>Admin</a> / <a>Test Catalog</a> / <a>Tests</a> / <span id="bcName">New test</span></div>
+
+<div class="editor-head">
+  <div>
+    <h1 id="testName">New test</h1>
+    <div class="code" id="testCode">Code: —</div>
+  </div>
+  <div class="save">
+    <button class="btn ghost">Save as new test…</button>
+    <button class="btn primary" onclick="save()">Save Test</button>
+  </div>
+</div>
+
+<div class="layout">
+  <div class="sidebar">
+    <div class="sidebar-group">Configuration</div>
+    <div class="sidebar-item current">Basic Info</div>
+    <div class="sidebar-item">Sample &amp; Results</div>
+    <div class="sidebar-item">Ranges</div>
+    <div class="sidebar-item">Sample Storage</div>
+    <div class="sidebar-group">Organization</div>
+    <div class="sidebar-item">Display Order</div>
+    <div class="sidebar-item">Panels</div>
+    <div class="sidebar-item">Terminology</div>
+    <div class="sidebar-group">Resources</div>
+    <div class="sidebar-item" id="navMethods">Methods</div>
+    <div class="sidebar-item">Analyzers</div>
+  </div>
+
+  <div class="main">
+    <div class="section-title">Basic Info</div>
+
+    <div class="fieldset">
+      <h3>Identity</h3>
+      <div class="frow">
+        <label class="lbl">Test name</label>
+        <input class="txt" id="fName" value="" placeholder="e.g. Mycobacterial culture (MGIT)">
+      </div>
+      <div class="frow">
+        <label class="lbl">Code</label>
+        <input class="txt" id="fCode" value="" placeholder="e.g. TBC-MGIT" style="max-width:220px;">
+      </div>
+      <div class="frow" style="margin-bottom:0;">
+        <label class="lbl">Domain <span style="color:#da1e28;">*</span></label>
+        <div class="radio-row">
+          <label><input type="radio" name="dom" checked> Clinical</label>
+          <label><input type="radio" name="dom"> Environmental</label>
+          <label><input type="radio" name="dom"> Vector</label>
+        </div>
+        <div class="axis-note">Domain answers <em>"what kind of testing program"</em> — a TB culture is still <strong>Clinical</strong>. It does not decide the micro workflow.</div>
+      </div>
+    </div>
+
+    <div class="fieldset">
+      <h3>Status &amp; surveillance</h3>
+      <div class="frow">
+        <label class="lbl">Status flags</label>
+        <div class="flag-row">
+          <label><input type="checkbox" checked> Active</label>
+          <label><input type="checkbox" checked> Orderable</label>
+          <label><input type="checkbox"> Internal QA — No Results Release</label>
+        </div>
+      </div>
+      <div class="frow" style="margin-bottom:0;">
+        <label class="lbl">AMR / WHONET surveillance</label>
+        <div class="flag-row">
+          <label><input type="checkbox" id="amrFlag" onchange="render()"> AMR test (export to WHONET / AMR surveillance)</label>
+        </div>
+        <div class="axis-note">AMR answers <em>"export results for surveillance"</em> — independent of the workflow below. A test can be one, both, or neither.</div>
+      </div>
+    </div>
+
+    <div class="fieldset">
+      <h3>Microbiology workflow <span class="new">NEW · OGC-925</span></h3>
+      <div class="frow" style="margin-bottom:0.4rem;">
+        <label class="lbl">Microbiology workflow</label>
+        <select class="sel" id="wf" onchange="onWf()">
+          <option value="">None — not a culture-workflow test</option>
+          <option value="BACTERIOLOGY">Bacteriology → bacterial Case (M-04)</option>
+          <option value="MYCOBACTERIOLOGY_TB">Mycobacteriology – TB → TB Case (M-14)</option>
+          <option value="MYCOLOGY" disabled>Mycology (coming with the Mycology module, M-16)</option>
+        </select>
+        <p class="help">Set the microbiology workflow to make ordering this test <strong>create the matching Microbiology Case</strong> and appear in the Worklist. Bacteriology and Mycobacteriology–TB use different case profiles, breakpoints, and reports. Persisted as <code>test.culture_workflow_type</code>.</p>
+        <div style="margin-top:0.5rem;">Current: <span id="wfPill" class="pill none">None</span></div>
+        <div class="axis-note">A <strong>test-level</strong> property — not set on Methods. Methods are assigned to tests and also pick the <em>analyzer</em>; there is no workflow↔method mapping, so workflow lives here on the test. The default Method (the culture protocol) is chosen independently on the Methods tab.</div>
+      </div>
+      <div id="hintBox"></div>
+    </div>
+
+    <div class="saved-note" id="savedNote"></div>
+  </div>
+</div>
+
+<script>
+  var mode = 'new';
+  var amrDismissed = false;
+
+  function setMode(m){
+    mode = m;
+    amrDismissed = false;
+    document.getElementById('modeNew').classList.toggle('on', m==='new');
+    document.getElementById('modeExisting').classList.toggle('on', m==='existing');
+    if(m==='existing'){
+      document.getElementById('fName').value = 'Blood culture, aerobic';
+      document.getElementById('fCode').value = 'BC-AER';
+      document.getElementById('testName').textContent = 'Blood culture, aerobic';
+      document.getElementById('bcName').textContent = 'Blood culture, aerobic';
+      document.getElementById('testCode').textContent = 'Code: BC-AER';
+      document.getElementById('amrFlag').checked = true;
+      document.getElementById('wf').value = 'BACTERIOLOGY';
+    } else {
+      document.getElementById('fName').value = '';
+      document.getElementById('fCode').value = '';
+      document.getElementById('testName').textContent = 'New test';
+      document.getElementById('bcName').textContent = 'New test';
+      document.getElementById('testCode').textContent = 'Code: —';
+      document.getElementById('amrFlag').checked = false;
+      document.getElementById('wf').value = '';
+    }
+    document.getElementById('savedNote').textContent = '';
+    render();
+  }
+
+  function onWf(){ amrDismissed = false; document.getElementById('savedNote').textContent=''; render(); }
+
+  function render(){
+    var wf = document.getElementById('wf').value;
+    var amr = document.getElementById('amrFlag').checked;
+    var pill = document.getElementById('wfPill');
+    var navMethods = document.getElementById('navMethods');
+
+    if(wf===''){ pill.className='pill none'; pill.textContent='None'; }
+    else if(wf==='BACTERIOLOGY'){ pill.className='pill bact'; pill.textContent='Bacteriology'; }
+    else { pill.className='pill tb'; pill.textContent='Mycobacteriology – TB'; }
+
+    var h = '';
+    // default method hint (assume a new test has no default method; existing bacterial one does)
+    var hasDefaultMethod = (mode==='existing');
+    if(wf!=='' && !hasDefaultMethod){
+      h += '<div class="hint warn"><span>⚠</span><div>No default <strong>Method</strong> set yet. Set one on the <strong>Methods</strong> tab — it becomes this culture\'s protocol. (Not a save-block; you can configure in any order.)</div></div>';
+      navMethods.classList.add('dim');
+    } else { navMethods.classList.remove('dim'); }
+
+    if(wf==='MYCOBACTERIOLOGY_TB'){
+      h += '<div class="hint info"><span>ℹ</span><div>TB workflow: the default Method should be a <strong>TB Method</strong> (MGIT / Löwenstein-Jensen / agar proportion), and interpretation will use the <strong>WHO-TB critical-concentration</strong> breakpoint family (M-02), not the clinical S/I/R ladder.</div></div>';
+    }
+    if(wf!=='' && !amr && !amrDismissed){
+      h += '<div class="hint amr"><span>○</span><div>Most culture tests are also exported for AMR surveillance — enable <strong>AMR</strong> above if this one should be.</div><span class="x" onclick="dismissAmr()">✕</span></div>';
+    }
+    if(mode==='existing' && wf!=='BACTERIOLOGY'){
+      h += '<div class="hint confirm"><span>!</span><div><strong>Changing the workflow on an existing test.</strong> New orders will create '+(wf===''?'<em>no</em>':'<strong>'+pill.textContent+'</strong>')+' cases. <strong>Existing open cases are unaffected</strong> — a tech reclassifies an open case from the Case Workbench (M-04 “Change workflow”). Nothing is retro-reclassified.</div></div>';
+    }
+    document.getElementById('hintBox').innerHTML = h;
+  }
+
+  function dismissAmr(){ amrDismissed = true; render(); }
+
+  function save(){
+    var wf = document.getElementById('wf').value;
+    var label = wf===''?'NULL (not a culture test)':wf;
+    document.getElementById('savedNote').textContent = '✓ Saved — test.culture_workflow_type = '+label+'  (audited)';
+  }
+
+  render();
+</script>
+</body>
+</html>

--- a/designs/admin-config/test-catalog-microbiology-workflow-attribute.md
+++ b/designs/admin-config/test-catalog-microbiology-workflow-attribute.md
@@ -1,0 +1,69 @@
+# Test Catalog v2.5 — Microbiology Workflow Attribute (`culture_workflow_type`) — FRS section
+
+**Version:** 1.0
+**Date:** 2026-06-08
+**Belongs to:** Test Catalog Management v2.5 — v1 (epic OGC-746), **Basic Info** editor section (sibling to OGC-748). Foldable into `test-catalog-requirements-v2.5.md` §2.1.
+**Driven by:** Microbiology module M-00/M-01/M-03 (the Culture-workflow designation the micro trigger resolver reads).
+**Status:** Draft — for coordination with the Test Catalog owner.
+
+> This is the **concrete home** for the attribute the micro specs depend on. M-03 §2.1a defines *how it's read* (the trigger resolver); this section defines *where and how an admin sets it* in the Test Catalog editor, and the schema. One nullable enum, in the Basic Info tab, orthogonal to Domain and the AMR flag.
+
+---
+
+## 1. Why this field exists
+A microbiology culture test (blood culture, TB culture, wound culture, …) is not just a result — ordering it should **start a multi-day Case workup** in the right profile (bacterial vs TB) and put the specimen on the Microbiology Worklist. Today the Test Catalog has no signal for this: its micro-relevant fields are the **AMR flag** (a WHONET/surveillance marker) and the test's **Methods**, neither of which says "run the culture workflow." Without a first-class field, case creation falls back to the clerk manually picking `Program = Microbiology`, which is forgettable and can't distinguish bacterial from TB. This field closes that gap.
+
+## 2. The field
+**`Microbiology workflow`** — a single optional select on the **Basic Info** tab.
+
+| Value | Meaning |
+|-------|---------|
+| *(blank / None)* | Not a culture-workflow test. Ordering it creates no Microbiology Case. (Default for all existing and new tests.) |
+| `BACTERIOLOGY` | Ordering it creates a **bacterial** Microbiology Case (M-04 profile). |
+| `MYCOBACTERIOLOGY_TB` | Ordering it creates a **TB** Microbiology Case (M-14 profile). |
+| `MYCOLOGY` | *Reserved* — not selectable until the Mycology module (M-16) ships. |
+
+- **Single enum, not a checkbox + select.** The presence of a value *is* "this is a culture-workflow test"; a separate boolean would be redundant and could drift out of sync. Blank = no workflow.
+- **Orthogonal to `Domain`.** A TB culture is still `Domain = CLINICAL`; `Domain` (Clinical / Environmental / Vector) answers "what kind of testing program," this answers "which micro case profile." They don't constrain each other.
+- **Orthogonal to the `AMR` flag.** `AMR` = "export results to WHONET / AMR surveillance." A test may be: culture-workflow only, AMR only, both (the common case for blood culture), or neither. The editor does not couple them, though selecting a workflow may *suggest* enabling AMR (non-blocking hint).
+- **Culture protocol is not set here.** It is the test's **default Method** (`test_method.is_default`) on the existing **Methods** tab (A-REUSE-1) — no `default_culture_protocol_id`. This field only routes the workflow.
+- **A test-level property, deliberately *not* a Method property.** `workflow_type` lives on the **test**, not on the Method, and there is **no workflow↔method mapping** — by design:
+  - Methods are **assigned to tests** (a test may have several) and are **reusable/shared** across tests, so a Method has no single workflow to carry; putting the enum there would be ambiguous and would leak one test's workflow onto every other test sharing that Method.
+  - Methods already do another job: **selecting which analyzer performs the work**. Overloading the Method with workflow routing would entangle "which instrument" with "which case profile" — two unrelated concerns — and force a new workflow↔method mapping the system doesn't have today.
+  - **Rejected alternative — "TB default Method prefills `workflow_type`."** Considered and dropped for the same reason: it would create exactly that method→workflow coupling. The TB-Method guidance in §3 stays **purely advisory** (a hint, no stored mapping, no auto-set). The admin sets `workflow_type` directly on the test; the default Method is chosen independently on the Methods tab for protocol + analyzer reasons.
+
+## 3. Editor behavior (Basic Info)
+- Rendered as a Carbon `Select`/`Dropdown` labeled **"Microbiology workflow"** in the Basic Info section, below the status flags, near the AMR flag group. Helper text: *"Set the microbiology workflow to make ordering this test create the matching Microbiology Case and appear in the Worklist. Bacteriology and Mycobacteriology–TB use different case profiles, breakpoints, and reports."*
+- When a non-blank value is selected, show a non-blocking inline hint group:
+  - if the test has **no default Method**, hint: *"Set a default Method on the Methods tab — it becomes this culture's protocol."* (warning, not a save-block, so configuration order is flexible);
+  - if `MYCOBACTERIOLOGY_TB` is selected, hint that the default Method should be a TB Method (MGIT / LJ / agar proportion) and interpretation will use the **WHO-TB critical-concentration** breakpoint family (M-02);
+  - if `AMR` is off, hint (dismissible): *"Most culture tests are also exported for AMR surveillance — enable AMR if this one should be."*
+- Changing the value on an existing test triggers a confirmation, mirroring the Domain-change pattern: *"New orders will create {workflow} cases. Existing open cases are unaffected; a tech can reclassify an open case from the Case Workbench."* (Existing cases are **not** retro-reclassified — that is the tech's Change-workflow action in M-04 §4.9.)
+- `MYCOLOGY` appears disabled with a "coming with the Mycology module" tooltip until M-16.
+
+## 4. Schema
+- **`test.culture_workflow_type`** — nullable enum/varchar (`BACTERIOLOGY` | `MYCOBACTERIOLOGY_TB` | `MYCOLOGY`), null = not a culture-workflow test. Liquibase changeset (Test Catalog migrations only; no direct DDL). Audited (`@Audited`) like other `test` fields.
+- No change to `test_amr_config` (AMR stays separate). No `default_culture_protocol_id` (protocol = default Method).
+- Persists on **Save Basic Info** alongside `test`, per OGC-748's persistence.
+
+## 5. How the rest of the system uses it
+- **M-03 trigger resolver** reads `culture_workflow_type` for each ordered test and returns the case `workflow_type` (or none) — the single source of truth for *whether* and *which* Case is created (M-03 §2.1a).
+- **Fallback unchanged:** if no ordered test carries the field, the manual `Program = Microbiology` path still creates a `BACTERIOLOGY` case, so untyped deployments keep working.
+- **Unassigned / mis-typed → tech reclassifies:** a case created without a valid `workflow_type` is `UNASSIGNED`; the tech sets/changes it via the Case Workbench **Change workflow** action (M-04 §4.9), audited and guarded once results exist. This field is the *configuration* default; M-04 §4.9 is the *runtime* correction.
+
+## 6. Migration / seeding
+- Backfill: all existing tests get `culture_workflow_type = NULL` (no behavior change). 
+- Deployments doing micro set the field on their culture tests as part of catalog setup; until they do, the fallback (and the M-04 `UNASSIGNED` escape hatch) cover them — no hard cutover.
+- Optional: a deployment data pack may seed common culture tests (blood culture → BACTERIOLOGY, TB culture / GeneXpert → MYCOBACTERIOLOGY_TB).
+
+## 7. Acceptance criteria
+- **AC-TC-MW-01** Basic Info shows a "Microbiology workflow" select with None / Bacteriology / Mycobacteriology–TB; Mycology disabled.
+- **AC-TC-MW-02** Selecting a value persists `test.culture_workflow_type`; blank persists null; field is audited.
+- **AC-TC-MW-03** The field is independent of Domain and the AMR flag (any combination is valid; only non-blocking hints are shown).
+- **AC-TC-MW-04** Ordering a test with `culture_workflow_type` set creates the matching Microbiology Case profile via the M-03 resolver; a blank test creates no case.
+- **AC-TC-MW-05** Changing the value warns that existing open cases are unaffected and reclassification is a Case-Workbench action; it does not retro-reclassify.
+- **AC-TC-MW-06** `MYCOBACTERIOLOGY_TB` with no TB default Method saves but surfaces the Method hint; configuration order is not forced.
+- **AC-TC-MW-07** Permission reuses `admin.testCatalog.manage`; all strings under `admin.testCatalog.basicInfo.microWorkflow.*`.
+
+## 8. Reuse / no-invention note
+Reuses the existing Basic Info editor, `test` table + audit, the Methods tab for the culture protocol, and the AMR flag for surveillance — adds exactly **one nullable enum column** and one select control. No new admin page, no coupling to Domain/AMR, no duplicate protocol store.

--- a/mockup-viewer/public/designs/admin-config/test-catalog-microbiology-workflow-attribute.html
+++ b/mockup-viewer/public/designs/admin-config/test-catalog-microbiology-workflow-attribute.html
@@ -1,0 +1,238 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Test Catalog — Microbiology Workflow Attribute — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+  body { background:#f4f4f4; margin:0; font-family:'IBM Plex Sans',sans-serif; color:#161616; }
+  .preview-banner { background:#0f62fe; color:#fff; padding:6px 1rem; font-size:12px; font-family:monospace; }
+  .preview-banner strong { background:#fff; color:#0f62fe; padding:1px 6px; border-radius:2px; margin:0 4px; }
+  .preview-banner .what { display:block; margin-top:4px; font-family:'IBM Plex Sans',sans-serif; font-size:12px; opacity:0.95; line-height:1.5; }
+  .demobar { background:#161616; color:#f4f4f4; font-size:12px; padding:0.5rem 1rem; display:flex; gap:0.6rem; align-items:center; flex-wrap:wrap; }
+  .demobar b { color:#78a9ff; }
+  .demobar button { font-size:12px; background:#393939; color:#f4f4f4; border:1px solid #6f6f6f; border-radius:3px; padding:3px 9px; cursor:pointer; }
+  .demobar button.on { background:#0f62fe; border-color:#0f62fe; }
+  .app-header { background:#161616; color:#f4f4f4; padding:0 1rem; height:48px; display:flex; align-items:center; gap:1rem; font-size:14px; }
+  .app-header .product { font-weight:600; }
+  .breadcrumbs { padding:0.6rem 2rem; background:#fff; border-bottom:1px solid #e0e0e0; font-size:13px; color:#525252; }
+  .breadcrumbs a { color:#0f62fe; text-decoration:none; }
+  .editor-head { background:#fff; padding:1rem 2rem 0; border-bottom:1px solid #e0e0e0; display:flex; align-items:flex-end; gap:1rem; }
+  .editor-head h1 { font-size:24px; font-weight:300; margin:0; }
+  .editor-head .code { font-size:13px; color:#6f6f6f; margin-bottom:5px; }
+  .editor-head .save { margin-left:auto; display:flex; gap:0.5rem; margin-bottom:0.6rem; }
+  .layout { display:grid; grid-template-columns:230px 1fr; }
+  .sidebar { background:#fff; border-right:1px solid #e0e0e0; min-height:calc(100vh - 200px); padding:0.5rem 0; }
+  .sidebar-group { padding:0.6rem 1rem 0.2rem; font-size:11px; color:#8d8d8d; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; }
+  .sidebar-item { padding:0.5rem 1rem; cursor:pointer; font-size:13px; border-left:3px solid transparent; }
+  .sidebar-item:hover { background:#e5e5e5; }
+  .sidebar-item.current { background:#e0e0e0; border-left-color:#0f62fe; font-weight:600; }
+  .sidebar-item.dim { color:#a8a8a8; }
+  .main { padding:1.5rem 2rem 5rem; max-width:760px; }
+  .section-title { font-size:18px; font-weight:400; margin:0 0 1.2rem; }
+  .fieldset { background:#fff; border:1px solid #e0e0e0; padding:1.2rem 1.4rem; margin-bottom:1.2rem; }
+  .fieldset h3 { font-size:11px; text-transform:uppercase; letter-spacing:0.5px; color:#525252; margin:0 0 0.9rem; font-weight:600; }
+  .fieldset h3 .new { background:#0f62fe; color:#fff; font-size:9px; padding:1px 6px; border-radius:3px; margin-left:8px; letter-spacing:0.5px; }
+  .frow { margin-bottom:1rem; }
+  label.lbl { display:block; font-size:12px; color:#525252; margin-bottom:0.3rem; }
+  input.txt, select.sel { font-family:inherit; font-size:14px; padding:0.55rem 0.7rem; border:none; border-bottom:1px solid #8d8d8d; background:#f4f4f4; width:100%; max-width:420px; }
+  select.sel { cursor:pointer; }
+  .help { font-size:12px; color:#6f6f6f; margin:0.3rem 0 0; max-width:520px; line-height:1.5; }
+  .radio-row, .flag-row { display:flex; gap:1.4rem; flex-wrap:wrap; }
+  .radio-row label, .flag-row label { font-size:14px; display:flex; align-items:center; gap:0.4rem; cursor:pointer; }
+  .hint { font-size:12.5px; padding:0.6rem 0.8rem; border-radius:2px; margin-top:0.7rem; display:flex; gap:0.5rem; align-items:flex-start; line-height:1.5; max-width:540px; }
+  .hint .x { margin-left:auto; cursor:pointer; color:#525252; font-weight:700; padding:0 4px; }
+  .hint.info { background:#edf5ff; border-left:3px solid #0f62fe; }
+  .hint.warn { background:#fff8e1; border-left:3px solid #f1c21b; }
+  .hint.amr  { background:#f6f2ff; border-left:3px solid #8a3ffc; }
+  .hint.confirm { background:#fff8e1; border-left:3px solid #ff832b; }
+  .pill { display:inline-block; padding:2px 9px; border-radius:12px; font-size:11px; font-weight:600; }
+  .pill.bact { background:#d0e2ff; color:#0043ce; } .pill.tb { background:#e8daff; color:#491d8b; } .pill.none { background:#e0e0e0; color:#525252; }
+  .btn { font-family:inherit; font-size:13px; padding:0.45rem 1rem; border-radius:2px; border:1px solid #0f62fe; cursor:pointer; }
+  .btn.primary { background:#0f62fe; color:#fff; } .btn.ghost { background:#fff; color:#0f62fe; }
+  .saved-note { font-size:12px; color:#24a148; margin-top:0.4rem; min-height:16px; font-weight:600; }
+  .axis-note { font-size:12px; color:#6f6f6f; background:#f4f4f4; padding:0.5rem 0.7rem; border-radius:2px; margin-top:0.4rem; }
+  code { background:#e8e8e8; padding:0 4px; border-radius:3px; font-size:12px; }
+</style>
+</head>
+<body>
+<div class="preview-banner">
+  PREVIEW MOCKUP <strong>Test Catalog v2.5</strong> Basic Info → <strong>Microbiology workflow</strong> (OGC-925)
+  <span class="what">Where an admin sets which micro workflow a culture test starts. One nullable <code>test.culture_workflow_type</code> enum, orthogonal to Domain and the AMR flag. Spec: test-catalog-micro-workflow-attribute.md.</span>
+</div>
+<div class="demobar">
+  <b>DEMO:</b> editing a&nbsp;
+  <button id="modeNew" class="on" onclick="setMode('new')">new test</button>
+  <button id="modeExisting" onclick="setMode('existing')">existing test (has open cases)</button>
+  <span style="margin-left:auto;opacity:0.8;">Change "Microbiology workflow" to see hints + (on an existing test) the reclassification notice.</span>
+</div>
+
+<div class="app-header"><span class="product">OpenELIS Global</span><span>· Admin · Test Catalog Management</span></div>
+<div class="breadcrumbs"><a>Admin</a> / <a>Test Catalog</a> / <a>Tests</a> / <span id="bcName">New test</span></div>
+
+<div class="editor-head">
+  <div>
+    <h1 id="testName">New test</h1>
+    <div class="code" id="testCode">Code: —</div>
+  </div>
+  <div class="save">
+    <button class="btn ghost">Save as new test…</button>
+    <button class="btn primary" onclick="save()">Save Test</button>
+  </div>
+</div>
+
+<div class="layout">
+  <div class="sidebar">
+    <div class="sidebar-group">Configuration</div>
+    <div class="sidebar-item current">Basic Info</div>
+    <div class="sidebar-item">Sample &amp; Results</div>
+    <div class="sidebar-item">Ranges</div>
+    <div class="sidebar-item">Sample Storage</div>
+    <div class="sidebar-group">Organization</div>
+    <div class="sidebar-item">Display Order</div>
+    <div class="sidebar-item">Panels</div>
+    <div class="sidebar-item">Terminology</div>
+    <div class="sidebar-group">Resources</div>
+    <div class="sidebar-item" id="navMethods">Methods</div>
+    <div class="sidebar-item">Analyzers</div>
+  </div>
+
+  <div class="main">
+    <div class="section-title">Basic Info</div>
+
+    <div class="fieldset">
+      <h3>Identity</h3>
+      <div class="frow">
+        <label class="lbl">Test name</label>
+        <input class="txt" id="fName" value="" placeholder="e.g. Mycobacterial culture (MGIT)">
+      </div>
+      <div class="frow">
+        <label class="lbl">Code</label>
+        <input class="txt" id="fCode" value="" placeholder="e.g. TBC-MGIT" style="max-width:220px;">
+      </div>
+      <div class="frow" style="margin-bottom:0;">
+        <label class="lbl">Domain <span style="color:#da1e28;">*</span></label>
+        <div class="radio-row">
+          <label><input type="radio" name="dom" checked> Clinical</label>
+          <label><input type="radio" name="dom"> Environmental</label>
+          <label><input type="radio" name="dom"> Vector</label>
+        </div>
+        <div class="axis-note">Domain answers <em>"what kind of testing program"</em> — a TB culture is still <strong>Clinical</strong>. It does not decide the micro workflow.</div>
+      </div>
+    </div>
+
+    <div class="fieldset">
+      <h3>Status &amp; surveillance</h3>
+      <div class="frow">
+        <label class="lbl">Status flags</label>
+        <div class="flag-row">
+          <label><input type="checkbox" checked> Active</label>
+          <label><input type="checkbox" checked> Orderable</label>
+          <label><input type="checkbox"> Internal QA — No Results Release</label>
+        </div>
+      </div>
+      <div class="frow" style="margin-bottom:0;">
+        <label class="lbl">AMR / WHONET surveillance</label>
+        <div class="flag-row">
+          <label><input type="checkbox" id="amrFlag" onchange="render()"> AMR test (export to WHONET / AMR surveillance)</label>
+        </div>
+        <div class="axis-note">AMR answers <em>"export results for surveillance"</em> — independent of the workflow below. A test can be one, both, or neither.</div>
+      </div>
+    </div>
+
+    <div class="fieldset">
+      <h3>Microbiology workflow <span class="new">NEW · OGC-925</span></h3>
+      <div class="frow" style="margin-bottom:0.4rem;">
+        <label class="lbl">Microbiology workflow</label>
+        <select class="sel" id="wf" onchange="onWf()">
+          <option value="">None — not a culture-workflow test</option>
+          <option value="BACTERIOLOGY">Bacteriology → bacterial Case (M-04)</option>
+          <option value="MYCOBACTERIOLOGY_TB">Mycobacteriology – TB → TB Case (M-14)</option>
+          <option value="MYCOLOGY" disabled>Mycology (coming with the Mycology module, M-16)</option>
+        </select>
+        <p class="help">Set the microbiology workflow to make ordering this test <strong>create the matching Microbiology Case</strong> and appear in the Worklist. Bacteriology and Mycobacteriology–TB use different case profiles, breakpoints, and reports. Persisted as <code>test.culture_workflow_type</code>.</p>
+        <div style="margin-top:0.5rem;">Current: <span id="wfPill" class="pill none">None</span></div>
+        <div class="axis-note">A <strong>test-level</strong> property — not set on Methods. Methods are assigned to tests and also pick the <em>analyzer</em>; there is no workflow↔method mapping, so workflow lives here on the test. The default Method (the culture protocol) is chosen independently on the Methods tab.</div>
+      </div>
+      <div id="hintBox"></div>
+    </div>
+
+    <div class="saved-note" id="savedNote"></div>
+  </div>
+</div>
+
+<script>
+  var mode = 'new';
+  var amrDismissed = false;
+
+  function setMode(m){
+    mode = m;
+    amrDismissed = false;
+    document.getElementById('modeNew').classList.toggle('on', m==='new');
+    document.getElementById('modeExisting').classList.toggle('on', m==='existing');
+    if(m==='existing'){
+      document.getElementById('fName').value = 'Blood culture, aerobic';
+      document.getElementById('fCode').value = 'BC-AER';
+      document.getElementById('testName').textContent = 'Blood culture, aerobic';
+      document.getElementById('bcName').textContent = 'Blood culture, aerobic';
+      document.getElementById('testCode').textContent = 'Code: BC-AER';
+      document.getElementById('amrFlag').checked = true;
+      document.getElementById('wf').value = 'BACTERIOLOGY';
+    } else {
+      document.getElementById('fName').value = '';
+      document.getElementById('fCode').value = '';
+      document.getElementById('testName').textContent = 'New test';
+      document.getElementById('bcName').textContent = 'New test';
+      document.getElementById('testCode').textContent = 'Code: —';
+      document.getElementById('amrFlag').checked = false;
+      document.getElementById('wf').value = '';
+    }
+    document.getElementById('savedNote').textContent = '';
+    render();
+  }
+
+  function onWf(){ amrDismissed = false; document.getElementById('savedNote').textContent=''; render(); }
+
+  function render(){
+    var wf = document.getElementById('wf').value;
+    var amr = document.getElementById('amrFlag').checked;
+    var pill = document.getElementById('wfPill');
+    var navMethods = document.getElementById('navMethods');
+
+    if(wf===''){ pill.className='pill none'; pill.textContent='None'; }
+    else if(wf==='BACTERIOLOGY'){ pill.className='pill bact'; pill.textContent='Bacteriology'; }
+    else { pill.className='pill tb'; pill.textContent='Mycobacteriology – TB'; }
+
+    var h = '';
+    // default method hint (assume a new test has no default method; existing bacterial one does)
+    var hasDefaultMethod = (mode==='existing');
+    if(wf!=='' && !hasDefaultMethod){
+      h += '<div class="hint warn"><span>⚠</span><div>No default <strong>Method</strong> set yet. Set one on the <strong>Methods</strong> tab — it becomes this culture\'s protocol. (Not a save-block; you can configure in any order.)</div></div>';
+      navMethods.classList.add('dim');
+    } else { navMethods.classList.remove('dim'); }
+
+    if(wf==='MYCOBACTERIOLOGY_TB'){
+      h += '<div class="hint info"><span>ℹ</span><div>TB workflow: the default Method should be a <strong>TB Method</strong> (MGIT / Löwenstein-Jensen / agar proportion), and interpretation will use the <strong>WHO-TB critical-concentration</strong> breakpoint family (M-02), not the clinical S/I/R ladder.</div></div>';
+    }
+    if(wf!=='' && !amr && !amrDismissed){
+      h += '<div class="hint amr"><span>○</span><div>Most culture tests are also exported for AMR surveillance — enable <strong>AMR</strong> above if this one should be.</div><span class="x" onclick="dismissAmr()">✕</span></div>';
+    }
+    if(mode==='existing' && wf!=='BACTERIOLOGY'){
+      h += '<div class="hint confirm"><span>!</span><div><strong>Changing the workflow on an existing test.</strong> New orders will create '+(wf===''?'<em>no</em>':'<strong>'+pill.textContent+'</strong>')+' cases. <strong>Existing open cases are unaffected</strong> — a tech reclassifies an open case from the Case Workbench (M-04 “Change workflow”). Nothing is retro-reclassified.</div></div>';
+    }
+    document.getElementById('hintBox').innerHTML = h;
+  }
+
+  function dismissAmr(){ amrDismissed = true; render(); }
+
+  function save(){
+    var wf = document.getElementById('wf').value;
+    var label = wf===''?'NULL (not a culture test)':wf;
+    document.getElementById('savedNote').textContent = '✓ Saved — test.culture_workflow_type = '+label+'  (audited)';
+  }
+
+  render();
+</script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -210,6 +210,18 @@ export const MOCKUP_REGISTRY = [
     jira: ['OGC-760','OGC-761','OGC-762','OGC-763','OGC-764','OGC-765','OGC-766','OGC-767'],
     tags: ['test-catalog', 'jira', 'v2', 'story-breakdown', 'admin'],
   },
+  {
+    name: 'Test Catalog — Microbiology Workflow Attribute',
+    category: 'admin-config',
+    component: null,
+    description: 'Test Catalog Basic Info: a nullable culture_workflow_type enum (None / Bacteriology / Mycobacteriology\u2013TB; Mycology reserved), orthogonal to Domain and the AMR flag; drives micro case routing (M-03/M-04). Foldable into Test Catalog v2.5 \u00a72.1 Basic Info.',
+    specPath: 'designs/admin-config/test-catalog-microbiology-workflow-attribute.md',
+    htmlUrl: 'designs/admin-config/test-catalog-microbiology-workflow-attribute.html',
+    added: '2026-06-08',
+    status: 'draft',
+    jira: ['OGC-925'],
+    tags: ['test-catalog', 'microbiology', 'png', 'workflow-type', 'basic-info', 'admin'],
+  },
 
   {
     name: 'RBAC Management',


### PR DESCRIPTION
…bute (OGC-925)

Registers the Test Catalog Basic Info microbiology workflow attribute spec + interactive prototype into the gallery (admin-config). Adds a nullable culture_workflow_type enum (Bacteriology / Mycobacteriology-TB) orthogonal to Domain and the AMR flag; drives micro case routing (M-03/M-04). Foldable into Test Catalog v2.5 §2.1 Basic Info so the test catalog work can reuse the concept. Tagged microbiology + png. HTML-only entry (no JSX); mockup-viewer tests green (228/228).

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
