### PR TITLE
feat(microbiology): add M-10 and M-12 interactive HTML prototypes

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -738,13 +738,16 @@
 - id: m-10-hub-subscription
   type: spec
   path: designs/microbiology/m-10-hub-subscription.md
+  preview: designs/microbiology/m-10-hub-subscription-prototype.html
   category: microbiology
   description: >
     M-10: Unified Hub admin for breakpoint + WHONET code + organism/antibiotic updates. Phase 1B.
   links:
     jira: ["OGC-795"]
     gallery: https://digi-uw.github.io/openelis-work/#/microbiology/m-10-hub-subscription
+    preview: https://digi-uw.github.io/openelis-work/designs/microbiology/m-10-hub-subscription-prototype.html
   added: "2026-05-15"
+  updated: "2026-06-08"
 
 - id: m-11-critical-result-acknowledgment
   type: spec
@@ -761,13 +764,16 @@
 - id: m-12-test-reagent-linkage
   type: spec
   path: designs/microbiology/m-12-test-reagent-linkage.md
+  preview: designs/microbiology/m-12-test-reagent-linkage-prototype.html
   category: microbiology
   description: >
     M-12: Test → Reagent linkage (ISO 15189 §7.3). General OE foundation; parallel pre-track.
   links:
     jira: ["OGC-784"]
     gallery: https://digi-uw.github.io/openelis-work/#/microbiology/m-12-test-to-reagent-linkage
+    preview: https://digi-uw.github.io/openelis-work/designs/microbiology/m-12-test-reagent-linkage-prototype.html
   added: "2026-05-15"
+  updated: "2026-06-08"
 
 # ─── Microbiology — FRS v1.0 formal docs ─────────────────────────────────
 

