### PR TITLE
ci: fix stuck Pages deploy — trigger on auto-merge + enable manual di…

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,5 +12,7 @@ jobs:
       - name: Enable auto-merge (squash) once CI passes
         run: gh pr merge --auto --squash "$PR_URL"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use a PAT so the squash-merge push triggers deploy-gallery.yml.
+          # GITHUB_TOKEN-performed merges do NOT cascade to other workflows.
+          GH_TOKEN: ${{ secrets.PR_BOT_TOKEN || secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/deploy-gallery.yml
+++ b/.github/workflows/deploy-gallery.yml
@@ -48,14 +48,14 @@ jobs:
           find . -maxdepth 1 -name '*.html' -exec cp {} mockup-viewer/dist/ \;
 
       - name: Upload artifact
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
         uses: actions/upload-pages-artifact@v3
         with:
           path: mockup-viewer/dist
 
   deploy:
     needs: build
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment:
       name: github-pages


### PR DESCRIPTION
…spatch

Root cause of the gallery being frozen at the 2026-06-12 build: auto-merge.yml ran `gh pr merge` with GITHUB_TOKEN. Merges performed with GITHUB_TOKEN do NOT trigger downstream workflows, so deploy-gallery.yml never ran for any auto-merged PR (#166, #167, #168). The site stayed at the last human merge (8764f85).

- auto-merge.yml: use secrets.PR_BOT_TOKEN (fallback GITHUB_TOKEN) so the squash merge push cascades to deploy-gallery.yml. Mirrors open-pr-on-push.yml.
- deploy-gallery.yml: allow workflow_dispatch to upload + deploy (not just push), giving a manual "Run workflow" escape hatch to publish on demand.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
