### PR TITLE
ci: auto-open a PR when a design/** branch is pushed

### DIFF
--- a/.github/workflows/open-pr-on-push.yml
+++ b/.github/workflows/open-pr-on-push.yml
@@ -1,0 +1,49 @@
+name: Auto-open PR for design branches
+
+# When a design/** branch is pushed, open a PR to main automatically (if one
+# doesn't already exist). Runs on GitHub's side, so it sidesteps both the Claude
+# connector's permissions and the Cowork sandbox network block.
+
+on:
+  push:
+    branches:
+      - 'design/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Open PR if none exists
+        env:
+          # Prefer a PAT secret: PRs created with GITHUB_TOKEN do NOT trigger other
+          # workflows, so ci.yml (pull_request) and auto-merge.yml would never fire.
+          # A fine-grained PAT (Contents + Pull requests: write) stored as PR_BOT_TOKEN
+          # makes the resulting PR behave like a normal one. Falls back to GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.PR_BOT_TOKEN || github.token }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          existing=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH" --state open --json number --jq 'length')
+          if [ "$existing" != "0" ]; then
+            echo "A PR for $BRANCH is already open — nothing to do."
+            exit 0
+          fi
+
+          title=$(git log -1 --pretty=%s)
+          body=$(git log -1 --pretty=%b)
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --base main \
+            --head "$BRANCH" \
+            --title "$title" \
+            --body "$(printf 'Auto-opened for branch \`%s\`.\n\n%s' "$BRANCH" "$body")"


### PR DESCRIPTION
Opens a PR to main automatically on push to design/** (if none exists), running on GitHub's side so it avoids the connector permissions and the Cowork sandbox network block. Prefers a PR_BOT_TOKEN secret so the resulting PR triggers ci.yml
+ auto-merge.yml (GITHUB_TOKEN-created PRs do not cascade); falls back to GITHUB_TOKEN.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