--- a/designs/microbiology/amr-micro-dependency-graph.svg
+++ b/designs/microbiology/amr-micro-dependency-graph.svg
@@ -1,85 +1,107 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1300 600" font-family="IBM Plex Sans, Arial, sans-serif">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1340 660" font-family="IBM Plex Sans, Arial, sans-serif">
   <style>
     .mvp { fill:#edf5ff; stroke:#0f62fe; stroke-width:1.5; }
     .plus { fill:#d9fbfb; stroke:#007d79; stroke-width:1.5; }
     .b1 { fill:#f6f2ff; stroke:#8a3ffc; stroke-width:1.5; }
+    .p2 { fill:#fff0f7; stroke:#d12771; stroke-width:1.5; }
+    .tb { fill:#f0e6ff; stroke:#6929c4; stroke-width:1.5; }
     .hub { fill:#fff8e1; stroke:#b28600; stroke-width:2.5; }
+    .umb { fill:#fff8e1; stroke:#8a3800; stroke-width:2.5; }
+    .ext { fill:#f4f4f4; stroke:#8d8d8d; stroke-width:1.3; stroke-dasharray:4 3; }
     .key { font-size:12px; font-weight:700; fill:#161616; }
     .name { font-size:11px; fill:#393939; }
     .pts { font-size:10px; fill:#6f6f6f; }
     .edge { stroke:#a8a8a8; stroke-width:1.3; fill:none; marker-end:url(#arrow); }
     .kdep { stroke:#0f62fe; stroke-width:1.8; fill:none; marker-end:url(#arrowb); }
+    .extedge { stroke:#8d8d8d; stroke-width:1.2; fill:none; stroke-dasharray:4 3; marker-end:url(#arrowg); }
     .tier { font-size:11px; fill:#8d8d8d; font-weight:600; letter-spacing:0.5px; }
     .title { font-size:20px; font-weight:600; fill:#161616; }
     .sub { font-size:12px; fill:#6f6f6f; }
     .legend { font-size:11px; fill:#393939; }
+    .tag { font-size:9px; font-weight:700; fill:#8a3800; }
   </style>
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#a8a8a8"/></marker>
     <marker id="arrowb" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#0f62fe"/></marker>
+    <marker id="arrowg" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M0,0 L10,5 L0,10 z" fill="#8d8d8d"/></marker>
   </defs>
 
   <text x="24" y="32" class="title">Microbiology / AMR — Epic Dependency Graph</text>
-  <text x="24" y="52" class="sub">Arrows = "blocks" (build order, left to right). 14 epics · 75 child stories · all relate to the M-00 spine. Blue = key dependency.</text>
+  <text x="24" y="52" class="sub">Arrows = "blocks" (build order, left to right). 17 epics · ~95 child stories · all relate to the M-00 umbrella (OGC-782). Case keyed to SampleItem × workflow_type. Blue = key dependency.</text>
 
-  <text x="95" y="86" class="tier" text-anchor="middle">FOUNDATIONS</text>
-  <text x="315" y="86" class="tier" text-anchor="middle">CATALOG</text>
-  <text x="520" y="86" class="tier" text-anchor="middle">CASE HUB</text>
-  <text x="735" y="86" class="tier" text-anchor="middle">OPERATIONAL</text>
-  <text x="935" y="86" class="tier" text-anchor="middle">REVIEW / WORKLIST</text>
-  <text x="1135" y="86" class="tier" text-anchor="middle">SURVEILLANCE</text>
+  <text x="95" y="84" class="tier" text-anchor="middle">FOUNDATIONS</text>
+  <text x="310" y="84" class="tier" text-anchor="middle">CATALOG</text>
+  <text x="522" y="84" class="tier" text-anchor="middle">CASE HUB</text>
+  <text x="740" y="84" class="tier" text-anchor="middle">OPERATIONAL</text>
+  <text x="940" y="84" class="tier" text-anchor="middle">REVIEW / WORKLIST</text>
+  <text x="1155" y="84" class="tier" text-anchor="middle">SURVEILLANCE / REPORTING</text>
 
-  <!-- EDGES -->
-  <path class="kdep" d="M170,134 L240,204"/>
-  <path class="kdep" d="M170,134 L440,275"/>
-  <path class="kdep" d="M170,134 L660,274"/>
-  <path class="edge" d="M170,134 L660,174"/>
-  <path class="edge" d="M170,134 L1060,200"/>
-  <path class="kdep" d="M170,204 L440,279"/>
-  <path class="edge" d="M170,204 L660,278"/>
-  <path class="edge" d="M170,274 L440,288"/>
-  <path class="edge" d="M170,274 L660,286"/>
-  <path class="kdep" d="M390,204 L440,275"/>
-  <path class="kdep" d="M390,204 L660,270"/>
-  <path class="kdep" d="M600,279 L660,274"/>
-  <path class="edge" d="M520,250 L660,178"/>
-  <path class="edge" d="M600,283 L860,352"/>
-  <path class="edge" d="M600,292 L660,470"/>
-  <path class="edge" d="M600,279 L1060,202"/>
-  <path class="edge" d="M810,274 L860,350"/>
-  <path class="edge" d="M810,278 L860,452"/>
-  <path class="edge" d="M810,274 L1060,206"/>
-  <path class="edge" d="M1010,452 L1060,214"/>
-  <path class="edge" d="M1135,252 L1135,300"/>
+  <!-- EDGES (key deps, blue) -->
+  <path class="kdep" d="M170,133 L235,188"/>
+  <path class="kdep" d="M170,133 L440,258"/>
+  <path class="kdep" d="M385,197 L440,262"/>
+  <path class="kdep" d="M385,200 L665,262"/>
+  <path class="kdep" d="M522,298 L522,330"/>
+  <path class="kdep" d="M385,210 L440,360"/>
+  <!-- EDGES (relates / feeds, grey) -->
+  <path class="edge" d="M665,172 L607,268"/>
+  <path class="edge" d="M815,265 L865,335"/>
+  <path class="edge" d="M815,268 L865,438"/>
+  <path class="edge" d="M607,268 L865,338"/>
+  <path class="edge" d="M607,288 L665,452"/>
+  <path class="edge" d="M170,133 L1075,168"/>
+  <path class="edge" d="M385,205 L1075,172"/>
+  <path class="edge" d="M815,265 L1075,262"/>
+  <path class="edge" d="M1155,200 L1155,240"/>
+  <path class="edge" d="M1075,470 L1075,360"/>
+  <!-- M-14 feeds M-09 (WHONET-TB) -->
+  <path class="edge" d="M607,352 L1075,178"/>
+  <!-- M-15 blocked by M-14 + M-09 (routed along the bottom to avoid nodes) -->
+  <path class="kdep" d="M522,388 L522,560 L1155,560 L1155,382"/>
+  <!-- external: Test Catalog workflow attribute blocks M-03 primary path -->
+  <path class="extedge" d="M385,318 L665,182"/>
 
   <!-- NODES -->
-  <g><rect class="mvp" x="20" y="110" width="150" height="48" rx="6"/><text x="30" y="131" class="key">OGC-786 · M-01</text><text x="30" y="148" class="name">Reference data</text></g>
-  <g><rect class="mvp" x="20" y="180" width="150" height="48" rx="6"/><text x="30" y="201" class="key">OGC-784 · M-12</text><text x="30" y="218" class="name">Reagent linkage</text></g>
-  <g><rect class="mvp" x="20" y="250" width="150" height="48" rx="6"/><text x="30" y="271" class="key">OGC-788 · M-08</text><text x="30" y="288" class="name">Macro library</text></g>
-  <g><rect class="mvp" x="20" y="320" width="150" height="48" rx="6"/><text x="30" y="341" class="key">OGC-782 · M-00</text><text x="30" y="358" class="name">Parent / spec</text></g>
-  <g><rect class="mvp" x="20" y="390" width="150" height="48" rx="6"/><text x="30" y="411" class="key">OGC-783 · M-NFR</text><text x="30" y="428" class="name">Non-functional</text></g>
+  <!-- FOUNDATIONS -->
+  <g><rect class="mvp" x="20" y="108" width="150" height="48" rx="6"/><text x="30" y="129" class="key">OGC-786 · M-01</text><text x="30" y="146" class="name">Reference data</text></g>
+  <g><rect class="mvp" x="20" y="172" width="150" height="48" rx="6"/><text x="30" y="193" class="key">OGC-784 · M-12</text><text x="30" y="210" class="name">Reagent linkage</text></g>
+  <g><rect class="mvp" x="20" y="236" width="150" height="48" rx="6"/><text x="30" y="257" class="key">OGC-788 · M-08</text><text x="30" y="274" class="name">Macro library</text></g>
+  <g><rect class="umb" x="20" y="300" width="150" height="50" rx="6"/><text x="30" y="320" class="key">OGC-782 · M-00</text><text x="30" y="336" class="name">Parent / umbrella</text><text x="30" y="347" class="tag">UMBRELLA · owns spine</text></g>
+  <g><rect class="mvp" x="20" y="372" width="150" height="48" rx="6"/><text x="30" y="393" class="key">OGC-783 · M-NFR</text><text x="30" y="410" class="name">Non-functional</text></g>
 
-  <g><rect class="mvp" x="240" y="180" width="150" height="48" rx="6"/><text x="250" y="201" class="key">OGC-787 · M-02</text><text x="250" y="218" class="name">Breakpoints</text></g>
+  <!-- CATALOG -->
+  <g><rect class="mvp" x="235" y="172" width="150" height="48" rx="6"/><text x="245" y="193" class="key">OGC-787 · M-02</text><text x="245" y="210" class="name">Breakpoints (+WHO-TB)</text></g>
+  <g><rect class="ext" x="235" y="300" width="150" height="50" rx="6"/><text x="245" y="320" class="key">OGC-925</text><text x="245" y="336" class="name">Test Catalog:</text><text x="245" y="348" class="name">workflow_type attr</text></g>
 
-  <g><rect class="hub" x="440" y="250" width="160" height="58" rx="6"/><text x="452" y="272" class="key">OGC-790 · M-04</text><text x="452" y="288" class="name">Case Workbench (hub)</text><text x="452" y="302" class="pts">21 stories · 95 pts</text></g>
+  <!-- CASE HUB -->
+  <g><rect class="hub" x="440" y="240" width="167" height="58" rx="6"/><text x="452" y="262" class="key">OGC-790 · M-04</text><text x="452" y="278" class="name">Case Workbench (hub)</text><text x="452" y="292" class="pts">keyed: sample_item × workflow_type</text></g>
+  <g><rect class="tb" x="440" y="330" width="167" height="58" rx="6"/><text x="452" y="352" class="key">OGC-901 · M-14</text><text x="452" y="368" class="name">Mycobacteriology / TB</text><text x="452" y="382" class="pts">TB profile of M-04</text></g>
 
-  <g><rect class="mvp" x="660" y="150" width="150" height="48" rx="6"/><text x="670" y="171" class="key">OGC-789 · M-03</text><text x="670" y="188" class="name">Order-entry hook</text></g>
-  <g><rect class="plus" x="660" y="250" width="150" height="48" rx="6"/><text x="670" y="271" class="key">OGC-791 · M-05</text><text x="670" y="288" class="name">AST entry</text></g>
-  <g><rect class="mvp" x="660" y="450" width="150" height="48" rx="6"/><text x="670" y="471" class="key">OGC-785 · M-11</text><text x="670" y="488" class="name">Critical notify</text></g>
+  <!-- OPERATIONAL -->
+  <g><rect class="mvp" x="665" y="150" width="150" height="48" rx="6"/><text x="675" y="171" class="key">OGC-789 · M-03</text><text x="675" y="188" class="name">Order-entry hook</text></g>
+  <g><rect class="plus" x="665" y="240" width="150" height="48" rx="6"/><text x="675" y="261" class="key">OGC-791 · M-05</text><text x="675" y="278" class="name">AST entry</text></g>
+  <g><rect class="mvp" x="665" y="440" width="150" height="48" rx="6"/><text x="675" y="461" class="key">OGC-785 · M-11</text><text x="675" y="478" class="name">Critical notify (reuse)</text></g>
 
-  <g><rect class="plus" x="860" y="330" width="150" height="48" rx="6"/><text x="870" y="351" class="key">OGC-792 · M-07</text><text x="870" y="368" class="name">Worklists</text></g>
-  <g><rect class="b1" x="860" y="430" width="150" height="48" rx="6"/><text x="870" y="451" class="key">OGC-793 · M-06</text><text x="870" y="468" class="name">Expert rules</text></g>
+  <!-- REVIEW / WORKLIST -->
+  <g><rect class="plus" x="865" y="320" width="150" height="48" rx="6"/><text x="875" y="341" class="key">OGC-792 · M-07</text><text x="875" y="358" class="name">Worklists</text></g>
+  <g><rect class="b1" x="865" y="420" width="150" height="48" rx="6"/><text x="875" y="441" class="key">OGC-793 · M-06</text><text x="875" y="458" class="name">Expert rules (inline)</text></g>
 
-  <g><rect class="plus" x="1060" y="180" width="150" height="48" rx="6"/><text x="1070" y="201" class="key">OGC-794 · M-09</text><text x="1070" y="218" class="name">WHONET export</text></g>
-  <g><rect class="b1" x="1060" y="300" width="150" height="48" rx="6"/><text x="1070" y="321" class="key">OGC-795 · M-10</text><text x="1070" y="338" class="name">Hub subscription</text></g>
+  <!-- SURVEILLANCE / REPORTING -->
+  <g><rect class="plus" x="1075" y="150" width="160" height="48" rx="6"/><text x="1085" y="171" class="key">OGC-794 · M-09</text><text x="1085" y="188" class="name">WHONET (reuse existing)</text></g>
+  <g><rect class="p2" x="1075" y="240" width="160" height="48" rx="6"/><text x="1085" y="261" class="key">OGC-900 · M-13</text><text x="1085" y="278" class="name">Antibiogram (CLSI M39)</text></g>
+  <g><rect class="p2" x="1075" y="332" width="160" height="50" rx="6"/><text x="1085" y="352" class="key">OGC-918 · M-15</text><text x="1085" y="368" class="name">GLASS via consolidated FHIR</text><text x="1085" y="379" class="tag" fill="#d12771">LAST</text></g>
+  <g><rect class="b1" x="1075" y="450" width="160" height="48" rx="6"/><text x="1085" y="471" class="key">OGC-795 · M-10</text><text x="1085" y="488" class="name">Hub subscription</text></g>
 
   <!-- legend -->
-  <g transform="translate(24,560)">
+  <g transform="translate(24,600)">
     <rect x="0" y="0" width="14" height="12" rx="2" fill="#edf5ff" stroke="#0f62fe"/><text x="20" y="10" class="legend">MVP-1A</text>
-    <rect x="95" y="0" width="14" height="12" rx="2" fill="#d9fbfb" stroke="#007d79"/><text x="115" y="10" class="legend">Phase 1A+</text>
-    <rect x="205" y="0" width="14" height="12" rx="2" fill="#f6f2ff" stroke="#8a3ffc"/><text x="225" y="10" class="legend">Phase 1B</text>
-    <rect x="300" y="0" width="14" height="12" rx="2" fill="#fff8e1" stroke="#b28600" stroke-width="2"/><text x="320" y="10" class="legend">Case hub</text>
-    <line x1="405" y1="6" x2="445" y2="6" class="kdep"/><text x="452" y="10" class="legend">key dependency</text>
-    <text x="600" y="10" class="legend" fill="#8d8d8d">(M-01, M-02, M-09 also feed M-10)</text>
+    <rect x="92" y="0" width="14" height="12" rx="2" fill="#d9fbfb" stroke="#007d79"/><text x="112" y="10" class="legend">Phase 1A+</text>
+    <rect x="200" y="0" width="14" height="12" rx="2" fill="#f6f2ff" stroke="#8a3ffc"/><text x="220" y="10" class="legend">Phase 1B</text>
+    <rect x="292" y="0" width="14" height="12" rx="2" fill="#fff0f7" stroke="#d12771"/><text x="312" y="10" class="legend">Phase 2</text>
+    <rect x="372" y="0" width="14" height="12" rx="2" fill="#f0e6ff" stroke="#6929c4"/><text x="392" y="10" class="legend">TB profile</text>
+    <rect x="458" y="0" width="14" height="12" rx="2" fill="#fff8e1" stroke="#8a3800" stroke-width="2"/><text x="478" y="10" class="legend">M-00 umbrella / case hub</text>
+    <rect x="640" y="0" width="14" height="12" rx="2" fill="#f4f4f4" stroke="#8d8d8d" stroke-dasharray="3 2"/><text x="660" y="10" class="legend">external dep (Test Catalog)</text>
+    <line x1="838" y1="6" x2="878" y2="6" class="kdep"/><text x="885" y="10" class="legend">key dependency</text>
   </g>
+  <text x="24" y="640" class="legend" fill="#8d8d8d">M-14 (TB) is a profile of M-04 and feeds M-09 (WHONET-TB). M-15 is blocked by M-09 + M-14 (+ M-02 WHO-TB). M-13/M-15 reuse M-09's first-isolate dedup. OGC-925 (Test Catalog workflow_type) gates M-03's primary path.</text>
 </svg>

--- a/designs/microbiology/m-10-hub-subscription-prototype.html
+++ b/designs/microbiology/m-10-hub-subscription-prototype.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-10 Hub Subscription — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+ body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+ .pv{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+ .pv strong{background:#fff;color:#0f62fe;padding:1px 6px;border-radius:2px;margin:0 4px;}
+ .pv .w{display:block;margin-top:4px;font-family:'IBM Plex Sans',sans-serif;font-size:12px;opacity:.95;}
+ .ah{background:#161616;color:#f4f4f4;height:44px;display:flex;align-items:center;gap:1rem;padding:0 1rem;font-size:14px;}.ah .p{font-weight:600;}
+ .bc{background:#fff;border-bottom:1px solid #e0e0e0;padding:.5rem 2rem;font-size:13px;color:#525252;}
+ .main{padding:1.25rem 2rem 4rem;max-width:880px;}
+ h2.pg{font-size:21px;font-weight:300;margin:0 0 .3rem;}.sub{font-size:13px;color:#6f6f6f;margin:0 0 1rem;}
+ .btn{font-family:inherit;font-size:13px;padding:.45rem .9rem;border-radius:2px;border:1px solid #0f62fe;cursor:pointer;background:#fff;color:#0f62fe;}
+ .btn.primary{background:#0f62fe;color:#fff;}.btn.sm{font-size:12px;padding:.3rem .6rem;}.btn.ghost{border-color:#8d8d8d;color:#393939;}
+ .card{background:#fff;border:1px solid #e0e0e0;padding:1rem 1.3rem;margin-bottom:1rem;border-radius:2px;}
+ .conn{display:flex;align-items:center;gap:.6rem;font-size:14px;}
+ .dot{width:10px;height:10px;border-radius:50%;background:#24a148;}
+ .upd{border:1px solid #e0e0e0;border-left:4px solid #0f62fe;border-radius:2px;padding:.7rem .9rem;margin-bottom:.6rem;}
+ .upd.conflict{border-left-color:#f1c21b;background:#fffdf4;}
+ .upd .h{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;} .upd .h .r{margin-left:auto;display:flex;gap:.4rem;}
+ .code{font-family:monospace;background:#e8e8e8;padding:1px 6px;border-radius:3px;font-size:12px;}
+ .diff{font-size:12px;color:#525252;margin-top:.4rem;} .add{color:#044317;} .chg{color:#0043ce;} .warn{color:#684e00;}
+ .note{font-size:12px;color:#6f6f6f;background:#edf5ff;border-left:3px solid #0f62fe;padding:.55rem .8rem;border-radius:2px;margin-top:.6rem;line-height:1.5;}
+ .toast{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);background:#161616;color:#fff;padding:.6rem 1.1rem;border-radius:4px;font-size:13px;opacity:0;transition:.25s;pointer-events:none;}.toast.show{opacity:1;}
+</style></head><body>
+<div class="pv">PREVIEW MOCKUP <strong>M-10</strong> Hub Subscription — pull updated AMR reference data
+<span class="w">Fetch official organism/antibiotic code lists and breakpoint standards from the central Hub; merge with local edits (local customizations preserved). Phase 1B.</span></div>
+<div class="ah"><span class="p">OpenELIS Global</span><span>· Admin · Hub Subscription</span></div>
+<div class="bc">Admin / Hub Subscription</div>
+<div class="main">
+ <h2 class="pg">Hub Subscription</h2>
+ <p class="sub">Keep WHONET codes and breakpoint standards current without manual CSV imports.</p>
+ <div class="card">
+  <div class="conn"><span class="dot"></span><strong>Connected</strong> — hub.openelis.org · last sync 2026-05-12 · channel: <span class="code">stable</span>
+   <span style="margin-left:auto;"></span><button class="btn ghost sm">Test connection</button><button class="btn primary sm" onclick="check()">Check for updates</button></div>
+ </div>
+ <div id="updates"></div>
+ <div class="note">Local customizations are <strong>protected</strong>: rows you've flagged as locally edited are excluded from Hub overrides and surfaced as conflicts for you to resolve, never silently replaced. Importing hands off to the relevant catalog (M-01 / M-02) and writes an audit entry; activation of a new breakpoint standard is a separate, explicit step (M-02).</div>
+</div>
+<div class="toast" id="toast"></div>
+<script>
+function check(){
+ document.getElementById('updates').innerHTML=
+  upd('CLSI M100 v34 (2024)','breakpoint standard',false,'<span class="add">+ 214 new breakpoints</span> · <span class="chg">~38 changed thresholds</span> · supersedes v33 (kept, archived)')
+ +upd('WHONET organism codes — 2024 refresh','reference data',false,'<span class="add">+ 12 organisms</span> (incl. 4 mycobacterial species) · <span class="chg">3 code corrections</span>')
+ +upd('WHONET antibiotic codes — 2024','reference data',true,'<span class="warn">2 entries conflict with local customizations</span> — review before import; your edits are preserved.');
+ toast('3 updates available');
+}
+function upd(title,kind,conflict,diff){
+ return '<div class="upd'+(conflict?' conflict':'')+'"><div class="h"><strong>'+title+'</strong> <span class="code">'+kind+'</span>'
+ +(conflict?'<span style="color:#684e00;font-weight:600;">⚠ conflict</span>':'<span style="color:#044317;font-weight:600;">ready</span>')
+ +'<span class="r">'+(conflict?'<button class="btn ghost sm">Review conflicts</button>':'<button class="btn sm" onclick="imp(this)">Import &amp; merge</button>')+'</span></div>'
+ +'<div class="diff">'+diff+'</div></div>';
+}
+function imp(b){ b.textContent='Imported ✓'; b.disabled=true; toast('Imported — local edits preserved; audit written'); }
+function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),2400);}
+</script></body></html>

--- a/designs/microbiology/m-12-test-reagent-linkage-prototype.html
+++ b/designs/microbiology/m-12-test-reagent-linkage-prototype.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-12 Test–Reagent Linkage — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+ body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+ .pv{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+ .pv strong{background:#fff;color:#0f62fe;padding:1px 6px;border-radius:2px;margin:0 4px;}
+ .pv .w{display:block;margin-top:4px;font-family:'IBM Plex Sans',sans-serif;font-size:12px;opacity:.95;}
+ .ah{background:#161616;color:#f4f4f4;height:44px;display:flex;align-items:center;gap:1rem;padding:0 1rem;font-size:14px;}.ah .p{font-weight:600;}
+ .bc{background:#fff;border-bottom:1px solid #e0e0e0;padding:.5rem 2rem;font-size:13px;color:#525252;}
+ .main{padding:1.25rem 2rem 4rem;max-width:880px;}
+ h2.pg{font-size:21px;font-weight:300;margin:0 0 .3rem;}.sub{font-size:13px;color:#6f6f6f;margin:0 0 1rem;}
+ .btn{font-family:inherit;font-size:13px;padding:.4rem .85rem;border-radius:2px;border:1px solid #0f62fe;cursor:pointer;background:#fff;color:#0f62fe;}
+ .btn.primary{background:#0f62fe;color:#fff;}.btn.sm{font-size:12px;padding:.3rem .6rem;}.btn.ghost{border-color:#8d8d8d;color:#393939;}.btn.disabled{border-color:#c6c6c6;color:#a8a8a8;cursor:not-allowed;}
+ table.t{width:100%;border-collapse:collapse;font-size:13px;background:#fff;border:1px solid #e0e0e0;}
+ table.t th{text-align:left;padding:.5rem .7rem;background:#f4f4f4;font-weight:600;border-bottom:1px solid #e0e0e0;font-size:11px;text-transform:uppercase;letter-spacing:.4px;color:#525252;}
+ table.t td{padding:.5rem .7rem;border-bottom:1px solid #eee;vertical-align:middle;}
+ .tag{font-size:10px;padding:1px 8px;border-radius:10px;background:#e0e0e0;color:#393939;}.tag.pri{background:#d0e2ff;color:#0043ce;}
+ .lot{border:1px solid #e0e0e0;border-radius:2px;padding:.5rem .7rem;margin-bottom:.4rem;display:flex;align-items:center;gap:.6rem;font-size:13px;}
+ .lot.exp{border-left:4px solid #da1e28;background:#fff1f1;}.lot.soon{border-left:4px solid #f1c21b;}.lot.ok{border-left:4px solid #24a148;}
+ .lot .r{margin-left:auto;display:flex;gap:.4rem;align-items:center;}
+ .pill{font-size:10px;padding:1px 8px;border-radius:10px;font-weight:700;}.pill.fifo{background:#d0e2ff;color:#0043ce;}.pill.blk{background:#ffd7d9;color:#750e13;}
+ .note{font-size:12px;color:#6f6f6f;background:#edf5ff;border-left:3px solid #0f62fe;padding:.55rem .8rem;border-radius:2px;margin-top:.8rem;line-height:1.5;}
+ .panel{border:1px solid #0f62fe;background:#f7faff;border-radius:2px;padding:.9rem 1.1rem;margin-top:.8rem;}
+</style></head><body>
+<div class="pv">PREVIEW MOCKUP <strong>M-12</strong> Test–Reagent Linkage — reagents/consumables on a test + lot picker
+<span class="w">Reuses the existing <span style="background:#fff;color:#0f62fe;padding:0 3px;border-radius:2px;">Inventory module</span> — InventoryItem / InventoryLot / InventoryUsage. The ReagentLotPicker reads <code style="background:#fff;color:#0f62fe;">InventoryLot</code>, suggests FIFO, blocks expired/QC-failed lots, and on Select <strong>writes an InventoryUsage</strong> (consumption — already exists).</span></div>
+<div class="ah"><span class="p">OpenELIS Global</span><span>· Admin · Test Catalog · Reagents</span></div>
+<div class="bc">Admin / Test Catalog / Mycobacterial culture (MGIT) / Reagents</div>
+<div class="main">
+ <h2 class="pg">Reagents &amp; consumables — Mycobacterial culture (MGIT)</h2>
+ <p class="sub">Link the reagents a test consumes, with usage type and quantity. Current stock shown from inventory.</p>
+ <div style="margin-bottom:.6rem;"><button class="btn primary sm">+ Link reagent</button></div>
+ <table class="t"><thead><tr><th>Reagent / consumable</th><th>Usage</th><th>Qty/test</th><th>In stock</th><th></th></tr></thead><tbody>
+  <tr><td>MGIT 960 tube</td><td><span class="tag pri">primary</span></td><td>1</td><td>240</td><td><button class="btn ghost sm">Edit</button></td></tr>
+  <tr><td>NALC-NaOH decontamination kit</td><td><span class="tag">secondary</span></td><td>1</td><td>18</td><td><button class="btn ghost sm">Edit</button></td></tr>
+  <tr><td>PANTA antibiotic supplement</td><td><span class="tag">secondary</span></td><td>0.5 mL</td><td>62</td><td><button class="btn ghost sm">Edit</button></td></tr>
+ </tbody></table>
+
+ <div class="panel">
+  <div style="font-size:13px;font-weight:600;margin-bottom:.6rem;">ReagentLotPicker — choosing a lot at inoculation (M-04)</div>
+  <div class="lot exp"><span>MGIT 960 · lot <strong>MG-2304</strong></span><span style="color:#750e13;">expired 2026-04-30</span><span class="r"><span class="pill blk">blocked</span><button class="btn disabled sm">Select</button></span></div>
+  <div class="lot ok"><span>MGIT 960 · lot <strong>MG-2511</strong></span><span style="color:#525252;">expires 2026-09-30 · opened 05-02</span><span class="r"><span class="pill fifo">FIFO — use first</span><button class="btn primary sm">Select</button></span></div>
+  <div class="lot soon"><span>MGIT 960 · lot <strong>MG-2602</strong></span><span style="color:#684e00;">expires 2026-07-15</span><span class="r"><button class="btn sm">Select</button></span></div>
+  <div style="font-size:12px;color:#6f6f6f;margin-top:.4rem;">Expired/locked lots are <strong>blocked</strong>; the picker highlights the <strong>FIFO</strong> recommendation (earliest-expiring open lot). Selecting records the lot on the inoculation for traceability.</div>
+ </div>
+ <div class="note"><strong>Mostly reuse, not new build.</strong> Lots/expiry/QC come from the existing <span style="font-family:monospace;">InventoryLot</span>; <strong>consumption + per-result traceability already exist</strong> as <span style="font-family:monospace;">InventoryUsage</span> (keyed to analysis_id / test_result_id) — selecting a lot writes one. The only genuinely new piece is the <strong>test↔reagent definition</strong> (<span style="font-family:monospace;">test_reagent_link</span>), which is owned by <strong>Test Catalog v2.5 (OGC-759)</strong> — M-12 contributes the picker + the result-entry wiring. Lot selection appears wherever media/cartridges are consumed (bacterial inoculation, TB decontamination/MGIT, GeneXpert cartridges).</div>
+</div>
+</body></html>

--- a/designs/microbiology/m-12-test-reagent-linkage.md
+++ b/designs/microbiology/m-12-test-reagent-linkage.md
@@ -11,6 +11,12 @@
 
 This spec adds a long-deferred OE foundation: the ability to declare which reagent lots are required (or optional) for a given test. Per memory `project_reagent_test_catalog_link`, the Test → Reagent linkage doesn't exist today even though reagent concepts (lots, expiration, QC status) do. Micro is the forcing function for this work — AST cards, discs, and culture media are all reagents with lot numbers that ISO 15189 §7.3 expects traceable to each patient result.
 
+> **⚠ Reuse update (verified in code + Jira) — supersedes the old `reagent`/`qc_lot` framing below.** Two pieces already exist and M-12 must build on them, not duplicate:
+> - **In code now — the Inventory module:** `InventoryItem` (ItemType REAGENT / CARTRIDGE / kit), `InventoryLot` (lot, expiry, `LotStatus` = ACTIVE/IN_USE/EXPIRED/CONSUMED/QUARANTINED, `QCStatus` = PENDING/PASSED/FAILED/QUARANTINED), `InventoryTransaction`, and **`InventoryUsage` — which already records consumption and is keyed to `analysis_id` + `test_result_id`.** So per-result lot **consumption + traceability already has a home**; it is *not* new work.
+> - **In Jira (not code yet) — the definitional link:** the Test↔Reagent "which reagents does this test use" link (`test_reagent_link`) is planned in **Test Catalog v2.5 v2 (OGC-759)**.
+>
+> **Therefore M-12 = reuse + wire, not build:** the **`ReagentLotPicker` over `InventoryLot`** (FIFO / expiry / QC blocking from `LotStatus`/`QCStatus`) whose selection **writes an `InventoryUsage`** (consumption + traceability — reuse), consuming the `test_reagent_link` definition from OGC-759. The picker UI + the result-entry wiring are the only net-new parts; the old `reagent` / `qc_lot` references in §3 below are superseded by the Inventory module.
+
 Several parked specs benefit: Reagent Forecasting, Reagent QC, Catalog Subscription, future Phase 2 chemistry reagent tracking improvements.
 
 ---
@@ -55,8 +61,8 @@ Define the relationship between Tests and Reagents so that:
 
 ### 2.4 Integration
 
-- **Test Catalog v2.5** — adds a new Reagents tab on the Test editor (the Reagents tab already exists in v2.5 but is empty placeholder; M-12 fills it).
-- **Reagent inventory** — existing OE reagent concepts (reagent definitions, lots, QC status).
+- **Test Catalog v2.5 (OGC-759)** — owns the Reagents tab **and the `test_reagent_link` definitional table**; M-12 fills the tab content + the picker. Coordinate so the link isn't double-built.
+- **Inventory module (existing, in code)** — `InventoryItem` (REAGENT/CARTRIDGE/kit), `InventoryLot` (lot/expiry/`LotStatus`/`QCStatus`), `InventoryUsage` (consumption, keyed to `analysis_id`/`test_result_id`), `InventoryTransaction`. The `ReagentLotPicker` reads `InventoryLot` and **writes an `InventoryUsage`** on selection. Supersedes the old `reagent`/`qc_lot` for this purpose.
 - **M-04 Case Workbench Core** — Inoculation modal picks reagent lots for media types via the shared `ReagentLotPicker`.
 - **M-05 AST Entry & Interpretation** — AST Setup modal picks reagent lots for AST cards / discs via the same `ReagentLotPicker`.
 - **FRS_Reagent_Forecasting** (parked) — unblocked by this spec.
@@ -73,7 +79,8 @@ Define the relationship between Tests and Reagents so that:
 test_reagent_link
 ├── link_id (UUID PK)
 ├── test_id (FK to test catalog — existing OE table)
-├── reagent_id (FK to reagent — existing OE table)
+├── inventory_item_id (FK to InventoryItem — existing Inventory module; the reagent/cartridge/kit)
+│        NOTE: this table is owned/built by Test Catalog v2.5 (OGC-759); M-12 consumes it.
 ├── linkage_type (enum: REQUIRED, OPTIONAL, SUBSTITUTE)
 ├── consumption_unit (enum: PER_TEST, PER_RUN, PER_BATCH, PER_DAY)
 ├── consumption_quantity (numeric, default 1 — e.g., 1 card per AST Run, 1 plate per culture)
@@ -94,13 +101,16 @@ test_reagent_method_constraint (sub-junction, optional refinement)
 test (existing OE table; no schema changes; gain inverse relation)
    └── test_reagent_link (1:N via test_id)
 
-reagent (existing OE table; no schema changes; gain inverse relation)
-   └── test_reagent_link (1:N via reagent_id)
+InventoryItem (existing Inventory module — ItemType REAGENT / CARTRIDGE / kit; replaces the old `reagent`)
+   └── test_reagent_link (1:N via inventory_item_id)
 
-qc_lot (existing OE table; key surface used at result entry)
-   ├── lot_number, expires_at, status (UNLOCKED / LOCKED / EXPIRED)
-   ├── reagent_id (FK)
-   └── (existing columns)
+InventoryLot (existing — the lot-picker surface at result entry; replaces the old `qc_lot`)
+   ├── lot_number, expiry, LotStatus (ACTIVE/IN_USE/EXPIRED/CONSUMED/QUARANTINED), QCStatus (PENDING/PASSED/FAILED/QUARANTINED)
+   └── picker blocks selection when EXPIRED / QUARANTINED / QC FAILED
+
+InventoryUsage (existing — consumption is ALREADY recorded here; M-12 writes a row on lot selection)
+   ├── inventory_item_id, lot_id, analysis_id, test_result_id, quantity_used, usage_date, performed_by_user
+   └── this IS the per-result lot traceability (ISO 15189 §7.3) — reused, not rebuilt
 ```
 
 ### 3.3 Linkage semantics

--- a/mockup-viewer/public/designs/microbiology/m-10-hub-subscription-prototype.html
+++ b/mockup-viewer/public/designs/microbiology/m-10-hub-subscription-prototype.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-10 Hub Subscription — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+ body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+ .pv{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+ .pv strong{background:#fff;color:#0f62fe;padding:1px 6px;border-radius:2px;margin:0 4px;}
+ .pv .w{display:block;margin-top:4px;font-family:'IBM Plex Sans',sans-serif;font-size:12px;opacity:.95;}
+ .ah{background:#161616;color:#f4f4f4;height:44px;display:flex;align-items:center;gap:1rem;padding:0 1rem;font-size:14px;}.ah .p{font-weight:600;}
+ .bc{background:#fff;border-bottom:1px solid #e0e0e0;padding:.5rem 2rem;font-size:13px;color:#525252;}
+ .main{padding:1.25rem 2rem 4rem;max-width:880px;}
+ h2.pg{font-size:21px;font-weight:300;margin:0 0 .3rem;}.sub{font-size:13px;color:#6f6f6f;margin:0 0 1rem;}
+ .btn{font-family:inherit;font-size:13px;padding:.45rem .9rem;border-radius:2px;border:1px solid #0f62fe;cursor:pointer;background:#fff;color:#0f62fe;}
+ .btn.primary{background:#0f62fe;color:#fff;}.btn.sm{font-size:12px;padding:.3rem .6rem;}.btn.ghost{border-color:#8d8d8d;color:#393939;}
+ .card{background:#fff;border:1px solid #e0e0e0;padding:1rem 1.3rem;margin-bottom:1rem;border-radius:2px;}
+ .conn{display:flex;align-items:center;gap:.6rem;font-size:14px;}
+ .dot{width:10px;height:10px;border-radius:50%;background:#24a148;}
+ .upd{border:1px solid #e0e0e0;border-left:4px solid #0f62fe;border-radius:2px;padding:.7rem .9rem;margin-bottom:.6rem;}
+ .upd.conflict{border-left-color:#f1c21b;background:#fffdf4;}
+ .upd .h{display:flex;align-items:center;gap:.6rem;flex-wrap:wrap;} .upd .h .r{margin-left:auto;display:flex;gap:.4rem;}
+ .code{font-family:monospace;background:#e8e8e8;padding:1px 6px;border-radius:3px;font-size:12px;}
+ .diff{font-size:12px;color:#525252;margin-top:.4rem;} .add{color:#044317;} .chg{color:#0043ce;} .warn{color:#684e00;}
+ .note{font-size:12px;color:#6f6f6f;background:#edf5ff;border-left:3px solid #0f62fe;padding:.55rem .8rem;border-radius:2px;margin-top:.6rem;line-height:1.5;}
+ .toast{position:fixed;bottom:18px;left:50%;transform:translateX(-50%);background:#161616;color:#fff;padding:.6rem 1.1rem;border-radius:4px;font-size:13px;opacity:0;transition:.25s;pointer-events:none;}.toast.show{opacity:1;}
+</style></head><body>
+<div class="pv">PREVIEW MOCKUP <strong>M-10</strong> Hub Subscription — pull updated AMR reference data
+<span class="w">Fetch official organism/antibiotic code lists and breakpoint standards from the central Hub; merge with local edits (local customizations preserved). Phase 1B.</span></div>
+<div class="ah"><span class="p">OpenELIS Global</span><span>· Admin · Hub Subscription</span></div>
+<div class="bc">Admin / Hub Subscription</div>
+<div class="main">
+ <h2 class="pg">Hub Subscription</h2>
+ <p class="sub">Keep WHONET codes and breakpoint standards current without manual CSV imports.</p>
+ <div class="card">
+  <div class="conn"><span class="dot"></span><strong>Connected</strong> — hub.openelis.org · last sync 2026-05-12 · channel: <span class="code">stable</span>
+   <span style="margin-left:auto;"></span><button class="btn ghost sm">Test connection</button><button class="btn primary sm" onclick="check()">Check for updates</button></div>
+ </div>
+ <div id="updates"></div>
+ <div class="note">Local customizations are <strong>protected</strong>: rows you've flagged as locally edited are excluded from Hub overrides and surfaced as conflicts for you to resolve, never silently replaced. Importing hands off to the relevant catalog (M-01 / M-02) and writes an audit entry; activation of a new breakpoint standard is a separate, explicit step (M-02).</div>
+</div>
+<div class="toast" id="toast"></div>
+<script>
+function check(){
+ document.getElementById('updates').innerHTML=
+  upd('CLSI M100 v34 (2024)','breakpoint standard',false,'<span class="add">+ 214 new breakpoints</span> · <span class="chg">~38 changed thresholds</span> · supersedes v33 (kept, archived)')
+ +upd('WHONET organism codes — 2024 refresh','reference data',false,'<span class="add">+ 12 organisms</span> (incl. 4 mycobacterial species) · <span class="chg">3 code corrections</span>')
+ +upd('WHONET antibiotic codes — 2024','reference data',true,'<span class="warn">2 entries conflict with local customizations</span> — review before import; your edits are preserved.');
+ toast('3 updates available');
+}
+function upd(title,kind,conflict,diff){
+ return '<div class="upd'+(conflict?' conflict':'')+'"><div class="h"><strong>'+title+'</strong> <span class="code">'+kind+'</span>'
+ +(conflict?'<span style="color:#684e00;font-weight:600;">⚠ conflict</span>':'<span style="color:#044317;font-weight:600;">ready</span>')
+ +'<span class="r">'+(conflict?'<button class="btn ghost sm">Review conflicts</button>':'<button class="btn sm" onclick="imp(this)">Import &amp; merge</button>')+'</span></div>'
+ +'<div class="diff">'+diff+'</div></div>';
+}
+function imp(b){ b.textContent='Imported ✓'; b.disabled=true; toast('Imported — local edits preserved; audit written'); }
+function toast(m){const t=document.getElementById('toast');t.textContent=m;t.classList.add('show');setTimeout(()=>t.classList.remove('show'),2400);}
+</script></body></html>

--- a/mockup-viewer/public/designs/microbiology/m-12-test-reagent-linkage-prototype.html
+++ b/mockup-viewer/public/designs/microbiology/m-12-test-reagent-linkage-prototype.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>M-12 Test–Reagent Linkage — Interactive Prototype</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<style>
+ body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+ .pv{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+ .pv strong{background:#fff;color:#0f62fe;padding:1px 6px;border-radius:2px;margin:0 4px;}
+ .pv .w{display:block;margin-top:4px;font-family:'IBM Plex Sans',sans-serif;font-size:12px;opacity:.95;}
+ .ah{background:#161616;color:#f4f4f4;height:44px;display:flex;align-items:center;gap:1rem;padding:0 1rem;font-size:14px;}.ah .p{font-weight:600;}
+ .bc{background:#fff;border-bottom:1px solid #e0e0e0;padding:.5rem 2rem;font-size:13px;color:#525252;}
+ .main{padding:1.25rem 2rem 4rem;max-width:880px;}
+ h2.pg{font-size:21px;font-weight:300;margin:0 0 .3rem;}.sub{font-size:13px;color:#6f6f6f;margin:0 0 1rem;}
+ .btn{font-family:inherit;font-size:13px;padding:.4rem .85rem;border-radius:2px;border:1px solid #0f62fe;cursor:pointer;background:#fff;color:#0f62fe;}
+ .btn.primary{background:#0f62fe;color:#fff;}.btn.sm{font-size:12px;padding:.3rem .6rem;}.btn.ghost{border-color:#8d8d8d;color:#393939;}.btn.disabled{border-color:#c6c6c6;color:#a8a8a8;cursor:not-allowed;}
+ table.t{width:100%;border-collapse:collapse;font-size:13px;background:#fff;border:1px solid #e0e0e0;}
+ table.t th{text-align:left;padding:.5rem .7rem;background:#f4f4f4;font-weight:600;border-bottom:1px solid #e0e0e0;font-size:11px;text-transform:uppercase;letter-spacing:.4px;color:#525252;}
+ table.t td{padding:.5rem .7rem;border-bottom:1px solid #eee;vertical-align:middle;}
+ .tag{font-size:10px;padding:1px 8px;border-radius:10px;background:#e0e0e0;color:#393939;}.tag.pri{background:#d0e2ff;color:#0043ce;}
+ .lot{border:1px solid #e0e0e0;border-radius:2px;padding:.5rem .7rem;margin-bottom:.4rem;display:flex;align-items:center;gap:.6rem;font-size:13px;}
+ .lot.exp{border-left:4px solid #da1e28;background:#fff1f1;}.lot.soon{border-left:4px solid #f1c21b;}.lot.ok{border-left:4px solid #24a148;}
+ .lot .r{margin-left:auto;display:flex;gap:.4rem;align-items:center;}
+ .pill{font-size:10px;padding:1px 8px;border-radius:10px;font-weight:700;}.pill.fifo{background:#d0e2ff;color:#0043ce;}.pill.blk{background:#ffd7d9;color:#750e13;}
+ .note{font-size:12px;color:#6f6f6f;background:#edf5ff;border-left:3px solid #0f62fe;padding:.55rem .8rem;border-radius:2px;margin-top:.8rem;line-height:1.5;}
+ .panel{border:1px solid #0f62fe;background:#f7faff;border-radius:2px;padding:.9rem 1.1rem;margin-top:.8rem;}
+</style></head><body>
+<div class="pv">PREVIEW MOCKUP <strong>M-12</strong> Test–Reagent Linkage — reagents/consumables on a test + lot picker
+<span class="w">Reuses the existing <span style="background:#fff;color:#0f62fe;padding:0 3px;border-radius:2px;">Inventory module</span> — InventoryItem / InventoryLot / InventoryUsage. The ReagentLotPicker reads <code style="background:#fff;color:#0f62fe;">InventoryLot</code>, suggests FIFO, blocks expired/QC-failed lots, and on Select <strong>writes an InventoryUsage</strong> (consumption — already exists).</span></div>
+<div class="ah"><span class="p">OpenELIS Global</span><span>· Admin · Test Catalog · Reagents</span></div>
+<div class="bc">Admin / Test Catalog / Mycobacterial culture (MGIT) / Reagents</div>
+<div class="main">
+ <h2 class="pg">Reagents &amp; consumables — Mycobacterial culture (MGIT)</h2>
+ <p class="sub">Link the reagents a test consumes, with usage type and quantity. Current stock shown from inventory.</p>
+ <div style="margin-bottom:.6rem;"><button class="btn primary sm">+ Link reagent</button></div>
+ <table class="t"><thead><tr><th>Reagent / consumable</th><th>Usage</th><th>Qty/test</th><th>In stock</th><th></th></tr></thead><tbody>
+  <tr><td>MGIT 960 tube</td><td><span class="tag pri">primary</span></td><td>1</td><td>240</td><td><button class="btn ghost sm">Edit</button></td></tr>
+  <tr><td>NALC-NaOH decontamination kit</td><td><span class="tag">secondary</span></td><td>1</td><td>18</td><td><button class="btn ghost sm">Edit</button></td></tr>
+  <tr><td>PANTA antibiotic supplement</td><td><span class="tag">secondary</span></td><td>0.5 mL</td><td>62</td><td><button class="btn ghost sm">Edit</button></td></tr>
+ </tbody></table>
+
+ <div class="panel">
+  <div style="font-size:13px;font-weight:600;margin-bottom:.6rem;">ReagentLotPicker — choosing a lot at inoculation (M-04)</div>
+  <div class="lot exp"><span>MGIT 960 · lot <strong>MG-2304</strong></span><span style="color:#750e13;">expired 2026-04-30</span><span class="r"><span class="pill blk">blocked</span><button class="btn disabled sm">Select</button></span></div>
+  <div class="lot ok"><span>MGIT 960 · lot <strong>MG-2511</strong></span><span style="color:#525252;">expires 2026-09-30 · opened 05-02</span><span class="r"><span class="pill fifo">FIFO — use first</span><button class="btn primary sm">Select</button></span></div>
+  <div class="lot soon"><span>MGIT 960 · lot <strong>MG-2602</strong></span><span style="color:#684e00;">expires 2026-07-15</span><span class="r"><button class="btn sm">Select</button></span></div>
+  <div style="font-size:12px;color:#6f6f6f;margin-top:.4rem;">Expired/locked lots are <strong>blocked</strong>; the picker highlights the <strong>FIFO</strong> recommendation (earliest-expiring open lot). Selecting records the lot on the inoculation for traceability.</div>
+ </div>
+ <div class="note"><strong>Mostly reuse, not new build.</strong> Lots/expiry/QC come from the existing <span style="font-family:monospace;">InventoryLot</span>; <strong>consumption + per-result traceability already exist</strong> as <span style="font-family:monospace;">InventoryUsage</span> (keyed to analysis_id / test_result_id) — selecting a lot writes one. The only genuinely new piece is the <strong>test↔reagent definition</strong> (<span style="font-family:monospace;">test_reagent_link</span>), which is owned by <strong>Test Catalog v2.5 (OGC-759)</strong> — M-12 contributes the picker + the result-entry wiring. Lot selection appears wherever media/cartridges are consumed (bacterial inoculation, TB decontamination/MGIT, GeneXpert cartridges).</div>
+</div>
+</body></html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -814,10 +814,12 @@ export const MOCKUP_REGISTRY = [
     component: null,
     description: 'Unified admin for breakpoint + WHONET code + organism/antibiotic master updates from a central repository. OE pulls; never pushes. Phase 1B.',
     specPath: 'designs/microbiology/m-10-hub-subscription.md',
+    htmlUrl: 'designs/microbiology/m-10-hub-subscription-prototype.html',
     added: '2026-05-15',
+    updated: '2026-06-08',
     status: 'draft',
     jira: ['OGC-795'],
-    tags: ['microbiology', 'hub-subscription', 'reference-data', 'phase-1b'],
+    tags: ['microbiology', 'hub-subscription', 'reference-data', 'phase-1b', 'interactive', 'prototype'],
   },
   {
     name: 'M-11 Critical-Result Acknowledgment',
@@ -837,10 +839,12 @@ export const MOCKUP_REGISTRY = [
     component: null,
     description: 'General OE foundation: declare which reagent lots are required for a given test (ISO 15189 §7.3). Micro is the forcing function. Parallel pre-track to MVP-1A.',
     specPath: 'designs/microbiology/m-12-test-reagent-linkage.md',
+    htmlUrl: 'designs/microbiology/m-12-test-reagent-linkage-prototype.html',
     added: '2026-05-15',
+    updated: '2026-06-08',
     status: 'draft',
     jira: ['OGC-784'],
-    tags: ['microbiology', 'reagent-linkage', 'iso-15189', 'cross-cutting', 'co-ship', 'mvp-1a'],
+    tags: ['microbiology', 'reagent-linkage', 'iso-15189', 'cross-cutting', 'co-ship', 'mvp-1a', 'interactive', 'prototype'],
   },
 
   // ─── Microbiology — FRS v1.0 formal docs ────────────────────────────────


### PR DESCRIPTION
Register interactive HTML prototypes for M-10 Hub Subscription (OGC-795) and M-12 Test→Reagent Linkage (OGC-784). Also updates m-12-test-reagent-linkage.md spec (31922B → latest) and amr-micro-dependency-graph.svg. App.jsx and MANIFEST.yaml updated with htmlUrl, preview field, updated date, and expanded tags.

Vitest: 228/228

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
