### PR TITLE
feat(analyzer-integration): register Analyzer Types & Mapping (draft)

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -3609,3 +3609,31 @@
     - labkesmas
   added: "2026-06-15"
   status: draft
+
+- id: analyzer-profile-mapping
+  type: html
+  path: designs/analyzer-integration/analyzer-profile-mapping.html
+  spec: designs/analyzer-integration/analyzer-profile-mapping.md
+  preview: designs/analyzer-integration/analyzer-profile-mapping.html
+  category: analyzer-integration
+  description: >
+    Analyzer Types & Mapping — reusable forkable Analyzer Types + lab-facing GUI mapping of
+    instrument tests/result values/QC codes to the catalog. Completes the Generic ASTM/HL7/Flat-file
+    module. HTML prototype + version-agnostic FRS.
+  links:
+    jira: ["OGC-1054"]
+    gallery: https://digi-uw.github.io/openelis-work/#/analyzer-integration/analyzer-profile-mapping
+    preview: https://digi-uw.github.io/openelis-work/designs/analyzer-integration/analyzer-profile-mapping.html
+  added: "2026-06-18"
+
+- id: analyzer-profile-mapping-gap-analysis
+  type: spec
+  path: designs/analyzer-integration/analyzer-profile-mapping-gap-analysis.md
+  category: analyzer-integration
+  description: >
+    Functional gap analysis grounding the Analyzer Types & Mapping FRS (reviews ~20 shipped
+    Madagascar profiles + ASTM/HL7/flat-file addenda).
+  links:
+    jira: ["OGC-1054"]
+    gallery: https://digi-uw.github.io/openelis-work/#/analyzer-integration/analyzer-profile-mapping-gap-analysis
+  added: "2026-06-18"

--- a/designs/analyzer-integration/analyzer-profile-mapping-gap-analysis.md
+++ b/designs/analyzer-integration/analyzer-profile-mapping-gap-analysis.md
@@ -1,0 +1,140 @@
+# Analyzer Profile Management & Test/Select-List Mapping — Functional Gap Analysis
+
+**Date:** 2026-06-17
+**Author:** Casey Iiams-Hauser
+**Status:** Draft for review
+**Scope:** The two parts of the Generic Analyzer module (ASTM / HL7 / Flat File) that were **not** brought in when the module shipped — (1) profile management through the GUI and (2) mapping of tests and select-list values through the GUI.
+**Lens:** This document describes *function* only — what a lab administrator should be able to do. It deliberately avoids implementation (data shapes, endpoints, field numbering, component choices); developers decide those later.
+
+**Source material reviewed**
+- ASTM Analyzer Mapping — Addendum v1.2 (profile system: apply, library, import/export, lab-unit assignment)
+- HL7 Analyzer Mapping — Addendum v1.1 (mapping surface, including Select List Value Mapping)
+- Flat File Import — Analyzer Configuration v2.0
+- Analyzer File Upload FRS v3.0
+- Mockups: `analyzer-mapping-templates.jsx` (ASTM), `hl7-analyzer-mapping.jsx`, `flat-file-analyzer-config.jsx`
+- The **full set of ~20 shipped profiles** in the Madagascar distro (`configs/analyzer-profiles/{astm,hl7,file}/`), examined in depth across a representative span: GeneXpert in all three protocols (ASTM, HL7, CSV), Sysmex XN, Mindray BC-5380, Abbott Architect, Tecan F50, Wondfo Finecare, Bruker FluoroCycler XT
+- Confluence admin guide "Analyzers / ASTM Management" (OGC-138)
+
+---
+
+## 1. What we actually have today
+
+**The delivered module.** The Generic ASTM / HL7 / Flat File module is in production. An administrator can register an analyzer, choose its protocol/plugin, set up the connection (or watch folder), test it, and map analyzer test codes to OpenELIS tests. Results flow in and land in the Analyzer Results review queue.
+
+**Profiles that actually ship.** About 20 profiles exist today as files in the distro, split across `astm/`, `hl7/`, and `file/` folders. Most profiles carry, in some form: identity (display name, manufacturer, category) and a **confidence rating**; an **instrument-recognition signature**; transport/connection defaults; a list of **test codes** with name hint, LOINC, and units; and a set of **QC identification rules**. The QC rules in particular are quite mature — site-specific control prefixes (`CNEG`/`CPOS`/`NTC`/`PTC`, `C+`/`C-`), field-equals checks, etc.
+
+But the most important thing the full corpus reveals is **how inconsistent the profiles are** — and that inconsistency is itself the core finding. All ~20 declare the same `analyzer-defaults/1.0` schema, yet they are structurally different documents:
+
+- **Value handling is captured three different ways — even for the same instrument.** GeneXpert ships as three profiles, one per protocol, and each handles result values differently:
+  - *GeneXpert ASTM* lists each test's **expected value set** (`result_type: qualitative`, `values: ["DETECTED","NOT DETECTED"]`) — the raw values, but no mapping target.
+  - *GeneXpert CSV* carries an actual **raw → label map** (`result_interpretation.qualitative_values`: `MTB DETECTED → Detected`, `… INDETERMINATE → Indeterminate`, `INVALID → Invalid`, `NO RESULT → No Result`).
+  - *GeneXpert HL7* carries **nothing** of the sort — code, name hint, LOINC, unit only.
+  
+  None of the three binds its values to the lab's actual OpenELIS select-list options; the closest (CSV) maps to normalized free-text labels. So the "value mapping" that exists is partial, inconsistent, and not connected to the lab's catalog. (This refines P-1 below — it isn't "profiles can't carry value info," it's "they carry it inconsistently and never bound to the lab's options.")
+- **The shape of a profile varies by protocol and by author.** File profiles add whole sections the ASTM/HL7 ones don't (`column_mapping`, `layouts` including 8×12 plate grids, `locale_support`, `parsing_notes`, PHI-exclusion notes). Some profiles carry a `communication`/bidirectional block, some an `msh3_pattern`, some serial baud settings. Several also carry **internal authoring/tracking signals** — `confidence` (HIGH…LOW), `verification_required`, and `validation_status` prose ("PENDING — awaiting real CSV sample") — which the OpenELIS team uses to track which profiles still need real-sample testing. These are bookkeeping, not admin-facing settings; the point here is only that they sit inline with the operational config rather than being cleanly separated (see P-3).
+
+This is exactly why "what *is* a profile?" (P-2) has to be settled before any GUI is built on top of it — the real files already disagree.
+
+**Mapping functions that are designed.** Across the addenda and mockups, the intended mapping surface is well thought out:
+
+- **Test mapping** — analyzer code → OpenELIS test, with auto-match (exact / suggested / unmapped), a "pending codes" list that learns codes seen in live traffic, and a query/scan to discover what an instrument sends.
+- **Select-list value mapping** — for qualitative tests, map each analyzer value (e.g., `DETECTED`) to one of the OpenELIS test's select-list options (e.g., `Positive`), with a defined behavior for values that have no mapping.
+- A **preview/simulator** that shows how a real message would parse under the current mapping.
+
+The gaps below are the distance between *that designed surface* and *what an administrator can actually rely on today* — described functionally.
+
+---
+
+## 2. Profile management — functional gaps
+
+| # | Gap | Severity | Why it matters |
+|---|-----|----------|----------------|
+| P-1 | **No consistent value mapping bound to the lab's select-list options.** Some profiles carry the analyzer's expected values (GeneXpert ASTM), some carry a raw→label map (GeneXpert CSV), some carry nothing (GeneXpert HL7) — and none binds those values to the lab's actual OpenELIS select-list options. | **High** | This is the biggest "didn't get brought in" item. For qualitative instruments (GeneXpert, ELISA readers, rapid molecular), value mapping *is* the hard, error-prone part of onboarding. Today even where a profile lists the expected values, an admin still has to bind each one to the right option in their own test catalog by hand — and where the profile carries nothing (HL7), they build it from scratch. The profile system doesn't yet deliver its core promise (fast, known-good onboarding) for exactly the instruments that need it most. The raw material is already in some profiles; it needs to be made consistent and catalog-bound. |
+| P-2 | **"Profile" isn't defined consistently — across ~20 shipped files on one nominal schema.** All claim `analyzer-defaults/1.0`, yet they differ structurally: value handling appears in three forms (or not at all), file profiles add column/layout/locale sections, some carry communication or recognition blocks, confidence and validation state are encoded inconsistently (including as prose). | **High** | Before any GUI work, we need one agreed answer to "what does a profile capture?" — including which parts are shared across protocols and which are protocol-specific (file parsing, plate layouts). Otherwise the import/export/library functions promise capability many profiles can't express, admins import a profile expecting turnkey and get a partial one, and the library shows profiles that behave inconsistently. The fix is functional, not cosmetic: define what a profile *means*, then make shipped and admin-exported profiles carry the same information. |
+| P-3 | **Authoring/tracking metadata is mixed in with operational config.** Fields like `confidence`, `verification_required`, and `validation_status` prose are **internal** signals the OpenELIS team uses to track which profiles still need real-sample testing — they are not meant for lab admins. Today they sit inline alongside the operational settings. | **Low** | These should *not* be surfaced in the GUI or gate an admin's setup — they're project bookkeeping. The only functional implication: the profile contract should cleanly separate "operational config the product uses" from "authoring metadata the team uses," so the GUI simply ignores the latter and nobody builds admin behavior on top of it. |
+| P-4 | **Instrument auto-recognition — CUT (see §7).** Suggesting a profile from an incoming message was considered and dropped: the in-message identity signal is unreliable (configurable/generic ASTM sender; none for flat file) and unverified in several profiles, and an admin should be able to pick their own instrument from the list. | **Cut** | The analyzer is already identified by its connection; the ongoing case is handled by unmapped-prompting (path 3), which doesn't need to guess the instrument. |
+| P-5 | **No profile update / re-adopt path.** When a better version of a built-in profile ships, there's no described function for an admin to see what changed and adopt it without losing local customizations. | **Medium** | Profiles are versioned (the shipped one is `1.2.0`). Without an adopt-changes function, improvements never reach existing sites, or sites re-import and silently lose their local edits. Needs a "review changes / keep my customizations" function. |
+| P-6 | **Export round-trip isn't guaranteed to reproduce the setup.** Export is only as complete as P-1/P-2 allow. If a profile can't carry value maps, then what an admin builds by hand can't be exported and re-used elsewhere. | **Medium** | The whole point of "export your working analyzer as a profile" is that another site (or the community) can reproduce it. That only holds if export captures everything the admin configured — most importantly the value maps. |
+| P-7 | **Where profiles come from — RESOLVED (see §5).** The admin guide implied profiles live in the application package; the real ones live in a per-distro config folder. Decision: a three-layer model — base catalog shipped with OpenELIS, curated distro bundles, and site-added imports — with the portable profile kept catalog-independent. | **Resolved** | Functionally the admin needs "a catalog of trustworthy profiles to start from," available out of the box and easy to extend. Distros tune the set (and can pre-bind to their catalog); sites add their own. This defines what "base / bundled / site" means in the library and who maintains each layer. |
+
+---
+
+## 3. Test & select-list mapping — functional gaps
+
+The test-code mapping function (analyzer code → OpenELIS test) is in good shape conceptually. The gaps concentrate in **select-list (qualitative value) mapping** and in **consistency across the three protocols**.
+
+| # | Gap | Severity | Why it matters |
+|---|-----|----------|----------------|
+| M-1 | **The select-list mapping target isn't consistently tied to the chosen test's own result options.** The HL7 mockup correctly shows "options from the mapped test's select list" and warns when the test has none. The ASTM mockup treats the target more loosely (a generic value type). | **High** | A value map is only safe if its right-hand side is constrained to the result values the chosen test can actually store. If an admin can map `DETECTED` to free text that the test doesn't recognize, the result can't validate or report correctly. Functionally: once a test is chosen, the value-map options should always come from *that test's* configured result list — same behavior in ASTM, HL7, and flat file. |
+| M-2 | **No guided path when the test has no select-list options yet.** A qualitative analyzer needs the target test to already have its result options defined; if it doesn't, the admin is stuck. | **Medium** | The mapping screen should detect "this test has no result options defined yet" and point the admin to set them up first (in Test Catalog), rather than letting them build a value map against nothing. The HL7 mock hints at this; it should be a guaranteed, consistent function. |
+| M-3 | **Unmapped-value behavior isn't consistent or visible end-to-end.** When the analyzer sends a coded value with no mapping, behavior (reject / pass-through / use a default) is described for HL7 but not uniformly, and it isn't clearly connected to what the reviewer sees. | **High** | An unmapped qualitative value must never silently drop or land as a raw code on a patient result. The function needed: a consistent, configurable behavior for unmapped values **and** a clear warning that surfaces in the Analyzer Results review queue (parallel to the existing "test not mapped" warning) so a human catches it. |
+| M-4 | **No completeness feedback on value mapping.** Nothing tells the admin "you've mapped 3 of the 4 values this analyzer is known to send." | **Medium** | If a profile declared the expected value set (ties to P-1), the mapping screen could show value-map completeness the same way it shows test-code match stats — turning "did I cover every result this thing can emit?" from a guess into a visible check. This is what prevents a surprise unmapped value on a live patient sample months later. |
+| M-5 | **The three protocols describe the same mapping job three different ways.** ASTM, HL7, and flat-file mapping live in separate addenda with divergent emphasis and terminology. | **Medium** | An admin mapping a flat-file analyzer and an HL7 analyzer should experience the *same* test-mapping and value-mapping functions, with only the source-field reference differing. Today there's real risk of three subtly different mapping editors. We should state the mapping functions once, protocol-agnostically, and let each protocol only vary the "where the value comes from" part. |
+| M-6 | **Reverse mapping (for outbound work orders) is unaddressed.** All mapping described is inbound (results → OpenELIS). Bidirectional instruments also need OpenELIS test → analyzer code for work orders / host query. | **Low (flag)** | Out of scope for this pass, but worth naming explicitly so it's a deliberate deferral, not an oversight. The query/host-query features already hint at it. |
+
+---
+
+## 4. One cross-cutting observation
+
+The published admin guide ("Analyzers / ASTM Management", OGC-138) already walks through **loading profiles, value mapping, and QC configuration as if they are fully shipped.** In reality, what's delivered is the generic module plus a defaults file; the richer profile and value-mapping functions described here are the parts not yet brought in. The documentation is currently ahead of the delivered function. Closing the gaps above also closes that gap between the docs and the product.
+
+A related mismatch worth flagging for the team: the HL7 design work is written around MLLP transport and HL7 v2.3.1, but the real GeneXpert profile declares HL7 **v2.5 over HTTP**. That's a connection-layer detail developers will sort out, but functionally it confirms the profile must be able to *say* how a given instrument actually talks (transport and version), and the mapping/connection functions can't assume one fixed answer.
+
+---
+
+## 5. Target functional model (agreed 2026-06-17)
+
+These decisions resolve the pivotal questions and set the direction for the spec revision. Described as function only.
+
+**A profile is the analyzer's living configuration — and it carries the select-list value maps.** There is no "profile mode" versus "manual mode." Every configured analyzer *has* a profile; the only difference is how that profile came to exist. A profile carries both the test-code mappings and the qualitative value → select-list-option mappings (resolving P-1 and P-2). This builds on what some profiles already do — listing an analyzer's expected values (GeneXpert ASTM) and even normalizing them (GeneXpert CSV) — and adds the missing piece: a consistent representation in which each analyzer value is bound to an actual option in the lab's test catalog. Value-map targets always come from the chosen test's own result options (resolving M-1); if the test has none defined yet, the admin is guided to set them up in Test Catalog first (M-2).
+
+**Three ways an analyzer gets configured — all end in a profile:**
+
+1. **Apply a prebuilt profile that matches the lab's test catalog.** Best case: pick it, confirm, activate. The profile already contains the test mappings and the value maps, so there's little or nothing left to do.
+2. **Build the mapping by hand in the GUI.** When no prebuilt profile fits, the admin maps test codes and value lists manually — and that work is **saved as a local profile**, so it's reusable, exportable, and not thrown away. Manual setup and profile creation are the same act.
+3. **Connect the analyzer with no (or partial) mapping and let it learn.** The system parses incoming messages and **prompts the admin to resolve anything it can't map** — unknown test codes and unknown coded values alike. Each resolution extends the local profile.
+
+**The "prompt me for what's unmapped" behavior is continuous, not just at setup.** The same mechanism that handles path 3 at onboarding also catches change over time:
+
+- An analyzer gets a **new cartridge** and starts sending a **new test code** that isn't in OpenELIS yet → it surfaces as a pending item for the admin to map.
+- An analyzer sends a **new coded value** a mapped test's value-list hasn't seen before (e.g., a result option that wasn't in the original profile) → it surfaces the same way.
+
+Unmapped tests and unmapped values are **never silently dropped**. They queue for the admin and are visible in the Analyzer Results review so a human always closes the loop (resolving M-3, and giving M-4 its completeness signal). This makes profiles self-maintaining: the configuration grows as the instrument's real behavior reveals itself.
+
+**How profiles are distributed — and why they stay catalog-independent.** Profiles are portable, drop-in units (think of a profile, or a bundle of them, as something added without rebuilding the application — "like a plugin"). They reach a site in three layers:
+
+1. **Base catalog (ships with OpenELIS).** Anyone who downloads the software gets a starting catalog of known-instrument profiles, available out of the box.
+2. **Distro bundles.** A deployment (Madagascar, PNG, …) can package a chosen subset — or all — of the profiles relevant to its instruments. Because a distro controls its own test catalog, its bundled profiles can ship **already bound** to that catalog's tests and select-list options — this is the "prebuilt profile that matches my catalog perfectly" best case from the three paths above.
+3. **Site-added profiles.** An admin can drop in or import a profile easily — hand-built (path 2) or shared from elsewhere — without a rebuild or a developer.
+
+The pivotal design consequence: **the portable profile must be catalog-independent.** Different distros and sites have different test catalogs, so a profile can't hard-wire bindings to one lab's tests. A portable profile describes the *analyzer's* behavior (its test codes, expected values, QC rules) and *suggests* targets (e.g., by LOINC and name); the actual binding to a site's tests and select-list options **resolves when the profile is applied** (resolving M-1 at apply-time, and explaining why auto-match exists). A distro bundle is then just the special case where that binding is pre-done because the catalog is known. This keeps one profile reusable everywhere while still allowing a perfect, zero-touch fit where the catalog is controlled.
+
+**What this closes:** P-1, P-2, P-7, M-1, M-2, M-3 are resolved in principle by this model; M-4 (completeness feedback) and P-5/P-6 (update path, faithful export) become the supporting functions that make the paths trustworthy and reusable. (P-4 recognition is cut — see §7.) P-3 is just a clean-up: keep the team's authoring/tracking metadata separate from the operational profile so the GUI ignores it.
+
+---
+
+## 6. Recommended sequence (functional, not implementation)
+
+1. **Settle what a profile is.** Agree the functional contents of a profile — and make it include the qualitative value/select-list mappings (P-1, P-2). Everything else in profile management depends on this answer.
+2. **Make select-list mapping safe and consistent.** Always source value-map targets from the chosen test's own result options, define one consistent unmapped-value behavior, and surface unmapped values to the reviewer (M-1, M-3, M-2).
+3. **Make profiles trustworthy and reusable.** Surface confidence, support a clean update/re-adopt path, and guarantee export reproduces what the admin built (P-3, P-5, P-6).
+4. **Unify the mapping experience across protocols** and add value-map completeness feedback (M-5, M-4).
+5. **Add instrument recognition** as the setup-effort payoff once profiles are complete (P-4).
+
+---
+
+## 7. Decisions and remaining questions
+
+**Decided (2026-06-17):**
+
+1. **Profile contents — DECIDED:** A profile **carries the qualitative value/select-list maps** (and is the analyzer's living configuration). See §5.
+2. **Select-list target — DECIDED:** Value-map options are always bound to the chosen test's own result list. See §5.
+3. **Unmapped tests/values — DECIDED:** Never dropped. The system parses the message and **prompts the admin to resolve** unmapped test codes and unmapped coded values, both at setup and continuously (new cartridge / new value). See §5.
+4. **Trust signals — DECIDED:** `confidence` / `verification_required` / `validation_status` are **internal** team-tracking metadata, not admin-facing. They should not appear in the GUI or gate setup; keep them separate from the operational profile. (P-3)
+5. **Distribution — DECIDED:** Profiles are portable, drop-in units in three layers — a base catalog that ships with OpenELIS for everyone, curated distro bundles (which may ship pre-bound to that distro's catalog), and site-added imports. The portable profile is catalog-independent; binding to a site's tests/options resolves at apply-time. See §5. (P-7)
+
+6. **Recognition — DECIDED (cut / out of scope):** Auto-suggesting a profile from an incoming message is **not** pursued. The in-message identity signal is unreliable (often a configurable/generic sender string in ASTM H.5; absent entirely for flat file) and several profiles' recognition patterns are unverified. More to the point: an admin who can't pick their own instrument from the profile list shouldn't be setting it up. The analyzer is already identified by its connection, and the unmapped-prompting (path 3 / §5) covers the ongoing case without needing to guess the instrument. (P-4)
+
+**Still open for the team:**
+
+7. **Pending-value review home:** Should unmapped tests/values be resolved from within the analyzer's mapping screen, from the Analyzer Results review queue, or both? (Affects M-3/M-4 surfacing.)

--- a/designs/analyzer-integration/analyzer-profile-mapping.html
+++ b/designs/analyzer-integration/analyzer-profile-mapping.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Analyzer Profiles & Mapping — Prototype — OpenELIS</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --navy:#152935; --navy2:#1c3142; --navHover:#2a4256;
+    --blue:#0f62fe; --blueHover:#0043ce; --blueBg:#edf5ff;
+    --g10:#f9f9f9; --g50:#f4f4f4; --g100:#e0e0e0; --g200:#c6c6c6; --g300:#a8a8a8; --g500:#8d8d8d;
+    --g600:#6f6f6f; --g700:#525252; --g800:#393939; --g900:#161616;
+    --white:#fff; --red:#da1e28; --redBg:#fff1f1; --green:#24a148; --greenBg:#defbe6;
+    --teal:#007d79; --tealBg:#d9fbfb; --amber:#f1c21b; --amberBg:#fcf4d6; --amberTx:#8a6a00; --purple:#8a3ffc; --purpleBg:#e8daff;
+    --font:'IBM Plex Sans',-apple-system,BlinkMacSystemFont,sans-serif; --mono:'IBM Plex Mono','Menlo',monospace;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--font);color:var(--g900);background:var(--g50);font-size:14px;}
+  .banner{background:var(--blue);color:#fff;padding:6px 16px;font-size:12px;font-family:var(--mono);}
+  .hdr{background:var(--navy);color:#fff;height:48px;display:flex;align-items:center;padding:0 16px;gap:14px;}
+  .hdr .brand{font-weight:600;font-size:15px;} .hdr .ver{font-size:11px;color:#8fa3b0;} .hdr .r{margin-left:auto;display:flex;gap:18px;color:#c9d4df;}
+  .shell{display:flex;min-height:calc(100vh - 48px - 27px);}
+  .side{width:228px;background:var(--navy);color:#c9d4df;flex-shrink:0;padding:6px 0;font-size:13.5px;}
+  .side .item{padding:10px 16px;cursor:pointer;color:#dde4ea;} .side .item:hover{background:var(--navHover);}
+  .side .item.active{background:var(--navy2);color:#fff;}
+  .side .sub{padding:8px 16px 8px 32px;color:#aebcc7;font-size:12.5px;cursor:pointer;} .side .sub:hover{background:var(--navHover);color:#fff;}
+  .side .sub.active{color:#fff;background:var(--blue);font-weight:500;}
+  .main{flex:1;min-width:0;}
+  .page{padding:22px 30px;max-width:1100px;}
+  .crumbtitle{font-size:23px;font-weight:400;margin:0 0 2px;} .crumbtitle b{font-weight:600;} .crumbtitle .sep{color:var(--g300);}
+  .crumbtitle a{color:var(--blue);cursor:pointer;}
+  .sub1{color:var(--g600);font-size:13px;margin-bottom:16px;}
+  .cards{display:flex;border:1px solid var(--g100);background:#fff;margin-bottom:16px;}
+  .cards .c{flex:1;padding:13px 18px;border-right:1px solid var(--g100);} .cards .c:last-child{border-right:none;}
+  .cards .l{font-size:11px;color:var(--g600);text-transform:uppercase;} .cards .n{font-size:25px;font-weight:300;margin-top:2px;}
+  .searchbar{display:flex;align-items:center;gap:8px;background:#fff;border:1px solid var(--g100);border-bottom:1px solid var(--g300);padding:10px 14px;}
+  .searchbar input{border:none;outline:none;font-size:14px;flex:1;background:transparent;font-family:var(--font);}
+  .filters{display:flex;gap:16px;background:#fff;border:1px solid var(--g100);border-top:none;padding:11px 14px;align-items:flex-end;flex-wrap:wrap;}
+  .filters .f label{display:block;font-size:11px;color:var(--g600);margin-bottom:4px;} .filters select{padding:6px 10px;border:1px solid var(--g200);font-size:12.5px;background:#f9f9f9;font-family:var(--font);}
+  .chk{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--g700);cursor:pointer;padding-bottom:6px;}
+  table{width:100%;border-collapse:collapse;background:#fff;} th{text-align:left;font-size:11px;text-transform:uppercase;color:var(--g600);padding:10px 14px;border-bottom:1px solid var(--g200);background:var(--g50);font-weight:600;white-space:nowrap;} td{padding:12px 14px;border-bottom:1px solid var(--g100);}
+  tr.click{cursor:pointer;} tr.click:hover td{background:#f7f9fc;}
+  .meta{font-size:12px;color:var(--g600);}
+  .mono{font-family:var(--mono);}
+  .tag{display:inline-block;padding:3px 10px;border-radius:13px;font-size:11px;font-weight:500;}
+  .t-green{background:var(--greenBg);color:#0e6027;} .t-amber{background:var(--amberBg);color:#8a6a00;} .t-blue{background:var(--blueBg);color:#0043ce;} .t-teal{background:var(--tealBg);color:#005d5d;} .t-gray{background:var(--g100);color:#525252;} .t-red{background:var(--redBg);color:#a2191f;}
+  .btn{font-family:var(--font);font-size:14px;border:none;padding:10px 17px;cursor:pointer;display:inline-flex;align-items:center;gap:7px;} .btn-sm{padding:6px 12px;font-size:12.5px;}
+  .btn-pri{background:var(--blue);color:#fff;} .btn-pri:hover{background:var(--blueHover);}
+  .btn-sec{background:#fff;border:1px solid var(--blue);color:var(--blue);} .btn-sec:hover{background:var(--blueBg);}
+  .btn-ghost{background:none;color:var(--g700);} .btn-ghost:hover{background:var(--g50);}
+  .note{padding:11px 14px;font-size:12.5px;display:flex;gap:8px;align-items:flex-start;line-height:1.55;} .note-info{background:var(--blueBg);border-left:3px solid var(--blue);color:#0b3a8f;} .note-ok{background:var(--greenBg);border-left:3px solid var(--green);color:#0e6027;} .note-warn{background:var(--amberBg);border-left:3px solid var(--amber);color:#6b5200;} .note-err{background:var(--redBg);border-left:3px solid var(--red);color:#a2191f;}
+  .field{margin-bottom:14px;} .field label{display:block;font-size:12px;color:var(--g600);margin-bottom:5px;} .field .help{font-size:11px;color:var(--g500);margin-top:4px;}
+  .field input,.field select{width:100%;padding:10px 12px;border:1px solid var(--g100);border-bottom:1px solid var(--g500);font-family:var(--font);font-size:13.5px;background:var(--g10);}
+  .row2{display:flex;gap:16px;} .row2>*{flex:1;}
+  .pillrow{display:flex;flex-wrap:wrap;gap:6px;align-items:center;border:1px solid var(--g100);border-bottom:1px solid var(--g500);background:var(--g10);padding:8px;min-height:42px;} .pillrow input{border:none;background:transparent;flex:1;min-width:80px;outline:none;font-family:var(--font);font-size:13px;}
+  .ovf{cursor:pointer;color:var(--g700);font-weight:700;letter-spacing:1px;padding:0 8px;} .ofmenu{position:relative;display:inline-block;} .ofmenu .menu{position:absolute;right:0;top:22px;background:#fff;border:1px solid var(--g200);box-shadow:0 4px 12px rgba(0,0,0,.12);z-index:20;min-width:150px;} .ofmenu .menu div{padding:9px 13px;font-size:13px;cursor:pointer;white-space:nowrap;} .ofmenu .menu div:hover{background:var(--g50);}
+  .hide{display:none;}
+  /* setup */
+  .setup{border:2px solid var(--blue);background:#fff;margin-bottom:18px;} .setup-h{background:var(--blueBg);padding:13px 18px;display:flex;align-items:center;gap:10px;font-weight:600;} .setup-h .x{margin-left:auto;cursor:pointer;color:var(--g600);font-size:16px;}
+  .sec{border-bottom:1px solid var(--g100);} .sec:last-child{border-bottom:none;}
+  .sec-h{padding:13px 18px;display:flex;align-items:center;gap:12px;} .sec-h .num{width:26px;height:26px;border-radius:50%;background:#fff;border:1px solid var(--g300);color:var(--g600);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:600;flex-shrink:0;}
+  .sec.done .num{background:var(--green);border-color:var(--green);color:#fff;} .sec.open .num{background:var(--blue);border-color:var(--blue);color:#fff;}
+  .sec-h .t{font-weight:600;} .sec-h .t .q{font-weight:400;color:var(--g600);font-size:12.5px;} .sec-h .summary{font-size:12.5px;color:var(--g600);} .sec-h .edit{margin-left:auto;color:var(--blue);font-size:12.5px;cursor:pointer;}
+  .sec-b{padding:2px 18px 20px 56px;} .sec.collapsed .sec-b{display:none;}
+  .inst{display:flex;align-items:center;gap:13px;padding:11px 14px;border:1px solid var(--g100);background:#fff;cursor:pointer;margin-bottom:-1px;} .inst:hover{background:var(--g10);} .inst.sel{border:2px solid var(--blue);background:var(--blueBg);}
+  .inst .ic{width:36px;height:36px;border-radius:7px;background:var(--g50);display:flex;align-items:center;justify-content:center;font-weight:600;color:var(--g700);font-size:12px;flex-shrink:0;} .inst.sel .ic{background:var(--blue);color:#fff;} .inst .nm{font-weight:600;} .inst .chev{margin-left:auto;color:var(--g400);}
+  .exp{background:#fffaf0;}
+  /* editor */
+  .card{background:#fff;border:1px solid var(--g100);margin-bottom:16px;} .card-h{padding:12px 16px;border-bottom:1px solid var(--g100);font-weight:600;display:flex;align-items:center;gap:10px;} .card-b{padding:16px;}
+  .ctx{border:1px solid var(--blue);background:var(--blueBg);padding:12px 16px;margin-bottom:16px;font-size:13px;display:flex;gap:10px;align-items:flex-start;line-height:1.5;}
+  .chg{background:#fffaf0;border-left:3px solid var(--amber);} .ovr{display:inline-block;font-size:10px;font-weight:600;color:var(--purple);background:var(--purpleBg);padding:1px 7px;border-radius:10px;margin-left:6px;}
+  .vm-row{display:grid;grid-template-columns:1fr 22px 1fr;gap:8px;align-items:center;padding:6px 0;}
+  .scope{border:2px solid var(--blue);background:#fff;margin-top:14px;} .scope-h{background:var(--blueBg);padding:12px 16px;font-weight:600;} .opt{display:flex;gap:12px;padding:14px 16px;border-bottom:1px solid var(--g100);cursor:pointer;} .opt:hover{background:var(--g10);} .opt.sel{background:var(--blueBg);} .opt .ot{font-weight:600;margin-bottom:2px;} .opt .od{font-size:12px;color:var(--g600);line-height:1.5;}
+  .savebar{position:sticky;bottom:0;background:#fff;border:1px solid var(--g200);padding:13px 16px;display:flex;gap:10px;align-items:center;}
+</style>
+</head>
+<body>
+<div class="banner">⚡ Functional Prototype — Analyzer Profiles &amp; Mapping &nbsp;|&nbsp; pick → verify → connect · editor-as-exception · shared-with-fork · ASTM &amp; HL7 &nbsp;|&nbsp; OpenELIS design mockup (not live)</div>
+<div class="hdr"><span style="font-size:18px;">☰</span><span><span class="brand">Test LIMS</span> <span class="ver">3.2.1.10</span></span><span class="r"><span>🔍</span><span>🔔</span><span>👤</span><span>❓</span></span></div>
+
+<div class="shell">
+  <div class="side">
+    <div class="item">Home</div>
+    <div class="item active">Analyzers</div>
+    <div class="sub" id="nav-list" onclick="view('list')">Analyzers List</div>
+    <div class="sub" id="nav-profiles" onclick="view('profiles')">Analyzer Types</div>
+    <div class="sub">Error Dashboard</div>
+    <div class="sub">Quality Control ⌄</div>
+    <div class="item">Results</div>
+    <div class="item">Alerts</div>
+    <div class="item">Admin</div>
+  </div>
+
+  <div class="main">
+
+    <!-- ===================== ANALYZERS LIST ===================== -->
+    <div id="v-list"><div class="page">
+      <div style="display:flex;align-items:flex-start;">
+        <div><div class="crumbtitle"><b>Analyzers</b> <span class="sep">&gt;</span> Analyzer List</div><div class="sub1">Manage laboratory analyzers and field mappings</div></div>
+        <button class="btn btn-pri" style="margin-left:auto;" onclick="openSetup()">Add Analyzer +</button>
+      </div>
+      <div class="cards">
+        <div class="c"><div class="l">Total</div><div class="n">4</div></div>
+        <div class="c"><div class="l">Active</div><div class="n" style="color:var(--green)">3</div></div>
+        <div class="c"><div class="l">In Setup</div><div class="n" style="color:var(--amber)">1</div></div>
+        <div class="c"><div class="l">Needs Attention</div><div class="n" style="color:var(--red)">1</div></div>
+      </div>
+
+      <div class="note note-err" style="margin-bottom:16px;">🚩 <span><b>Mindray BC-5380</b> is sending a result OpenELIS can't map (<span class="mono">NRBC#</span>). It's parked in <b>Alerts</b> for acknowledgment — the result isn't lost, but it won't post until you map it. <a style="color:var(--red);font-weight:600;cursor:pointer;" onclick="openMappings('hl7')">Resolve →</a></span></div>
+
+      <!-- inline guided setup (list stays visible below) -->
+      <div class="setup hide" id="setup">
+        <div class="setup-h">🔬 Set up a new analyzer <span class="x" onclick="closeSetup()">✕</span></div>
+
+        <!-- 1 Instrument -->
+        <div class="sec open" id="sec1">
+          <div class="sec-h"><span class="num">1</span><span class="t">Instrument <span class="q" id="q1">— pick what you're connecting</span></span><span class="summary hide" id="sum1"></span><span class="edit hide" id="edit1" onclick="openSec(1)">Edit</span></div>
+          <div class="sec-b" id="body1">
+            <div class="searchbar" style="margin-bottom:12px;"><span style="color:var(--g400)">🔍</span><input placeholder="Search by make or model — GeneXpert, Sysmex, Mindray…"></div>
+            <div onclick="pick(this)" class="inst sel"><div class="ic">GX</div><div><div class="nm">Cepheid GeneXpert</div><div class="meta">Molecular / PCR · ASTM</div></div><span class="chev">●</span></div>
+            <div onclick="pick(this)" class="inst"><div class="ic">MR</div><div><div class="nm">Mindray BC-5380</div><div class="meta">Hematology · HL7</div></div><span class="chev">›</span></div>
+            <div style="padding:8px 2px;font-size:13px;"><a style="color:var(--blue);cursor:pointer;" onclick="toggleNew()">My instrument isn't listed →</a> <span class="meta">define a new profile (protocol + connection type)</span></div>
+            <div id="newprof" class="hide" style="border:1px dashed var(--blue);background:var(--blueBg);padding:14px;margin-bottom:10px;">
+              <div style="font-weight:600;margin-bottom:8px;">Define a new profile</div>
+              <div class="note note-info" style="margin-bottom:12px;">ℹ️ Tell us how this instrument communicates — this becomes a new profile you can reuse. It starts with <b>no mappings</b>; you'll fill them by sending a result from the analyzer in the next step, or by hand.</div>
+              <div class="row2"><div class="field" style="margin:0;"><label>Profile name</label><input placeholder="e.g., Acme ChemPro 200"></div><div class="field" style="margin:0;"><label>Protocol</label><select><option>ASTM LIS2-A2</option><option>HL7 v2.x</option><option>Flat file (CSV/XML)</option></select></div></div>
+              <div class="field" style="margin-top:12px;margin-bottom:0;"><label>Connection type</label><select><option>Network — analyzer connects to OpenELIS</option><option>Network — OpenELIS connects to analyzer</option><option>Watched folder (files)</option></select></div>
+            </div>
+            <div class="row2" style="margin-top:8px;"><div class="field" style="margin:0;"><label>Name</label><input id="anName" value="GeneXpert MTB/RIF #2"></div><div class="field" style="margin:0;"><label>Lab unit(s)</label><div class="pillrow"><span class="tag t-blue">Molecular Biology ✕</span><input placeholder="Add…"></div></div></div>
+            <button class="btn btn-pri btn-sm" style="margin-top:10px;" onclick="doneSec(1)">Continue →</button>
+          </div>
+        </div>
+
+        <!-- 2 Verify -->
+        <div class="sec collapsed" id="sec2">
+          <div class="sec-h"><span class="num">2</span><span class="t">Verify the mappings <span class="q">— confirm what the profile set up; you don't build this by hand</span></span><span class="summary hide" id="sum2"></span><span class="edit hide" id="edit2" onclick="openSec(2)">Edit</span></div>
+          <div class="sec-b" id="body2">
+            <div class="note note-ok" style="margin-bottom:14px;">✅ <span>Loaded <b>Cepheid GeneXpert — MTB/RIF</b>. <b>3 of 4 tests</b> matched to your catalog by LOINC and ready; <b>1 needs a quick look</b>. Review and confirm — this is your sign-off, so nothing maps itself silently.</span></div>
+            <table>
+              <thead><tr><th style="width:28px;"></th><th>Analyzer sends</th><th>Matched to your test</th><th>By LOINC</th><th>Status</th><th>Checked vs live</th><th></th></tr></thead>
+              <tbody>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">MTB-RIF</td><td>MTB Detection</td><td class="mono">85362-2</td><td><span class="tag t-green">matched · active</span></td><td id="lv-mtb" class="meta">— not seen yet</td><td></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">HIV-VL</td><td>HIV-1 Viral Load</td><td class="mono">20447-9</td><td><span class="tag t-green">matched · active</span></td><td id="lv-hiv" class="meta">— not seen yet</td><td></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">RIF</td><td>Rifampin Resistance</td><td class="mono">46244-0</td><td><span class="tag t-green">matched · active</span></td><td id="lv-rif" class="meta">— not seen yet</td><td></td></tr>
+                <tr class="exp"><td>⚠</td><td class="mono" style="font-weight:600;">COVID19</td><td style="color:var(--amberTx);">SARS-CoV-2 — no LOINC match in your catalog</td><td class="mono">94500-6</td><td><span class="tag t-amber">needs attention</span></td><td id="lv-covid" class="meta">—</td><td style="text-align:right;"><button class="btn btn-sec btn-sm" onclick="document.getElementById('exrow').classList.toggle('hide')">Resolve ▾</button></td></tr>
+                <tr id="exrow" class="hide"><td colspan="7" style="background:#fff;padding:0;">
+                  <div style="padding:14px 18px;border-left:3px solid var(--amber);">
+                    <div style="font-weight:600;margin-bottom:8px;">Resolve COVID19 <span class="mono" style="font-weight:400;color:var(--g600)">94500-6</span> — the editor opens only for this exception</div>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r" checked> <b>Map to an existing test in your catalog</b></label>
+                    <div style="display:flex;align-items:center;gap:8px;border:1px solid var(--g200);background:#fff;padding:8px 12px;margin:4px 0 6px 26px;max-width:480px;"><span style="color:var(--g400)">🔍</span><input style="border:none;outline:none;flex:1;font-family:var(--font);font-size:13px;" placeholder="Search your catalog by name, code, or LOINC…" value="SARS"></div>
+                    <div style="margin:0 0 8px 26px;font-size:12px;color:var(--g600);">2 of ~500 catalog tests match · <span class="mono">SARS-CoV-2 RNA</span> (94500-6) · <span class="mono">COVID-19 PCR</span> (94500-6)</div>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r"> Not in your catalog? <a style="color:var(--blue);cursor:pointer;margin-left:4px;">Add it in Test Catalog ↗</a> first, then return and map <span style="font-size:11px;color:var(--g500);margin-left:6px;">(adding a test is multi-step — done in Test Catalog, not here)</span></label>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r"> Don't receive this test from this analyzer</label>
+                    <div style="margin-top:10px;"><button class="btn btn-pri btn-sm" onclick="resolveEx()">Apply</button> <button class="btn btn-ghost btn-sm" onclick="document.getElementById('exrow').classList.add('hide')">Cancel</button></div>
+                  </div>
+                </td></tr>
+              </tbody>
+            </table>
+
+            <div style="margin-top:18px;font-weight:600;font-size:13px;">Quality control codes <span class="sub1" style="font-weight:400;margin:0;">— confirm controls are recognized so QC runs don't post as patient results</span></div>
+            <table style="margin-top:6px;">
+              <thead><tr><th style="width:28px;"></th><th>QC code</th><th>Recognized as</th><th>Status</th></tr></thead>
+              <tbody>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">CNEG</td><td>Negative control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">CPOS</td><td>Positive control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">Q</td><td>Control flag (field O.12 = Q)</td><td><span class="tag t-green">recognized</span></td></tr>
+              </tbody>
+            </table>
+
+            <div class="note note-info" style="margin-top:14px;">ℹ️ <span><b>Verify against a real message.</b> Mappings come from the profile, but a given instrument may send different codes (enabled assays vary). Push a result from the analyzer to reconcile what's actually transmitted against the mappings.</span></div>
+            <div style="margin-top:10px;"><button class="btn btn-sec btn-sm" onclick="simulateResult()">▶ Send a result from the analyzer now</button> <span class="meta" id="recvHint"></span></div>
+
+            <div id="recvPanel" class="hide" style="border:1px solid var(--g200);margin-top:12px;">
+              <div style="padding:11px 14px;border-bottom:1px solid var(--g100);font-weight:600;font-size:13px;display:flex;align-items:center;gap:10px;">Transmission received <span class="meta" style="font-weight:400;">1 message · 3 results · 09:42</span></div>
+              <table>
+                <thead><tr><th>Received</th><th>Interpreted</th><th>Match</th><th>Action</th></tr></thead>
+                <tbody>
+                  <tr><td class="mono"><b>MTB-RIF</b> = NOT DETECTED</td><td>MTB Detection = Not Detected</td><td><span class="tag t-green">matches mapping</span></td><td class="meta">verified ✓</td></tr>
+                  <tr id="recv-rif" style="background:#fffaf0;"><td class="mono"><b>RIF</b> = INDETERMINATE</td><td>Rifampin Resistance = <span style="color:var(--amberTx)">result not mapped</span></td><td><span class="tag t-amber">new result</span></td><td><select id="rifsel" style="padding:4px 8px;border:1px solid var(--amber);font-family:var(--font);font-size:12.5px;"><option>— map to —</option><option selected>Indeterminate</option></select> <button class="btn btn-pri btn-sm" onclick="applyRecv('rif')">Map</button></td></tr>
+                  <tr id="recv-xdr" style="background:#fffaf0;"><td class="mono"><b>XDR</b> = DETECTED</td><td><span style="color:var(--amberTx)">no test mapped — new code</span></td><td><span class="tag t-amber">new test code</span></td><td><input placeholder="🔍 search catalog…" style="padding:4px 8px;border:1px solid var(--amber);font-family:var(--font);font-size:12.5px;width:140px;" value="MTB/XDR Resistance"> <button class="btn btn-pri btn-sm" onclick="applyRecv('xdr')">Map</button></td></tr>
+                </tbody>
+              </table>
+              <div class="note note-info" style="margin:0;">ℹ️ Nothing that doesn't match is dropped — map it here now, or (on a live analyzer) it waits under <b>Alerts</b>. If <b>nothing</b> matched, every row would appear here to map — which is exactly how a brand-new profile (no mappings yet) gets built from a real message.</div>
+            </div>
+
+            <div style="margin-top:14px;display:flex;gap:10px;align-items:center;"><button class="btn btn-pri" onclick="doneSec(2)">Confirm &amp; continue →</button><span class="sub1" style="margin:0;" id="confirmHint">1 item still needs attention</span></div>
+          </div>
+        </div>
+
+        <!-- 3 Connect -->
+        <div class="sec collapsed" id="sec3">
+          <div class="sec-h"><span class="num">3</span><span class="t">Connect it <span class="q">— network address and which way data flows</span></span></div>
+          <div class="sec-b" id="body3">
+            <div class="row2"><div class="field" style="margin:0;"><label>Analyzer IP address</label><input placeholder="10.42.20.10"></div><div class="field" style="margin:0;"><label>Port</label><input value="9600"></div></div>
+            <div class="field" style="margin-top:12px;"><label>Data flow</label>
+              <label class="chk" style="padding:5px 0;color:var(--g900);"><input type="radio" name="dir" checked> Results only (one-way)</label>
+              <label class="chk" style="padding:5px 0;color:var(--g900);"><input type="radio" name="dir"> Two-way (send orders/queries) — verified by the test below</label>
+              <div class="help">Two-way needs OpenELIS to reach the analyzer. If the analyzer is on a private network with no route back, the test times out and it runs one-way.</div></div>
+            <button class="btn btn-sec btn-sm" onclick="document.getElementById('cr').classList.remove('hide')">Test connection</button>
+            <div id="cr" class="note note-ok hide" style="margin-top:10px;">✅ Connected — one-way verified. Two-way not reachable on this network; running results-only.</div>
+            <div style="margin-top:14px;display:flex;gap:10px;"><button class="btn btn-pri" onclick="finishSetup()">Finish &amp; activate</button><button class="btn btn-sec" onclick="finishSetup()">Save &amp; finish later</button><button class="btn btn-ghost" onclick="closeSetup()">Cancel</button></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="searchbar"><span style="color:var(--g400)">🔍</span><input placeholder="Search analyzers…"></div>
+      <table>
+        <thead><tr><th>Name</th><th>Connection</th><th>Lab Units</th><th>Analyzer type</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          <tr class="click" onclick="openMappings('astm')"><td><b>Cepheid GeneXpert (ASTM Mode)</b></td><td class="mono" style="font-size:12px;">10.42.20.10:9600 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Molecular Biology</td><td class="meta">GeneXpert — MTB/RIF</td><td><span class="tag t-amber">Setup</span></td><td><span class="ovf" onclick="event.stopPropagation();om(this)">⋮</span><div class="ofmenu"><div class="menu hide"><div onclick="openMappings('astm')">Field Mappings</div><div>Test Connection</div><div>Copy Mappings</div><div>Edit</div><div>QC Rules</div><div>Deactivate</div></div></div></td></tr>
+          <tr class="click" onclick="openMappings('hl7')"><td><b>Mindray BC-5380</b> <span class="tag t-red" style="font-size:9px;">unmapped result</span></td><td class="mono" style="font-size:12px;">10.42.21.10:5380 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Hematology</td><td class="meta">Mindray BC-5380</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Sysmex XN-550</b></td><td class="mono" style="font-size:12px;">10.42.21.20:5001 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Hematology</td><td class="meta">Sysmex XN Series</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Tecan Infinite F50</b></td><td class="meta">watch folder</td><td class="meta">Immunology</td><td class="meta">Tecan F50 — HIV ELISA</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+        </tbody>
+      </table>
+      <div class="note note-info" style="margin-top:12px;">ℹ️ Click <b>GeneXpert (ASTM)</b> or <b>Mindray (HL7)</b> to open the mapping editor — same surface; only the field reference differs by protocol. The editor is the exception/edit path; a clean setup never needs it.</div>
+    </div></div>
+
+    <!-- ===================== MAPPING EDITOR (exception / edit) ===================== -->
+    <div id="v-map" class="hide"><div class="page">
+      <div class="crumbtitle"><a onclick="view('list')">← Analyzers</a> <span class="sep">&gt;</span> Field Mappings <span class="sep">&gt;</span> <span id="mapAn">GeneXpert MTB/RIF #1</span></div>
+      <div class="sub1">Edit how this analyzer's results map to your tests. Most setups never need this — it's the exception path.</div>
+      <div class="ctx">📋 <div>Editing the analyzer type <b id="mapProf">Cepheid GeneXpert — MTB/RIF</b> (<span id="mapProto">ASTM</span>) — used by <b id="mapUsed">3 analyzers</b>. On save you'll choose: a <b>new type</b> for this analyzer (default), or update the shared type for all of them.</div></div>
+
+      <div class="card">
+        <div class="card-h">Test codes <span class="sub1" style="margin:0;font-weight:400;">— what the analyzer sends (<span class="mono" id="fref">R.3</span>) → your test</span></div>
+        <div class="card-b">
+          <div class="note note-info" style="margin-bottom:14px;">ℹ️ Every row is editable — re-point the <b>linked test</b> (search your ~500-test catalog) or change the code, even on rows already matched. Broad changes should <b>Save as a new analyzer type</b>.</div>
+          <div class="row2 chg" style="padding:8px 0 8px 13px;margin-bottom:8px;align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code <span class="ovr">changed</span></label><input value="RIF-RESIST"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="Rifampin Resistance" style="font-size:13.5px;"><div class="help">🔍 type to search ~500 tests</div></div><span style="color:var(--g500);cursor:pointer;padding-bottom:22px;" title="Remove">✕</span></div>
+          <div class="row2" style="margin-bottom:8px;align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code</label><input value="MTB-RIF"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="MTB Detection" style="font-size:13.5px;"></div><span style="color:var(--g500);cursor:pointer;padding-bottom:9px;" title="Remove">✕</span></div>
+          <div class="row2" style="align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code</label><input value="HIV-VL"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="HIV-1 Viral Load" style="font-size:13.5px;"></div><span style="color:var(--g500);cursor:pointer;padding-bottom:9px;" title="Remove">✕</span></div>
+          <button class="btn btn-ghost btn-sm" style="margin-top:10px;">+ Add test mapping</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">Results — Rifampin Resistance <span class="tag t-amber">2 of 3 mapped</span></div>
+        <div class="card-b">
+          <div class="note note-info" style="margin-bottom:12px;">ℹ️ Options come from the <b>Rifampin Resistance</b> test's result list (Resistant / Susceptible / Indeterminate).</div>
+          <div class="vm-row" style="font-size:11px;color:var(--g600);text-transform:uppercase;border-bottom:1px solid var(--g200);"><div>Analyzer value</div><div></div><div>Your result</div></div>
+          <div class="vm-row"><div class="mono">DETECTED</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select><option selected>Resistant</option><option>Susceptible</option></select></div></div>
+          <div class="vm-row"><div class="mono">NOT DETECTED</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select><option>Resistant</option><option selected>Susceptible</option></select></div></div>
+          <div class="vm-row" style="background:var(--amberBg);"><div class="mono">INDETERMINATE</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select style="border-color:var(--amber)"><option selected style="color:var(--g500)">— choose —</option><option>Indeterminate</option></select></div></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">QC codes</div>
+        <div class="card-b"><table><thead><tr><th>QC code</th><th>Recognized as</th><th>Status</th></tr></thead><tbody>
+          <tr><td class="mono" style="font-weight:600;">CNEG</td><td>Negative control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+          <tr><td class="mono" style="font-weight:600;">CPOS</td><td>Positive control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+          <tr><td class="mono" style="font-weight:600;">Q</td><td>Control flag (field O.12 = Q)</td><td><span class="tag t-green">recognized</span></td></tr>
+        </tbody></table></div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">Result formatting</div>
+        <div class="card-b"><div class="row2"><div class="field" style="margin:0;"><label>Date format</label><select><option>DD/MM/YYYY</option><option selected>MM/DD/YYYY</option></select></div><div class="field" style="margin:0;"><label>Decimal separator</label><select><option selected>Period (1.5)</option><option>Comma (1,5)</option></select></div></div></div>
+      </div>
+
+      <div class="savebar"><span style="font-size:12.5px;color:var(--amber);font-weight:600;">unsaved changes</span><span style="margin-left:auto;"></span><button class="btn btn-ghost btn-sm">Discard</button><button class="btn btn-pri" onclick="showScope()">Save changes</button></div>
+
+      <div class="scope hide" id="scope">
+        <div class="scope-h">How should these changes save?</div>
+        <label class="opt sel" onclick="selOpt(this,'new')"><input type="radio" name="scope" checked><div><div class="ot">Save as a new analyzer type <span class="tag t-blue" style="font-size:10px;">recommended</span></div><div class="od">This analyzer gets its own type (the other 2 stay untouched). No hidden one-offs — it's a type of its own, shown with its lineage.</div>
+          <div style="margin-top:8px;"><div class="field" style="margin:0;max-width:420px;"><label>New analyzer type name <span style="color:var(--g500);font-weight:400;">— auto-numbered to stay unique</span></label><input id="newProfName" value="Cepheid GeneXpert — MTB/RIF -1"><div class="help">Suggested from the source type + the next free number; rename if you like.</div></div></div></div></label>
+        <label class="opt" onclick="selOpt(this,'all')"><input type="radio" name="scope"><div><div class="ot">Update this analyzer type — affects all 3 analyzers</div><div class="od">⚠ Changes the shared type for GeneXpert #1, #2, and #3. Use only when every unit of this model should match.</div></div></label>
+        <div style="padding:14px 16px;display:flex;gap:10px;"><button class="btn btn-pri" onclick="view('list')">Confirm &amp; save</button><button class="btn btn-ghost" onclick="document.getElementById('scope').classList.add('hide')">Back</button></div>
+      </div>
+    </div></div>
+
+    <!-- ===================== ANALYZER PROFILES ===================== -->
+    <div id="v-profiles" class="hide"><div class="page">
+      <div class="crumbtitle"><b>Analyzers</b> <span class="sep">&gt;</span> Analyzer Types</div>
+      <div class="sub1">The reusable setups behind your analyzers.</div>
+      <div class="note note-info" style="margin-bottom:16px;">ℹ️ <span><b>What is this?</b> An analyzer type is the reusable setup for a kind of analyzer — its test codes, the results it reports and how they map to your tests, formatting, and QC codes. <b>How to use it:</b> identical analyzers share one type, so fixing it once updates them all; when a unit differs, open it and <b>Save as a new type</b>. Analyzer types are deactivated (not deleted) to keep this list tidy.</span></div>
+      <div class="cards">
+        <div class="c"><div class="l">Analyzer Types</div><div class="n">42</div></div>
+        <div class="c"><div class="l">In Use</div><div class="n" style="color:var(--green)">7</div></div>
+        <div class="c"><div class="l">Has Unmapped Results</div><div class="n" style="color:var(--amber)">3</div></div>
+        <div class="c"><div class="l">Deactivated</div><div class="n" style="color:var(--g500)">9</div></div>
+      </div>
+      <div class="searchbar"><span style="color:var(--g400)">🔍</span><input placeholder="Search profiles by name, manufacturer, model…"></div>
+      <div class="filters">
+        <div class="f"><label>Created</label><select><option>All</option><option>Site-created</option><option>Shipped with OpenELIS</option></select></div>
+        <div class="f"><label>Protocol</label><select><option>All</option><option>ASTM</option><option>HL7</option><option>Flat file</option></select></div>
+        <div class="f"><label>Mapping status</label><select><option>All</option><option>Has unmapped results</option><option>Fully mapped</option></select></div>
+        <label class="chk"><input type="checkbox"> Show deactivated</label>
+      </div>
+      <table>
+        <thead><tr><th>Analyzer type</th><th>Protocol</th><th>Tests mapped</th><th>Results mapped</th><th>Used by</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          <tr class="click" onclick="openMappings('astm')"><td><b>Cepheid GeneXpert — MTB/RIF</b><div class="meta" style="font-size:11px;">Cepheid · GeneXpert · v1.2</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">4 / 4 · 100%</span></td><td><span style="color:var(--amberTx);font-weight:500;">5 / 6 · 83%</span></td><td><span class="tag t-green">3 analyzers</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf" onclick="event.stopPropagation();om(this)">⋮</span><div class="ofmenu"><div class="menu hide"><div onclick="openMappings('astm')">Edit mappings</div><div>Export</div><div>Deactivate</div></div></div></td></tr>
+          <tr class="click" onclick="openMappings('astm')"><td><b>GeneXpert MTB/RIF -1</b><div class="meta" style="font-size:11px;">derived from Cepheid GeneXpert — MTB/RIF</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">4 / 4 · 100%</span></td><td><span style="color:var(--green);font-weight:500;">6 / 6 · 100%</span></td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr class="click" onclick="openMappings('hl7')"><td><b>Mindray BC-5380</b><div class="meta" style="font-size:11px;">Mindray · BC-5380 · v1.2</div></td><td>HL7</td><td><span style="color:var(--amberTx);font-weight:500;">12 / 13 · 92%</span></td><td class="meta">— numeric</td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Sysmex XN Series</b><div class="meta" style="font-size:11px;">Sysmex · XN · v1.2</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">13 / 13 · 100%</span></td><td class="meta">— numeric</td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Tecan Infinite F50 — HIV ELISA</b><div class="meta" style="font-size:11px;">Tecan · F50 · v2.0</div></td><td>Flat file</td><td><span style="color:var(--green);font-weight:500;">1 / 1 · 100%</span></td><td><span style="color:var(--green);font-weight:500;">3 / 3 · 100%</span></td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+        </tbody>
+      </table>
+      <div class="note note-info" style="margin-top:12px;">ℹ️ <b>Shared-with-fork:</b> identical analyzers share one type; the moment one diverges, Save-as-new-type creates a fork (auto-numbered, shown with lineage). No Clone, no hidden overrides. Analyzer types deactivate/reactivate, never delete. Test pickers and search are built for large (~500-test) catalogs.</div>
+    </div></div>
+
+  </div>
+</div>
+
+<script>
+  function view(v){
+    ['list','map','profiles'].forEach(x=>document.getElementById('v-'+x).classList.toggle('hide',x!==v));
+    document.getElementById('nav-list').classList.toggle('active',v==='list'||v==='map');
+    document.getElementById('nav-profiles').classList.toggle('active',v==='profiles');
+    const sc=document.getElementById('scope'); if(sc) sc.classList.add('hide');
+    window.scrollTo(0,0);
+  }
+  function om(el){const m=el.parentNode.querySelector('.menu');document.querySelectorAll('.ofmenu .menu').forEach(x=>{if(x!==m)x.classList.add('hide');});m.classList.toggle('hide');}
+  document.addEventListener('click',e=>{if(!e.target.closest('.ofmenu')&&!e.target.classList.contains('ovf'))document.querySelectorAll('.ofmenu .menu').forEach(x=>x.classList.add('hide'));});
+  function openSetup(){document.getElementById('setup').classList.remove('hide');window.scrollTo(0,0);}
+  function closeSetup(){document.getElementById('setup').classList.add('hide');}
+  function pick(el){document.querySelectorAll('.inst').forEach(i=>{i.classList.remove('sel');i.querySelector('.chev').textContent='›';});el.classList.add('sel');el.querySelector('.chev').textContent='●';}
+  function doneSec(n){const s=document.getElementById('sec'+n);s.classList.remove('open');s.classList.add('done','collapsed');
+    if(n===1){const nm=document.getElementById('anName').value;const su=document.getElementById('sum1');su.textContent='Cepheid GeneXpert · '+nm+' · Molecular Biology';su.classList.remove('hide');document.getElementById('q1').classList.add('hide');document.getElementById('edit1').classList.remove('hide');}
+    if(n===2){const su=document.getElementById('sum2');su.textContent='4 tests verified · 3 QC codes recognized';su.classList.remove('hide');document.getElementById('edit2').classList.remove('hide');}
+    const nx=document.getElementById('sec'+(n+1));if(nx){nx.classList.remove('collapsed');nx.classList.add('open');nx.scrollIntoView({behavior:'smooth',block:'center'});}}
+  function openSec(n){[1,2,3].forEach(i=>{const s=document.getElementById('sec'+i);if(i===n){s.classList.remove('collapsed');s.classList.add('open');}else if(s.classList.contains('open')){s.classList.add('collapsed');s.classList.remove('open');}});document.getElementById('sec'+n).scrollIntoView({behavior:'smooth',block:'center'});}
+  function resolveEx(){document.getElementById('exrow').classList.add('hide');const row=document.querySelector('#body2 .exp');row.classList.remove('exp');row.innerHTML='<td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">COVID19</td><td>SARS-CoV-2 RNA</td><td class="mono">94500-6</td><td><span class="tag t-green">matched · active</span></td><td></td>';document.getElementById('confirmHint').textContent='All 4 tests matched — ready to confirm';}
+  function finishSetup(){closeSetup();view('list');}
+  function openMappings(proto){view('map');const isHL7=proto==='hl7';document.getElementById('mapProto').textContent=isHL7?'HL7':'ASTM';document.getElementById('fref').textContent=isHL7?'OBX-3':'R.3';if(isHL7){document.getElementById('mapAn').textContent='Mindray BC-5380';document.getElementById('mapProf').textContent='Mindray BC-5380';document.getElementById('mapUsed').textContent='1 analyzer';}else{document.getElementById('mapAn').textContent='GeneXpert MTB/RIF #1';document.getElementById('mapProf').textContent='Cepheid GeneXpert — MTB/RIF';document.getElementById('mapUsed').textContent='3 analyzers';}}
+  function showScope(){document.getElementById('scope').classList.remove('hide');document.getElementById('scope').scrollIntoView({behavior:'smooth'});}
+  function selOpt(el,which){document.querySelectorAll('.opt').forEach(o=>{o.classList.remove('sel');o.querySelector('input').checked=false;});el.classList.add('sel');el.querySelector('input').checked=true;}
+  function toggleNew(){document.getElementById('newprof').classList.toggle('hide');}
+  function simulateResult(){
+    document.getElementById('recvPanel').classList.remove('hide');
+    document.getElementById('lv-mtb').innerHTML='<span class="tag t-green">✓ seen · verified</span>';
+    document.getElementById('lv-rif').innerHTML='<span class="tag t-amber">⚠ new result</span>';
+    // HIV-VL was not in this transmission — stays "not seen yet"
+    document.getElementById('recvHint').textContent='Reconciled 3 results: 1 verified, 2 need mapping (1 was not transmitted)';
+    document.getElementById('recvPanel').scrollIntoView({behavior:'smooth',block:'center'});
+  }
+  function applyRecv(which){
+    const row=document.getElementById('recv-'+which);
+    if(which==='rif'){row.style.background='';row.cells[2].innerHTML='<span class="tag t-green">mapped</span>';row.cells[3].innerHTML='<span class="meta">→ Indeterminate · verified ✓</span>';document.getElementById('lv-rif').innerHTML='<span class="tag t-green">✓ verified</span>';}
+    if(which==='xdr'){row.style.background='';row.cells[2].innerHTML='<span class="tag t-green">mapped</span>';row.cells[3].innerHTML='<span class="meta">→ MTB/XDR Resistance · added to profile ✓</span>';}
+  }
+</script>
+</body>
+</html>

--- a/designs/analyzer-integration/analyzer-profile-mapping.md
+++ b/designs/analyzer-integration/analyzer-profile-mapping.md
@@ -1,0 +1,263 @@
+# Analyzer Types & Mapping — Functional Requirements Specification
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft for review |
+| **Module** | Admin → Analyzers (Analyzer Profiles, Analyzer setup, Field Mappings) |
+| **Author** | Casey Iiams-Hauser |
+| **Date** | 2026-06-17 |
+| **Supersedes** | The deployed "Analyzer Types" page (the first cut of this work) and the unbuilt portions of the Generic ASTM/HL7/Flat-file module: profile management and GUI mapping of tests and results |
+| **Front end** | Carbon React |
+| **Companion artifacts** | `analyzer-profile-mapping-prototype.html` (functional prototype), `analyzer-profile-mapping-gap-analysis.md` |
+
+> This FRS is version-agnostic — it describes the whole feature. Version/sprint boundaries are decided later in `/breakdown`.
+>
+> **Terminology:** the user-facing name is **Analyzer Type** — the reusable, forkable configuration for a kind of analyzer (test codes, result mappings, QC codes, formatting). This document uses **"profile"** as a synonym for that same object/entity; all UI labels read "Analyzer Type." (It is distinct from the dev-only **Plugin Type**, which stays in the Advanced/implementer area.)
+
+---
+
+## Lab Context
+
+### Current State
+
+A clinical lab runs benchtop and molecular instruments — a Cepheid GeneXpert for TB and viral load, a Mindray or Sysmex hematology analyzer, a Tecan ELISA reader. Each instrument can send its results to OpenELIS electronically instead of a tech reading a printout and typing numbers into the computer by hand. For that to work, OpenELIS has to know two things about each instrument: how it talks (the network connection and message format) and what its codes mean — when the GeneXpert sends a result labeled `RIF` with the value `DETECTED`, OpenELIS has to know that means the "Rifampin Resistance" test and the result "Resistant" in the lab's own catalog.
+
+Today OpenELIS ships a generic plugin that can talk to ASTM and HL7 (the two common standards instruments use to transmit results) and flat-file instruments, and an admin can add an analyzer and connect it. But the part that translates the instrument's codes into the lab's tests and results was never finished in the interface. The current "Analyzer Types" admin page exposes developer-level fields — a Java plugin class name, a regular expression — that no lab person can fill in, and the mapping of an instrument's result values to the lab's result options can't be done through the screen at all. Labs that need it today rely on a developer to hand-edit configuration.
+
+### Pain
+
+Because the mapping interface is unfinished, connecting an analyzer is a developer task, not a lab task. A lab that gets a new GeneXpert cartridge — which makes the instrument start reporting a new test code — has no way to map that new code themselves; the result arrives and there's nowhere for it to go. Qualitative instruments are the worst case: a GeneXpert reports `DETECTED` / `NOT DETECTED` / `INDETERMINATE`, and without a way to say which of the lab's result options each of those means, the results can't be recorded correctly. When a shipped configuration doesn't quite match a particular lab's catalog, the lab has no safe way to fix it — and the screen that should help is full of fields meant for programmers. The net effect is that automated result import, the whole point of connecting an instrument, stalls on configuration that the lab can't do for itself.
+
+### What Changes
+
+A lab administrator sets up an analyzer by answering one question — *which instrument is this?* — and picking it from a searchable list. OpenELIS loads a ready-made **profile** for that instrument (its test codes, the results it reports, its quality-control codes, how it formats values) and shows the administrator a short list to **verify**: "this analyzer sends MTB-RIF, which matches your MTB Detection test by its LOINC code (the international standard code that identifies a lab test) — confirm." The administrator confirms the matches, enters the network address, tests the connection, and the analyzer is live. They never see a Java class or a regular expression. When something doesn't line up — a test the instrument reports isn't in the lab's catalog, or a result value isn't recognized — only that one item opens an editor to fix, and the administrator either points it at an existing catalog test (searchable, because catalogs run to hundreds of tests) or is sent to add the test in the Test Catalog first. If the instrument later sends something new, like a new cartridge's test, OpenELIS doesn't lose the result — it parks it and raises an alert so a person maps it. The same screens work whether the instrument speaks ASTM, HL7, or sends a file.
+
+---
+
+## Overview
+
+This feature completes the Generic Analyzer module by adding (1) **analyzer profiles** — reusable, shareable configurations for a kind of instrument — and (2) a **GUI for mapping** an instrument's tests, result values, and QC codes to the lab's catalog. It reframes the deployed, developer-facing "Analyzer Types" page into a lab-facing **Analyzer Profiles** page, and replaces the bare "Add Analyzer" form with a **guided, instrument-first setup** whose normal path is *verify*, not hand-editing.
+
+The governing principle: **verifying is the norm, editing is the exception.** A clean, profile-matched analyzer is set up by confirming a short list and entering a network address; the full mapping editor only appears for items that don't line up or when an administrator deliberately changes a profile.
+
+### Navigation & URL
+
+- **SideNav:** `Analyzers → Analyzer Types` (a sibling of Analyzers List, Error Dashboard, Quality Control). This is the **next version of the existing `Analyzers → Analyzer Types` page**, which it replaces (today that page is a developer-facing plugin registry; it becomes the lab-facing analyzer-type/profile manager).
+- **Breadcrumb:** `Home / Analyzers / Analyzer Types`; the mapping editor is `Home / Analyzers / Field Mappings / [Analyzer or Type name]`.
+- **Routes:** analyzer-types list `/analyzers/types` (existing route, repurposed); mapping editor `/analyzers/{id}/mappings` (existing) and `/analyzers/types/{typeId}` for type-context editing. Add-analyzer setup is **inline within `/analyzers`** (expands in the list; not a modal, not a separate page).
+
+### Permissions & Audit
+
+- **Role attachment:** accessible via the existing **Admin** role bundle (the same that governs Analyzers List / Analyzer Types today). No new per-action permission keys. Verification/confirmation, profile edits, deactivation, and connection changes are admin actions; do not invent a granular matrix.
+- **Audit events** (`audit_trail`): `ANALYZER_PROFILE_CREATED`, `ANALYZER_PROFILE_UPDATED`, `ANALYZER_PROFILE_DEACTIVATED`/`_REACTIVATED`, `ANALYZER_MAPPING_VERIFIED` (records the human sign-off on setup, with analyzer + profile id), `ANALYZER_TESTMAP_CHANGED`, `ANALYZER_RESULTMAP_CHANGED`, `ANALYZER_CONNECTION_CHANGED`. Do not audit reads.
+- **Envers:** the analyzer profile entity and analyzer↔profile association are configuration data → `@Audited`.
+
+### Scope boundaries (out of scope)
+
+- **Instrument auto-recognition** from an incoming message (cut — unreliable signal; an admin who can't identify their instrument shouldn't be setting it up).
+- **Creating a new test inline** during mapping (multi-step; done in Test Catalog, then mapped).
+- **Importing profiles from a file** and any **community profile sharing/marketplace** (future). Profile **Export** is download-only (for backup or sending to support); **re-importing** an exported profile is part of the deferred sharing work.
+- **LLM-assisted authoring** (esp. flat-file CSV/XML parsing and value inference) — parked as a Catalyst candidate.
+- Deep flat-file column/layout configuration beyond what a profile already carries (candidate for the Catalyst path).
+
+---
+
+## User Stories
+
+1. *As a lab administrator,* I want to set up an analyzer by choosing my instrument and confirming a short list, so that I can connect it without developer help or technical jargon.
+2. *As a lab administrator,* I want OpenELIS to tell me which of the instrument's tests already exist and are active in my catalog (matched by LOINC), so that I can trust what will receive results and fix what won't.
+3. *As a lab administrator,* I want to confirm — not hand-build — how the instrument's result values map to my result options, so that qualitative results record correctly with a human sign-off.
+4. *As a lab administrator,* when an instrument's test or value isn't recognized, I want to map it to an existing catalog test by searching, or be told to add it in Test Catalog first, so that I'm never stuck and never silently dropping results.
+5. *As a lab administrator,* I want a change I make for one analyzer to default to a new profile (not silently alter every other analyzer), so that I can't break the others by accident.
+6. *As a lab administrator,* I want unmapped codes or results from a live analyzer to raise an alert and flag the analyzer, so that nothing piles up unnoticed.
+7. *As a lab administrator,* I want one place that lists the reusable profiles with how complete their mappings are, so that I can see and manage what's configured.
+
+---
+
+## Functional Requirements
+
+### A. Profiles
+
+**FR-A1 — Profile as the unit of configuration.** A *profile* is a reusable configuration for a kind of analyzer. It carries: test-code mappings (analyzer code → catalog test, with the test's LOINC), result mappings (analyzer value → the test's result option), QC codes (control identifiers and how they're recognized), result formatting (date format, decimal separator, units), and the instrument's protocol/connection capability (including whether it supports two-way). It does **not** carry analyzer-specific facts: name, lab unit assignment, network address, or connection direction in use.
+
+**FR-A2 — Shared, with fork.** An analyzer references exactly one profile. Multiple analyzers may share a profile. There is no per-analyzer override layer and no "clone": when an analyzer must differ, the change is saved as a **new profile** (a fork).
+
+**FR-A3 — Deactivate, never delete.** Profiles (and analyzers) are deactivated/reactivated, never hard-deleted. Lists hide deactivated profiles by default with a "Show deactivated" toggle. (See constitution: no hard delete in a LIMS.)
+
+**FR-A4 — Shipped profiles.** OpenELIS ships a base catalog of profiles for common instruments, with their tests pre-mapped by LOINC. Deployments/distros may ship additional profiles bound to their own catalogs. Profiles created by a site are also stored. The Analyzer Profiles list can filter by **Created** (site-created vs. shipped) but does not otherwise organize by source.
+
+**FR-A5 — Trust metadata is internal.** Authoring/validation metadata (confidence, verification-required, validation status) is internal team tracking and is **not** surfaced in the admin UI nor used to gate setup.
+
+### B. Guided analyzer setup (inline)
+
+**FR-B1 — Inline, in the list.** "Add Analyzer" expands a guided setup **inline within the Analyzers List** (the list stays visible for context); it is not a modal. Setup is presented as stacked sections that reveal in order: **Instrument → Verify → Connect**. Completed sections collapse to a one-line summary with Edit.
+
+**FR-B2 — Instrument-first.** Section 1 asks the administrator to pick the instrument from a **searchable** list (manufacturer/model). Selecting it loads that instrument's profile. The administrator names the analyzer and assigns one or more **lab units**. No protocol, plugin, or pattern fields appear here.
+
+**FR-B3 — "Not listed" path.** If the instrument isn't listed, the administrator defines a **new profile**: profile name, protocol (ASTM / HL7 / flat file), and connection type. (This is the only place these fields appear in the lab flow; they otherwise live with the profile.)
+
+**FR-B4 — Verify, don't build (the sign-off).** Section 2 shows the profile's tests as a list to **verify**: each row shows the analyzer code, the matched catalog test, the matching LOINC, and a status. Verification is a **mandatory human confirmation** (per-row, or confirm-all) and is recorded in the audit trail. Nothing maps itself silently. This is by design a patient-safety gate; the fragility is intentional.
+
+**FR-B5 — QC codes are verified too.** Section 2 also lists the instrument's **QC codes** (control identifiers, e.g., specimen-ID prefixes or a control flag field) for confirmation, so control runs are recognized and don't post as patient results.
+
+**FR-B6 — Connect.** Section 3 collects the network address and the **data flow** (see FR-F). A connection test reports the result in plain language.
+
+**FR-B7 — Push-a-result option.** The verify step offers "send a result from the analyzer now" — capturing a real message so the administrator can verify against the codes/values the instrument *actually* sends (proactive learn-from-traffic; reflects that, e.g., GeneXpert sites enable/disable assays so the live code set may differ from the profile).
+
+**FR-B8 — Reconcile the transmission against the mappings.** When a result is received during setup, the screen reconciles each transmitted item against the current mappings and updates live:
+
+- **Verified:** a transmitted test code / result value that matches an existing mapping is marked **verified against the live message** (a per-test "checked vs live" indicator flips from "not seen yet" to "verified"). This is stronger than a profile match — it confirms the instrument really sends what the profile assumed.
+- **New result value:** a value arriving for a mapped test that the result-map doesn't cover surfaces inline, pre-populated with the transmitted value, with the test's result options offered so the administrator maps it on the spot.
+- **New test code:** a code arriving with no test mapping surfaces inline with a catalog **search** to map it (or send to Test Catalog per FR-C2).
+- **Not transmitted:** a mapped test that did *not* appear in this message stays "not seen yet" (not an error — the assay may simply not have run).
+- **Nothing matches / blank profile:** when the profile has no mappings yet (the "not listed → new profile" path), the transmission **populates** the rows from what was received and the administrator maps each — i.e., a new profile is built directly from a real message rather than from a blank form.
+
+Mappings resolved this way update the profile immediately (subject to the save-scope rule, FR-H). Reconciliation never discards a transmitted item.
+
+### C. Catalog readiness check (LOINC matching)
+
+**FR-C1 — Deterministic 1:1 LOINC match.** A profile test is matched to a catalog test when the profile's LOINC **equals** a LOINC on an **active** catalog test — a deterministic 1:1 key, not fuzzy auto-matching. The verify step shows, per test: matched · active / not matched.
+
+**FR-C2 — Resolve a non-match (inline, for the exception only).** When a profile test has no LOINC match, the row offers a **Resolve** action with, in priority order: (a) **Map to an existing test** via a **search** of the catalog (by name, code, or LOINC) — the primary path; (b) **Add it in Test Catalog first**, then return and map (a link out; inline test creation is out of scope because adding a test is multi-step); (c) **Don't receive this test** from this analyzer. Resolving updates the readiness state.
+
+**FR-C3 — Missing tests don't block the rest.** A test absent from the catalog is flagged and does not block verifying/activating the others. Results for an unmapped test follow FR-G (never dropped).
+
+### D. Test mapping (editor)
+
+**FR-D1 — Editable rows.** In the mapping editor, every test-code row is editable — the administrator can change the analyzer code or **re-point the linked test**, even on rows already matched, and can remove a row or add one.
+
+**FR-D2 — Search-based test picker.** Linked-test selection is a **search** over the catalog (assume ~500 tests), implemented as a Carbon `ComboBox`/typeahead (match on name, code, or LOINC). It is never a long static dropdown.
+
+**FR-D3 — Protocol-agnostic surface.** The editor is identical for ASTM, HL7, and flat-file analyzers; only the field-reference label differs (e.g., `R.3` for ASTM, `OBX-3` for HL7). 
+
+### E. Result mapping (editor)
+
+**FR-E1 — Bound to the test's own results.** For a qualitative test, the result-mapping targets are exactly the **result options defined on the matched catalog test** (its dictionary/select-list results). The administrator can only map to results that test can store.
+
+**FR-E2 — Guided empty state.** If the matched test has no result options defined, the editor explains this and links to Test Catalog to define them first, rather than allowing a map against nothing.
+
+**FR-E3 — Unmatched-value behavior.** Each qualitative mapping defines what happens to a value with no mapping: flag for review (default — never dropped), pass through raw, or use a default. (See FR-G for the active-analyzer alerting.)
+
+**FR-E4 — Completeness.** Mapping completeness is shown as **X / Y · %** for both tests mapped and results mapped, on the profile and in the editor.
+
+### F. Connection & data flow
+
+**FR-F1 — Per-analyzer connection.** Network address (IP/port or watched folder) and **data flow** are analyzer-level, not part of the shared profile.
+
+**FR-F2 — Direction is intent + probe, not a guarantee.** Default is **Results only (one-way)**. **Two-way** (OpenELIS sends orders/queries back) is offered only when the profile declares the instrument supports it. The connection test attempts the round trip; on timeout it reports that two-way isn't reachable (e.g., analyzer on a private network) and the analyzer runs one-way. Setup is never blocked by a failed two-way probe. The verified direction is shown on the analyzer.
+
+### G. Learn-from-traffic (never drop, make it loud)
+
+**FR-G1 — Accept and flag, don't block.** OpenELIS cannot control what an instrument sends, so inbound results are **never blocked**. An unmapped test code or unmapped result value is accepted and held, not dropped.
+
+**FR-G2 — Active analyzers raise alerts.** For an **active** analyzer, an unmapped code/result posts to the **Alerts** page for acknowledgment and handling (acknowledged by Admin; Lab Manager optional), and raises a visible flag on the **Analyzers List** row and on the **profile**. (Aligns with the global critical-acknowledgment direction.)
+
+**FR-G3 — Resolve updates the profile.** Resolving a pending item from the alert/queue maps it; the resolution updates the analyzer's profile so the same code/value maps automatically next time. This is the same mechanism that handles a new cartridge's new test code or a newly-seen result value. HL7 pending items show the display name (OBX-3.2) and value type (OBX-2); ASTM shows the bare code.
+
+### H. Edit scope (shared-with-fork)
+
+**FR-H1 — Save choices.** Saving changes made from an analyzer's mapping editor presents two choices: **Save as a new profile** (default) or **Update this profile (affects N analyzers)**.
+
+**FR-H2 — Safe default.** When the profile is used by more than one analyzer, **Save as a new profile** is the default and "Update this profile" carries an explicit warning naming the affected analyzers. When the profile is used by only the current analyzer, "Update this profile" is harmless and may be the default.
+
+**FR-H3 — Unique names by default.** A new (forked) profile's suggested name is the source profile's name with an **auto-incremented suffix** (`-1`, `-2`, …) chosen as the next value that is not already in use, guaranteeing uniqueness; the administrator may rename. The fork records its **lineage** ("derived from …").
+
+### I. Analyzer Types page
+
+**FR-I1 — List.** Columns: Profile (name + manufacturer/model/version), Protocol, **Tests mapped (X/Y · %)**, **Results mapped (X/Y · %)**, Used by (count), Status. Row actions: Edit mappings, Export (download a copy for backup/support — re-import is future), Deactivate/Reactivate. (No Clone, no Delete.)
+
+**FR-I2 — Search & filters.** A search over name/manufacturer/model (built for large libraries). Filters: **Created** (site-created / shipped), **Protocol**, **Mapping status** (has unmapped results / fully mapped), and **Show deactivated** (off by default).
+
+**FR-I3 — Intro/explainer.** The page opens with a short plain-language explanation of what a profile is and how to use it (share across identical analyzers; fork when one differs; deactivate not delete).
+
+**FR-I4 — Editing a profile == the mapping editor.** Editing a profile opens the same editor reached from an analyzer's Field Mappings — a profile *is* its mappings, not just a list row.
+
+---
+
+## Data Model & Dependencies
+
+Grounded in existing OpenELIS entities; new data is flagged as a named dependency, not invented domain concepts.
+
+| Concept | Source / status |
+|---------|-----------------|
+| Catalog test, result type, result options | **Existing** — Test Catalog; qualitative results are dictionary-backed result options. Result mapping targets these. |
+| LOINC on a test | **Existing** field; the deterministic match key. OpenELIS ships default tests pre-mapped with LOINC as part of this work. |
+| Lab unit (test unit) | **Existing** — used for analyzer assignment and RBAC context. |
+| Analyzer (instance) | **Existing** — gains a profile reference, lab-unit association, and verified data-flow direction. |
+| Analyzer plugin / type | **Existing** ("Analyzer Types" registry) — the generic plugin per protocol; profiles ride on the generic plugin. Lab-facing surface replaced by Analyzer Profiles. |
+| **Analyzer profile** | **NEW** — reusable config entity (FR-A1) with lineage to a parent profile for forks; `@Audited`. |
+| Pending/unmapped code & result queue | **Dependency** — learn-from-traffic store; surfaces to Alerts. Partly exists as "pending codes" on the deployed Field Mappings page; extend to cover unmapped result values. |
+| Alerts | **Existing** Alerts page — receives unmapped-code/result events for active analyzers (FR-G2). |
+| QC identification rules / control codes | **Existing** in profiles/QC config — surfaced for verification (FR-B5); detailed QC limits live in Quality Control. |
+
+---
+
+## Localization
+
+All UI strings use localization keys (`label.analyzer.profile.*`, `label.analyzer.setup.*`, `label.analyzer.mapping.*`, `label.analyzer.verify.*`). Representative keys:
+
+| Key | English |
+|-----|---------|
+| `label.analyzer.profiles.title` | Analyzer Profiles |
+| `label.analyzer.profiles.intro` | A profile is the reusable setup for a kind of analyzer… |
+| `label.analyzer.setup.identify` | Instrument |
+| `label.analyzer.setup.verify` | Verify the mappings |
+| `label.analyzer.setup.connect` | Connect it |
+| `label.analyzer.verify.matchedActive` | matched · active |
+| `label.analyzer.verify.needsAttention` | needs attention |
+| `label.analyzer.verify.confirm` | Confirm & continue |
+| `label.analyzer.catalog.notInCatalog` | Not in your catalog |
+| `label.analyzer.catalog.mapExisting` | Map to an existing test in your catalog |
+| `label.analyzer.catalog.addInCatalog` | Add it in Test Catalog first, then return and map |
+| `label.analyzer.qc.recognized` | recognized |
+| `label.analyzer.connect.dataflow` | Data flow |
+| `label.analyzer.connect.oneway` | Results only (one-way) |
+| `label.analyzer.connect.twoway` | Two-way (send orders/queries) |
+| `label.analyzer.connect.twowayUnreachable` | Two-way not reachable on this network; running results-only |
+| `label.analyzer.scope.newProfile` | Save as a new profile |
+| `label.analyzer.scope.updateProfile` | Update this profile (affects {count} analyzers) |
+| `label.analyzer.mapping.testsMapped` | Tests mapped |
+| `label.analyzer.mapping.resultsMapped` | Results mapped |
+| `label.analyzer.unmapped.alert` | Analyzer is sending a result that isn't mapped |
+
+---
+
+## Acceptance Criteria
+
+- [ ] **AC-1** Add Analyzer expands inline in the Analyzers List (not a modal); the list remains visible.
+- [ ] **AC-2** Setup proceeds Instrument → Verify → Connect as stacked, progressively revealed sections; completed sections collapse to a summary with Edit.
+- [ ] **AC-3** The instrument picker is search-based; selecting an instrument loads its profile.
+- [ ] **AC-4** "My instrument isn't listed" collects profile name, protocol, and connection type to define a new profile.
+- [ ] **AC-5** The verify step shows each profile test with analyzer code, matched catalog test, LOINC, and status; matching is deterministic LOINC==LOINC against active tests.
+- [ ] **AC-6** Verification requires explicit human confirmation and writes `ANALYZER_MAPPING_VERIFIED` to the audit trail.
+- [ ] **AC-7** QC codes appear in the verify step and require confirmation.
+- [ ] **AC-8** A non-matching test offers Resolve → map-to-existing (search), add-in-Test-Catalog (link out), or don't-receive; inline test creation is not offered.
+- [ ] **AC-9** A missing test does not block verifying/activating the others.
+- [ ] **AC-10** Connect defaults to one-way; two-way is offered only when the profile supports it, is verified by a probe, and degrades to one-way on timeout without blocking setup.
+- [ ] **AC-11** In the editor, every test-code row is editable (re-point linked test via search, edit code, remove, add).
+- [ ] **AC-12** Result mapping targets are exactly the matched test's result options; an empty option set shows the Test-Catalog guidance.
+- [ ] **AC-13** Saving from an analyzer defaults to Save-as-new-profile when used-by > 1; Update-this-profile warns and names affected analyzers.
+- [ ] **AC-14** A forked profile's suggested name uses the next free `-N` suffix and is guaranteed unique; lineage is recorded.
+- [ ] **AC-15** Unmapped codes/results from an active analyzer post to Alerts and flag the row and the profile; results are never dropped or blocked.
+- [ ] **AC-16** The Analyzer Profiles list shows Tests mapped and Results mapped as X/Y · %, supports search and the four filters, and hides deactivated by default.
+- [ ] **AC-17** Profiles are deactivated/reactivated; no delete action exists.
+- [ ] **AC-18** The mapping editor is identical across ASTM/HL7/flat file except the field-reference label.
+- [ ] **AC-19** No developer-only fields (plugin class, identifier-pattern regex, raw config JSON) appear in the lab-facing flow; any such reference is in a clearly secondary "Advanced — for IT/implementers" area.
+- [ ] **AC-20** All UI strings use localization keys.
+- [ ] **AC-21** "Send a result from the analyzer" reconciles the transmission live: matched items are marked verified-against-live; a new result value surfaces pre-populated with the test's options to map; a new test code surfaces with a catalog search; a mapped test not in the message stays "not seen yet."
+- [ ] **AC-22** Reconciliation never discards a transmitted item; resolving one updates the profile (per FR-H scope).
+- [ ] **AC-23** On the "not listed → new profile" path, a received message populates the (empty) mapping rows so a new profile can be built from real data; the "My instrument isn't listed" control reveals the new-profile fields (name, protocol, connection type).
+
+---
+
+## Related Documents
+
+| Document | Relationship |
+|----------|-------------|
+| `analyzer-profile-mapping-gap-analysis.md` | Why this work exists; the gap between shipped profiles and the needed GUI |
+| `analyzer-profile-mapping-prototype.html` | Functional prototype embodying this FRS |
+| ASTM / HL7 / Flat-file mapping addenda | Prior protocol-level mapping specs this consolidates and supersedes for the GUI surface |
+| Deployed "Analyzer Types" page | The first cut of this work; superseded by Analyzer Profiles |
+| Test Catalog FRS | Defines the tests, result types, and result options that mappings target |
+| Alerts | Receives unmapped-code/result events for active analyzers |
+| Ideas backlog — Catalyst-assisted analyzer mapping | The LLM-assisted future direction (flat-file inference), out of scope here |

--- a/mockup-viewer/public/designs/analyzer-integration/analyzer-profile-mapping.html
+++ b/mockup-viewer/public/designs/analyzer-integration/analyzer-profile-mapping.html
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Analyzer Profiles & Mapping — Prototype — OpenELIS</title>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root{
+    --navy:#152935; --navy2:#1c3142; --navHover:#2a4256;
+    --blue:#0f62fe; --blueHover:#0043ce; --blueBg:#edf5ff;
+    --g10:#f9f9f9; --g50:#f4f4f4; --g100:#e0e0e0; --g200:#c6c6c6; --g300:#a8a8a8; --g500:#8d8d8d;
+    --g600:#6f6f6f; --g700:#525252; --g800:#393939; --g900:#161616;
+    --white:#fff; --red:#da1e28; --redBg:#fff1f1; --green:#24a148; --greenBg:#defbe6;
+    --teal:#007d79; --tealBg:#d9fbfb; --amber:#f1c21b; --amberBg:#fcf4d6; --amberTx:#8a6a00; --purple:#8a3ffc; --purpleBg:#e8daff;
+    --font:'IBM Plex Sans',-apple-system,BlinkMacSystemFont,sans-serif; --mono:'IBM Plex Mono','Menlo',monospace;
+  }
+  *{box-sizing:border-box;}
+  body{margin:0;font-family:var(--font);color:var(--g900);background:var(--g50);font-size:14px;}
+  .banner{background:var(--blue);color:#fff;padding:6px 16px;font-size:12px;font-family:var(--mono);}
+  .hdr{background:var(--navy);color:#fff;height:48px;display:flex;align-items:center;padding:0 16px;gap:14px;}
+  .hdr .brand{font-weight:600;font-size:15px;} .hdr .ver{font-size:11px;color:#8fa3b0;} .hdr .r{margin-left:auto;display:flex;gap:18px;color:#c9d4df;}
+  .shell{display:flex;min-height:calc(100vh - 48px - 27px);}
+  .side{width:228px;background:var(--navy);color:#c9d4df;flex-shrink:0;padding:6px 0;font-size:13.5px;}
+  .side .item{padding:10px 16px;cursor:pointer;color:#dde4ea;} .side .item:hover{background:var(--navHover);}
+  .side .item.active{background:var(--navy2);color:#fff;}
+  .side .sub{padding:8px 16px 8px 32px;color:#aebcc7;font-size:12.5px;cursor:pointer;} .side .sub:hover{background:var(--navHover);color:#fff;}
+  .side .sub.active{color:#fff;background:var(--blue);font-weight:500;}
+  .main{flex:1;min-width:0;}
+  .page{padding:22px 30px;max-width:1100px;}
+  .crumbtitle{font-size:23px;font-weight:400;margin:0 0 2px;} .crumbtitle b{font-weight:600;} .crumbtitle .sep{color:var(--g300);}
+  .crumbtitle a{color:var(--blue);cursor:pointer;}
+  .sub1{color:var(--g600);font-size:13px;margin-bottom:16px;}
+  .cards{display:flex;border:1px solid var(--g100);background:#fff;margin-bottom:16px;}
+  .cards .c{flex:1;padding:13px 18px;border-right:1px solid var(--g100);} .cards .c:last-child{border-right:none;}
+  .cards .l{font-size:11px;color:var(--g600);text-transform:uppercase;} .cards .n{font-size:25px;font-weight:300;margin-top:2px;}
+  .searchbar{display:flex;align-items:center;gap:8px;background:#fff;border:1px solid var(--g100);border-bottom:1px solid var(--g300);padding:10px 14px;}
+  .searchbar input{border:none;outline:none;font-size:14px;flex:1;background:transparent;font-family:var(--font);}
+  .filters{display:flex;gap:16px;background:#fff;border:1px solid var(--g100);border-top:none;padding:11px 14px;align-items:flex-end;flex-wrap:wrap;}
+  .filters .f label{display:block;font-size:11px;color:var(--g600);margin-bottom:4px;} .filters select{padding:6px 10px;border:1px solid var(--g200);font-size:12.5px;background:#f9f9f9;font-family:var(--font);}
+  .chk{display:flex;align-items:center;gap:6px;font-size:12.5px;color:var(--g700);cursor:pointer;padding-bottom:6px;}
+  table{width:100%;border-collapse:collapse;background:#fff;} th{text-align:left;font-size:11px;text-transform:uppercase;color:var(--g600);padding:10px 14px;border-bottom:1px solid var(--g200);background:var(--g50);font-weight:600;white-space:nowrap;} td{padding:12px 14px;border-bottom:1px solid var(--g100);}
+  tr.click{cursor:pointer;} tr.click:hover td{background:#f7f9fc;}
+  .meta{font-size:12px;color:var(--g600);}
+  .mono{font-family:var(--mono);}
+  .tag{display:inline-block;padding:3px 10px;border-radius:13px;font-size:11px;font-weight:500;}
+  .t-green{background:var(--greenBg);color:#0e6027;} .t-amber{background:var(--amberBg);color:#8a6a00;} .t-blue{background:var(--blueBg);color:#0043ce;} .t-teal{background:var(--tealBg);color:#005d5d;} .t-gray{background:var(--g100);color:#525252;} .t-red{background:var(--redBg);color:#a2191f;}
+  .btn{font-family:var(--font);font-size:14px;border:none;padding:10px 17px;cursor:pointer;display:inline-flex;align-items:center;gap:7px;} .btn-sm{padding:6px 12px;font-size:12.5px;}
+  .btn-pri{background:var(--blue);color:#fff;} .btn-pri:hover{background:var(--blueHover);}
+  .btn-sec{background:#fff;border:1px solid var(--blue);color:var(--blue);} .btn-sec:hover{background:var(--blueBg);}
+  .btn-ghost{background:none;color:var(--g700);} .btn-ghost:hover{background:var(--g50);}
+  .note{padding:11px 14px;font-size:12.5px;display:flex;gap:8px;align-items:flex-start;line-height:1.55;} .note-info{background:var(--blueBg);border-left:3px solid var(--blue);color:#0b3a8f;} .note-ok{background:var(--greenBg);border-left:3px solid var(--green);color:#0e6027;} .note-warn{background:var(--amberBg);border-left:3px solid var(--amber);color:#6b5200;} .note-err{background:var(--redBg);border-left:3px solid var(--red);color:#a2191f;}
+  .field{margin-bottom:14px;} .field label{display:block;font-size:12px;color:var(--g600);margin-bottom:5px;} .field .help{font-size:11px;color:var(--g500);margin-top:4px;}
+  .field input,.field select{width:100%;padding:10px 12px;border:1px solid var(--g100);border-bottom:1px solid var(--g500);font-family:var(--font);font-size:13.5px;background:var(--g10);}
+  .row2{display:flex;gap:16px;} .row2>*{flex:1;}
+  .pillrow{display:flex;flex-wrap:wrap;gap:6px;align-items:center;border:1px solid var(--g100);border-bottom:1px solid var(--g500);background:var(--g10);padding:8px;min-height:42px;} .pillrow input{border:none;background:transparent;flex:1;min-width:80px;outline:none;font-family:var(--font);font-size:13px;}
+  .ovf{cursor:pointer;color:var(--g700);font-weight:700;letter-spacing:1px;padding:0 8px;} .ofmenu{position:relative;display:inline-block;} .ofmenu .menu{position:absolute;right:0;top:22px;background:#fff;border:1px solid var(--g200);box-shadow:0 4px 12px rgba(0,0,0,.12);z-index:20;min-width:150px;} .ofmenu .menu div{padding:9px 13px;font-size:13px;cursor:pointer;white-space:nowrap;} .ofmenu .menu div:hover{background:var(--g50);}
+  .hide{display:none;}
+  /* setup */
+  .setup{border:2px solid var(--blue);background:#fff;margin-bottom:18px;} .setup-h{background:var(--blueBg);padding:13px 18px;display:flex;align-items:center;gap:10px;font-weight:600;} .setup-h .x{margin-left:auto;cursor:pointer;color:var(--g600);font-size:16px;}
+  .sec{border-bottom:1px solid var(--g100);} .sec:last-child{border-bottom:none;}
+  .sec-h{padding:13px 18px;display:flex;align-items:center;gap:12px;} .sec-h .num{width:26px;height:26px;border-radius:50%;background:#fff;border:1px solid var(--g300);color:var(--g600);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:600;flex-shrink:0;}
+  .sec.done .num{background:var(--green);border-color:var(--green);color:#fff;} .sec.open .num{background:var(--blue);border-color:var(--blue);color:#fff;}
+  .sec-h .t{font-weight:600;} .sec-h .t .q{font-weight:400;color:var(--g600);font-size:12.5px;} .sec-h .summary{font-size:12.5px;color:var(--g600);} .sec-h .edit{margin-left:auto;color:var(--blue);font-size:12.5px;cursor:pointer;}
+  .sec-b{padding:2px 18px 20px 56px;} .sec.collapsed .sec-b{display:none;}
+  .inst{display:flex;align-items:center;gap:13px;padding:11px 14px;border:1px solid var(--g100);background:#fff;cursor:pointer;margin-bottom:-1px;} .inst:hover{background:var(--g10);} .inst.sel{border:2px solid var(--blue);background:var(--blueBg);}
+  .inst .ic{width:36px;height:36px;border-radius:7px;background:var(--g50);display:flex;align-items:center;justify-content:center;font-weight:600;color:var(--g700);font-size:12px;flex-shrink:0;} .inst.sel .ic{background:var(--blue);color:#fff;} .inst .nm{font-weight:600;} .inst .chev{margin-left:auto;color:var(--g400);}
+  .exp{background:#fffaf0;}
+  /* editor */
+  .card{background:#fff;border:1px solid var(--g100);margin-bottom:16px;} .card-h{padding:12px 16px;border-bottom:1px solid var(--g100);font-weight:600;display:flex;align-items:center;gap:10px;} .card-b{padding:16px;}
+  .ctx{border:1px solid var(--blue);background:var(--blueBg);padding:12px 16px;margin-bottom:16px;font-size:13px;display:flex;gap:10px;align-items:flex-start;line-height:1.5;}
+  .chg{background:#fffaf0;border-left:3px solid var(--amber);} .ovr{display:inline-block;font-size:10px;font-weight:600;color:var(--purple);background:var(--purpleBg);padding:1px 7px;border-radius:10px;margin-left:6px;}
+  .vm-row{display:grid;grid-template-columns:1fr 22px 1fr;gap:8px;align-items:center;padding:6px 0;}
+  .scope{border:2px solid var(--blue);background:#fff;margin-top:14px;} .scope-h{background:var(--blueBg);padding:12px 16px;font-weight:600;} .opt{display:flex;gap:12px;padding:14px 16px;border-bottom:1px solid var(--g100);cursor:pointer;} .opt:hover{background:var(--g10);} .opt.sel{background:var(--blueBg);} .opt .ot{font-weight:600;margin-bottom:2px;} .opt .od{font-size:12px;color:var(--g600);line-height:1.5;}
+  .savebar{position:sticky;bottom:0;background:#fff;border:1px solid var(--g200);padding:13px 16px;display:flex;gap:10px;align-items:center;}
+</style>
+</head>
+<body>
+<div class="banner">⚡ Functional Prototype — Analyzer Profiles &amp; Mapping &nbsp;|&nbsp; pick → verify → connect · editor-as-exception · shared-with-fork · ASTM &amp; HL7 &nbsp;|&nbsp; OpenELIS design mockup (not live)</div>
+<div class="hdr"><span style="font-size:18px;">☰</span><span><span class="brand">Test LIMS</span> <span class="ver">3.2.1.10</span></span><span class="r"><span>🔍</span><span>🔔</span><span>👤</span><span>❓</span></span></div>
+
+<div class="shell">
+  <div class="side">
+    <div class="item">Home</div>
+    <div class="item active">Analyzers</div>
+    <div class="sub" id="nav-list" onclick="view('list')">Analyzers List</div>
+    <div class="sub" id="nav-profiles" onclick="view('profiles')">Analyzer Types</div>
+    <div class="sub">Error Dashboard</div>
+    <div class="sub">Quality Control ⌄</div>
+    <div class="item">Results</div>
+    <div class="item">Alerts</div>
+    <div class="item">Admin</div>
+  </div>
+
+  <div class="main">
+
+    <!-- ===================== ANALYZERS LIST ===================== -->
+    <div id="v-list"><div class="page">
+      <div style="display:flex;align-items:flex-start;">
+        <div><div class="crumbtitle"><b>Analyzers</b> <span class="sep">&gt;</span> Analyzer List</div><div class="sub1">Manage laboratory analyzers and field mappings</div></div>
+        <button class="btn btn-pri" style="margin-left:auto;" onclick="openSetup()">Add Analyzer +</button>
+      </div>
+      <div class="cards">
+        <div class="c"><div class="l">Total</div><div class="n">4</div></div>
+        <div class="c"><div class="l">Active</div><div class="n" style="color:var(--green)">3</div></div>
+        <div class="c"><div class="l">In Setup</div><div class="n" style="color:var(--amber)">1</div></div>
+        <div class="c"><div class="l">Needs Attention</div><div class="n" style="color:var(--red)">1</div></div>
+      </div>
+
+      <div class="note note-err" style="margin-bottom:16px;">🚩 <span><b>Mindray BC-5380</b> is sending a result OpenELIS can't map (<span class="mono">NRBC#</span>). It's parked in <b>Alerts</b> for acknowledgment — the result isn't lost, but it won't post until you map it. <a style="color:var(--red);font-weight:600;cursor:pointer;" onclick="openMappings('hl7')">Resolve →</a></span></div>
+
+      <!-- inline guided setup (list stays visible below) -->
+      <div class="setup hide" id="setup">
+        <div class="setup-h">🔬 Set up a new analyzer <span class="x" onclick="closeSetup()">✕</span></div>
+
+        <!-- 1 Instrument -->
+        <div class="sec open" id="sec1">
+          <div class="sec-h"><span class="num">1</span><span class="t">Instrument <span class="q" id="q1">— pick what you're connecting</span></span><span class="summary hide" id="sum1"></span><span class="edit hide" id="edit1" onclick="openSec(1)">Edit</span></div>
+          <div class="sec-b" id="body1">
+            <div class="searchbar" style="margin-bottom:12px;"><span style="color:var(--g400)">🔍</span><input placeholder="Search by make or model — GeneXpert, Sysmex, Mindray…"></div>
+            <div onclick="pick(this)" class="inst sel"><div class="ic">GX</div><div><div class="nm">Cepheid GeneXpert</div><div class="meta">Molecular / PCR · ASTM</div></div><span class="chev">●</span></div>
+            <div onclick="pick(this)" class="inst"><div class="ic">MR</div><div><div class="nm">Mindray BC-5380</div><div class="meta">Hematology · HL7</div></div><span class="chev">›</span></div>
+            <div style="padding:8px 2px;font-size:13px;"><a style="color:var(--blue);cursor:pointer;" onclick="toggleNew()">My instrument isn't listed →</a> <span class="meta">define a new profile (protocol + connection type)</span></div>
+            <div id="newprof" class="hide" style="border:1px dashed var(--blue);background:var(--blueBg);padding:14px;margin-bottom:10px;">
+              <div style="font-weight:600;margin-bottom:8px;">Define a new profile</div>
+              <div class="note note-info" style="margin-bottom:12px;">ℹ️ Tell us how this instrument communicates — this becomes a new profile you can reuse. It starts with <b>no mappings</b>; you'll fill them by sending a result from the analyzer in the next step, or by hand.</div>
+              <div class="row2"><div class="field" style="margin:0;"><label>Profile name</label><input placeholder="e.g., Acme ChemPro 200"></div><div class="field" style="margin:0;"><label>Protocol</label><select><option>ASTM LIS2-A2</option><option>HL7 v2.x</option><option>Flat file (CSV/XML)</option></select></div></div>
+              <div class="field" style="margin-top:12px;margin-bottom:0;"><label>Connection type</label><select><option>Network — analyzer connects to OpenELIS</option><option>Network — OpenELIS connects to analyzer</option><option>Watched folder (files)</option></select></div>
+            </div>
+            <div class="row2" style="margin-top:8px;"><div class="field" style="margin:0;"><label>Name</label><input id="anName" value="GeneXpert MTB/RIF #2"></div><div class="field" style="margin:0;"><label>Lab unit(s)</label><div class="pillrow"><span class="tag t-blue">Molecular Biology ✕</span><input placeholder="Add…"></div></div></div>
+            <button class="btn btn-pri btn-sm" style="margin-top:10px;" onclick="doneSec(1)">Continue →</button>
+          </div>
+        </div>
+
+        <!-- 2 Verify -->
+        <div class="sec collapsed" id="sec2">
+          <div class="sec-h"><span class="num">2</span><span class="t">Verify the mappings <span class="q">— confirm what the profile set up; you don't build this by hand</span></span><span class="summary hide" id="sum2"></span><span class="edit hide" id="edit2" onclick="openSec(2)">Edit</span></div>
+          <div class="sec-b" id="body2">
+            <div class="note note-ok" style="margin-bottom:14px;">✅ <span>Loaded <b>Cepheid GeneXpert — MTB/RIF</b>. <b>3 of 4 tests</b> matched to your catalog by LOINC and ready; <b>1 needs a quick look</b>. Review and confirm — this is your sign-off, so nothing maps itself silently.</span></div>
+            <table>
+              <thead><tr><th style="width:28px;"></th><th>Analyzer sends</th><th>Matched to your test</th><th>By LOINC</th><th>Status</th><th>Checked vs live</th><th></th></tr></thead>
+              <tbody>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">MTB-RIF</td><td>MTB Detection</td><td class="mono">85362-2</td><td><span class="tag t-green">matched · active</span></td><td id="lv-mtb" class="meta">— not seen yet</td><td></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">HIV-VL</td><td>HIV-1 Viral Load</td><td class="mono">20447-9</td><td><span class="tag t-green">matched · active</span></td><td id="lv-hiv" class="meta">— not seen yet</td><td></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">RIF</td><td>Rifampin Resistance</td><td class="mono">46244-0</td><td><span class="tag t-green">matched · active</span></td><td id="lv-rif" class="meta">— not seen yet</td><td></td></tr>
+                <tr class="exp"><td>⚠</td><td class="mono" style="font-weight:600;">COVID19</td><td style="color:var(--amberTx);">SARS-CoV-2 — no LOINC match in your catalog</td><td class="mono">94500-6</td><td><span class="tag t-amber">needs attention</span></td><td id="lv-covid" class="meta">—</td><td style="text-align:right;"><button class="btn btn-sec btn-sm" onclick="document.getElementById('exrow').classList.toggle('hide')">Resolve ▾</button></td></tr>
+                <tr id="exrow" class="hide"><td colspan="7" style="background:#fff;padding:0;">
+                  <div style="padding:14px 18px;border-left:3px solid var(--amber);">
+                    <div style="font-weight:600;margin-bottom:8px;">Resolve COVID19 <span class="mono" style="font-weight:400;color:var(--g600)">94500-6</span> — the editor opens only for this exception</div>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r" checked> <b>Map to an existing test in your catalog</b></label>
+                    <div style="display:flex;align-items:center;gap:8px;border:1px solid var(--g200);background:#fff;padding:8px 12px;margin:4px 0 6px 26px;max-width:480px;"><span style="color:var(--g400)">🔍</span><input style="border:none;outline:none;flex:1;font-family:var(--font);font-size:13px;" placeholder="Search your catalog by name, code, or LOINC…" value="SARS"></div>
+                    <div style="margin:0 0 8px 26px;font-size:12px;color:var(--g600);">2 of ~500 catalog tests match · <span class="mono">SARS-CoV-2 RNA</span> (94500-6) · <span class="mono">COVID-19 PCR</span> (94500-6)</div>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r"> Not in your catalog? <a style="color:var(--blue);cursor:pointer;margin-left:4px;">Add it in Test Catalog ↗</a> first, then return and map <span style="font-size:11px;color:var(--g500);margin-left:6px;">(adding a test is multi-step — done in Test Catalog, not here)</span></label>
+                    <label class="chk" style="padding:6px 0;color:var(--g900);"><input type="radio" name="r"> Don't receive this test from this analyzer</label>
+                    <div style="margin-top:10px;"><button class="btn btn-pri btn-sm" onclick="resolveEx()">Apply</button> <button class="btn btn-ghost btn-sm" onclick="document.getElementById('exrow').classList.add('hide')">Cancel</button></div>
+                  </div>
+                </td></tr>
+              </tbody>
+            </table>
+
+            <div style="margin-top:18px;font-weight:600;font-size:13px;">Quality control codes <span class="sub1" style="font-weight:400;margin:0;">— confirm controls are recognized so QC runs don't post as patient results</span></div>
+            <table style="margin-top:6px;">
+              <thead><tr><th style="width:28px;"></th><th>QC code</th><th>Recognized as</th><th>Status</th></tr></thead>
+              <tbody>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">CNEG</td><td>Negative control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">CPOS</td><td>Positive control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+                <tr><td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">Q</td><td>Control flag (field O.12 = Q)</td><td><span class="tag t-green">recognized</span></td></tr>
+              </tbody>
+            </table>
+
+            <div class="note note-info" style="margin-top:14px;">ℹ️ <span><b>Verify against a real message.</b> Mappings come from the profile, but a given instrument may send different codes (enabled assays vary). Push a result from the analyzer to reconcile what's actually transmitted against the mappings.</span></div>
+            <div style="margin-top:10px;"><button class="btn btn-sec btn-sm" onclick="simulateResult()">▶ Send a result from the analyzer now</button> <span class="meta" id="recvHint"></span></div>
+
+            <div id="recvPanel" class="hide" style="border:1px solid var(--g200);margin-top:12px;">
+              <div style="padding:11px 14px;border-bottom:1px solid var(--g100);font-weight:600;font-size:13px;display:flex;align-items:center;gap:10px;">Transmission received <span class="meta" style="font-weight:400;">1 message · 3 results · 09:42</span></div>
+              <table>
+                <thead><tr><th>Received</th><th>Interpreted</th><th>Match</th><th>Action</th></tr></thead>
+                <tbody>
+                  <tr><td class="mono"><b>MTB-RIF</b> = NOT DETECTED</td><td>MTB Detection = Not Detected</td><td><span class="tag t-green">matches mapping</span></td><td class="meta">verified ✓</td></tr>
+                  <tr id="recv-rif" style="background:#fffaf0;"><td class="mono"><b>RIF</b> = INDETERMINATE</td><td>Rifampin Resistance = <span style="color:var(--amberTx)">result not mapped</span></td><td><span class="tag t-amber">new result</span></td><td><select id="rifsel" style="padding:4px 8px;border:1px solid var(--amber);font-family:var(--font);font-size:12.5px;"><option>— map to —</option><option selected>Indeterminate</option></select> <button class="btn btn-pri btn-sm" onclick="applyRecv('rif')">Map</button></td></tr>
+                  <tr id="recv-xdr" style="background:#fffaf0;"><td class="mono"><b>XDR</b> = DETECTED</td><td><span style="color:var(--amberTx)">no test mapped — new code</span></td><td><span class="tag t-amber">new test code</span></td><td><input placeholder="🔍 search catalog…" style="padding:4px 8px;border:1px solid var(--amber);font-family:var(--font);font-size:12.5px;width:140px;" value="MTB/XDR Resistance"> <button class="btn btn-pri btn-sm" onclick="applyRecv('xdr')">Map</button></td></tr>
+                </tbody>
+              </table>
+              <div class="note note-info" style="margin:0;">ℹ️ Nothing that doesn't match is dropped — map it here now, or (on a live analyzer) it waits under <b>Alerts</b>. If <b>nothing</b> matched, every row would appear here to map — which is exactly how a brand-new profile (no mappings yet) gets built from a real message.</div>
+            </div>
+
+            <div style="margin-top:14px;display:flex;gap:10px;align-items:center;"><button class="btn btn-pri" onclick="doneSec(2)">Confirm &amp; continue →</button><span class="sub1" style="margin:0;" id="confirmHint">1 item still needs attention</span></div>
+          </div>
+        </div>
+
+        <!-- 3 Connect -->
+        <div class="sec collapsed" id="sec3">
+          <div class="sec-h"><span class="num">3</span><span class="t">Connect it <span class="q">— network address and which way data flows</span></span></div>
+          <div class="sec-b" id="body3">
+            <div class="row2"><div class="field" style="margin:0;"><label>Analyzer IP address</label><input placeholder="10.42.20.10"></div><div class="field" style="margin:0;"><label>Port</label><input value="9600"></div></div>
+            <div class="field" style="margin-top:12px;"><label>Data flow</label>
+              <label class="chk" style="padding:5px 0;color:var(--g900);"><input type="radio" name="dir" checked> Results only (one-way)</label>
+              <label class="chk" style="padding:5px 0;color:var(--g900);"><input type="radio" name="dir"> Two-way (send orders/queries) — verified by the test below</label>
+              <div class="help">Two-way needs OpenELIS to reach the analyzer. If the analyzer is on a private network with no route back, the test times out and it runs one-way.</div></div>
+            <button class="btn btn-sec btn-sm" onclick="document.getElementById('cr').classList.remove('hide')">Test connection</button>
+            <div id="cr" class="note note-ok hide" style="margin-top:10px;">✅ Connected — one-way verified. Two-way not reachable on this network; running results-only.</div>
+            <div style="margin-top:14px;display:flex;gap:10px;"><button class="btn btn-pri" onclick="finishSetup()">Finish &amp; activate</button><button class="btn btn-sec" onclick="finishSetup()">Save &amp; finish later</button><button class="btn btn-ghost" onclick="closeSetup()">Cancel</button></div>
+          </div>
+        </div>
+      </div>
+
+      <div class="searchbar"><span style="color:var(--g400)">🔍</span><input placeholder="Search analyzers…"></div>
+      <table>
+        <thead><tr><th>Name</th><th>Connection</th><th>Lab Units</th><th>Analyzer type</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          <tr class="click" onclick="openMappings('astm')"><td><b>Cepheid GeneXpert (ASTM Mode)</b></td><td class="mono" style="font-size:12px;">10.42.20.10:9600 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Molecular Biology</td><td class="meta">GeneXpert — MTB/RIF</td><td><span class="tag t-amber">Setup</span></td><td><span class="ovf" onclick="event.stopPropagation();om(this)">⋮</span><div class="ofmenu"><div class="menu hide"><div onclick="openMappings('astm')">Field Mappings</div><div>Test Connection</div><div>Copy Mappings</div><div>Edit</div><div>QC Rules</div><div>Deactivate</div></div></div></td></tr>
+          <tr class="click" onclick="openMappings('hl7')"><td><b>Mindray BC-5380</b> <span class="tag t-red" style="font-size:9px;">unmapped result</span></td><td class="mono" style="font-size:12px;">10.42.21.10:5380 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Hematology</td><td class="meta">Mindray BC-5380</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Sysmex XN-550</b></td><td class="mono" style="font-size:12px;">10.42.21.20:5001 <span class="tag t-gray" style="font-size:9px;">1-way</span></td><td class="meta">Hematology</td><td class="meta">Sysmex XN Series</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Tecan Infinite F50</b></td><td class="meta">watch folder</td><td class="meta">Immunology</td><td class="meta">Tecan F50 — HIV ELISA</td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+        </tbody>
+      </table>
+      <div class="note note-info" style="margin-top:12px;">ℹ️ Click <b>GeneXpert (ASTM)</b> or <b>Mindray (HL7)</b> to open the mapping editor — same surface; only the field reference differs by protocol. The editor is the exception/edit path; a clean setup never needs it.</div>
+    </div></div>
+
+    <!-- ===================== MAPPING EDITOR (exception / edit) ===================== -->
+    <div id="v-map" class="hide"><div class="page">
+      <div class="crumbtitle"><a onclick="view('list')">← Analyzers</a> <span class="sep">&gt;</span> Field Mappings <span class="sep">&gt;</span> <span id="mapAn">GeneXpert MTB/RIF #1</span></div>
+      <div class="sub1">Edit how this analyzer's results map to your tests. Most setups never need this — it's the exception path.</div>
+      <div class="ctx">📋 <div>Editing the analyzer type <b id="mapProf">Cepheid GeneXpert — MTB/RIF</b> (<span id="mapProto">ASTM</span>) — used by <b id="mapUsed">3 analyzers</b>. On save you'll choose: a <b>new type</b> for this analyzer (default), or update the shared type for all of them.</div></div>
+
+      <div class="card">
+        <div class="card-h">Test codes <span class="sub1" style="margin:0;font-weight:400;">— what the analyzer sends (<span class="mono" id="fref">R.3</span>) → your test</span></div>
+        <div class="card-b">
+          <div class="note note-info" style="margin-bottom:14px;">ℹ️ Every row is editable — re-point the <b>linked test</b> (search your ~500-test catalog) or change the code, even on rows already matched. Broad changes should <b>Save as a new analyzer type</b>.</div>
+          <div class="row2 chg" style="padding:8px 0 8px 13px;margin-bottom:8px;align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code <span class="ovr">changed</span></label><input value="RIF-RESIST"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="Rifampin Resistance" style="font-size:13.5px;"><div class="help">🔍 type to search ~500 tests</div></div><span style="color:var(--g500);cursor:pointer;padding-bottom:22px;" title="Remove">✕</span></div>
+          <div class="row2" style="margin-bottom:8px;align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code</label><input value="MTB-RIF"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="MTB Detection" style="font-size:13.5px;"></div><span style="color:var(--g500);cursor:pointer;padding-bottom:9px;" title="Remove">✕</span></div>
+          <div class="row2" style="align-items:flex-end;"><div class="field" style="margin:0;"><label>Analyzer code</label><input value="HIV-VL"></div><div class="field" style="margin:0;"><label>Linked test (search catalog)</label><input value="HIV-1 Viral Load" style="font-size:13.5px;"></div><span style="color:var(--g500);cursor:pointer;padding-bottom:9px;" title="Remove">✕</span></div>
+          <button class="btn btn-ghost btn-sm" style="margin-top:10px;">+ Add test mapping</button>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">Results — Rifampin Resistance <span class="tag t-amber">2 of 3 mapped</span></div>
+        <div class="card-b">
+          <div class="note note-info" style="margin-bottom:12px;">ℹ️ Options come from the <b>Rifampin Resistance</b> test's result list (Resistant / Susceptible / Indeterminate).</div>
+          <div class="vm-row" style="font-size:11px;color:var(--g600);text-transform:uppercase;border-bottom:1px solid var(--g200);"><div>Analyzer value</div><div></div><div>Your result</div></div>
+          <div class="vm-row"><div class="mono">DETECTED</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select><option selected>Resistant</option><option>Susceptible</option></select></div></div>
+          <div class="vm-row"><div class="mono">NOT DETECTED</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select><option>Resistant</option><option selected>Susceptible</option></select></div></div>
+          <div class="vm-row" style="background:var(--amberBg);"><div class="mono">INDETERMINATE</div><div style="text-align:center;color:var(--g300)">→</div><div class="field" style="margin:0;"><select style="border-color:var(--amber)"><option selected style="color:var(--g500)">— choose —</option><option>Indeterminate</option></select></div></div>
+        </div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">QC codes</div>
+        <div class="card-b"><table><thead><tr><th>QC code</th><th>Recognized as</th><th>Status</th></tr></thead><tbody>
+          <tr><td class="mono" style="font-weight:600;">CNEG</td><td>Negative control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+          <tr><td class="mono" style="font-weight:600;">CPOS</td><td>Positive control (specimen ID prefix)</td><td><span class="tag t-green">recognized</span></td></tr>
+          <tr><td class="mono" style="font-weight:600;">Q</td><td>Control flag (field O.12 = Q)</td><td><span class="tag t-green">recognized</span></td></tr>
+        </tbody></table></div>
+      </div>
+
+      <div class="card">
+        <div class="card-h">Result formatting</div>
+        <div class="card-b"><div class="row2"><div class="field" style="margin:0;"><label>Date format</label><select><option>DD/MM/YYYY</option><option selected>MM/DD/YYYY</option></select></div><div class="field" style="margin:0;"><label>Decimal separator</label><select><option selected>Period (1.5)</option><option>Comma (1,5)</option></select></div></div></div>
+      </div>
+
+      <div class="savebar"><span style="font-size:12.5px;color:var(--amber);font-weight:600;">unsaved changes</span><span style="margin-left:auto;"></span><button class="btn btn-ghost btn-sm">Discard</button><button class="btn btn-pri" onclick="showScope()">Save changes</button></div>
+
+      <div class="scope hide" id="scope">
+        <div class="scope-h">How should these changes save?</div>
+        <label class="opt sel" onclick="selOpt(this,'new')"><input type="radio" name="scope" checked><div><div class="ot">Save as a new analyzer type <span class="tag t-blue" style="font-size:10px;">recommended</span></div><div class="od">This analyzer gets its own type (the other 2 stay untouched). No hidden one-offs — it's a type of its own, shown with its lineage.</div>
+          <div style="margin-top:8px;"><div class="field" style="margin:0;max-width:420px;"><label>New analyzer type name <span style="color:var(--g500);font-weight:400;">— auto-numbered to stay unique</span></label><input id="newProfName" value="Cepheid GeneXpert — MTB/RIF -1"><div class="help">Suggested from the source type + the next free number; rename if you like.</div></div></div></div></label>
+        <label class="opt" onclick="selOpt(this,'all')"><input type="radio" name="scope"><div><div class="ot">Update this analyzer type — affects all 3 analyzers</div><div class="od">⚠ Changes the shared type for GeneXpert #1, #2, and #3. Use only when every unit of this model should match.</div></div></label>
+        <div style="padding:14px 16px;display:flex;gap:10px;"><button class="btn btn-pri" onclick="view('list')">Confirm &amp; save</button><button class="btn btn-ghost" onclick="document.getElementById('scope').classList.add('hide')">Back</button></div>
+      </div>
+    </div></div>
+
+    <!-- ===================== ANALYZER PROFILES ===================== -->
+    <div id="v-profiles" class="hide"><div class="page">
+      <div class="crumbtitle"><b>Analyzers</b> <span class="sep">&gt;</span> Analyzer Types</div>
+      <div class="sub1">The reusable setups behind your analyzers.</div>
+      <div class="note note-info" style="margin-bottom:16px;">ℹ️ <span><b>What is this?</b> An analyzer type is the reusable setup for a kind of analyzer — its test codes, the results it reports and how they map to your tests, formatting, and QC codes. <b>How to use it:</b> identical analyzers share one type, so fixing it once updates them all; when a unit differs, open it and <b>Save as a new type</b>. Analyzer types are deactivated (not deleted) to keep this list tidy.</span></div>
+      <div class="cards">
+        <div class="c"><div class="l">Analyzer Types</div><div class="n">42</div></div>
+        <div class="c"><div class="l">In Use</div><div class="n" style="color:var(--green)">7</div></div>
+        <div class="c"><div class="l">Has Unmapped Results</div><div class="n" style="color:var(--amber)">3</div></div>
+        <div class="c"><div class="l">Deactivated</div><div class="n" style="color:var(--g500)">9</div></div>
+      </div>
+      <div class="searchbar"><span style="color:var(--g400)">🔍</span><input placeholder="Search profiles by name, manufacturer, model…"></div>
+      <div class="filters">
+        <div class="f"><label>Created</label><select><option>All</option><option>Site-created</option><option>Shipped with OpenELIS</option></select></div>
+        <div class="f"><label>Protocol</label><select><option>All</option><option>ASTM</option><option>HL7</option><option>Flat file</option></select></div>
+        <div class="f"><label>Mapping status</label><select><option>All</option><option>Has unmapped results</option><option>Fully mapped</option></select></div>
+        <label class="chk"><input type="checkbox"> Show deactivated</label>
+      </div>
+      <table>
+        <thead><tr><th>Analyzer type</th><th>Protocol</th><th>Tests mapped</th><th>Results mapped</th><th>Used by</th><th>Status</th><th>Actions</th></tr></thead>
+        <tbody>
+          <tr class="click" onclick="openMappings('astm')"><td><b>Cepheid GeneXpert — MTB/RIF</b><div class="meta" style="font-size:11px;">Cepheid · GeneXpert · v1.2</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">4 / 4 · 100%</span></td><td><span style="color:var(--amberTx);font-weight:500;">5 / 6 · 83%</span></td><td><span class="tag t-green">3 analyzers</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf" onclick="event.stopPropagation();om(this)">⋮</span><div class="ofmenu"><div class="menu hide"><div onclick="openMappings('astm')">Edit mappings</div><div>Export</div><div>Deactivate</div></div></div></td></tr>
+          <tr class="click" onclick="openMappings('astm')"><td><b>GeneXpert MTB/RIF -1</b><div class="meta" style="font-size:11px;">derived from Cepheid GeneXpert — MTB/RIF</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">4 / 4 · 100%</span></td><td><span style="color:var(--green);font-weight:500;">6 / 6 · 100%</span></td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr class="click" onclick="openMappings('hl7')"><td><b>Mindray BC-5380</b><div class="meta" style="font-size:11px;">Mindray · BC-5380 · v1.2</div></td><td>HL7</td><td><span style="color:var(--amberTx);font-weight:500;">12 / 13 · 92%</span></td><td class="meta">— numeric</td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Sysmex XN Series</b><div class="meta" style="font-size:11px;">Sysmex · XN · v1.2</div></td><td>ASTM</td><td><span style="color:var(--green);font-weight:500;">13 / 13 · 100%</span></td><td class="meta">— numeric</td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+          <tr><td><b>Tecan Infinite F50 — HIV ELISA</b><div class="meta" style="font-size:11px;">Tecan · F50 · v2.0</div></td><td>Flat file</td><td><span style="color:var(--green);font-weight:500;">1 / 1 · 100%</span></td><td><span style="color:var(--green);font-weight:500;">3 / 3 · 100%</span></td><td><span class="tag t-green">1 analyzer</span></td><td><span class="tag t-green">Active</span></td><td><span class="ovf">⋮</span></td></tr>
+        </tbody>
+      </table>
+      <div class="note note-info" style="margin-top:12px;">ℹ️ <b>Shared-with-fork:</b> identical analyzers share one type; the moment one diverges, Save-as-new-type creates a fork (auto-numbered, shown with lineage). No Clone, no hidden overrides. Analyzer types deactivate/reactivate, never delete. Test pickers and search are built for large (~500-test) catalogs.</div>
+    </div></div>
+
+  </div>
+</div>
+
+<script>
+  function view(v){
+    ['list','map','profiles'].forEach(x=>document.getElementById('v-'+x).classList.toggle('hide',x!==v));
+    document.getElementById('nav-list').classList.toggle('active',v==='list'||v==='map');
+    document.getElementById('nav-profiles').classList.toggle('active',v==='profiles');
+    const sc=document.getElementById('scope'); if(sc) sc.classList.add('hide');
+    window.scrollTo(0,0);
+  }
+  function om(el){const m=el.parentNode.querySelector('.menu');document.querySelectorAll('.ofmenu .menu').forEach(x=>{if(x!==m)x.classList.add('hide');});m.classList.toggle('hide');}
+  document.addEventListener('click',e=>{if(!e.target.closest('.ofmenu')&&!e.target.classList.contains('ovf'))document.querySelectorAll('.ofmenu .menu').forEach(x=>x.classList.add('hide'));});
+  function openSetup(){document.getElementById('setup').classList.remove('hide');window.scrollTo(0,0);}
+  function closeSetup(){document.getElementById('setup').classList.add('hide');}
+  function pick(el){document.querySelectorAll('.inst').forEach(i=>{i.classList.remove('sel');i.querySelector('.chev').textContent='›';});el.classList.add('sel');el.querySelector('.chev').textContent='●';}
+  function doneSec(n){const s=document.getElementById('sec'+n);s.classList.remove('open');s.classList.add('done','collapsed');
+    if(n===1){const nm=document.getElementById('anName').value;const su=document.getElementById('sum1');su.textContent='Cepheid GeneXpert · '+nm+' · Molecular Biology';su.classList.remove('hide');document.getElementById('q1').classList.add('hide');document.getElementById('edit1').classList.remove('hide');}
+    if(n===2){const su=document.getElementById('sum2');su.textContent='4 tests verified · 3 QC codes recognized';su.classList.remove('hide');document.getElementById('edit2').classList.remove('hide');}
+    const nx=document.getElementById('sec'+(n+1));if(nx){nx.classList.remove('collapsed');nx.classList.add('open');nx.scrollIntoView({behavior:'smooth',block:'center'});}}
+  function openSec(n){[1,2,3].forEach(i=>{const s=document.getElementById('sec'+i);if(i===n){s.classList.remove('collapsed');s.classList.add('open');}else if(s.classList.contains('open')){s.classList.add('collapsed');s.classList.remove('open');}});document.getElementById('sec'+n).scrollIntoView({behavior:'smooth',block:'center'});}
+  function resolveEx(){document.getElementById('exrow').classList.add('hide');const row=document.querySelector('#body2 .exp');row.classList.remove('exp');row.innerHTML='<td><input type="checkbox" checked></td><td class="mono" style="font-weight:600;">COVID19</td><td>SARS-CoV-2 RNA</td><td class="mono">94500-6</td><td><span class="tag t-green">matched · active</span></td><td></td>';document.getElementById('confirmHint').textContent='All 4 tests matched — ready to confirm';}
+  function finishSetup(){closeSetup();view('list');}
+  function openMappings(proto){view('map');const isHL7=proto==='hl7';document.getElementById('mapProto').textContent=isHL7?'HL7':'ASTM';document.getElementById('fref').textContent=isHL7?'OBX-3':'R.3';if(isHL7){document.getElementById('mapAn').textContent='Mindray BC-5380';document.getElementById('mapProf').textContent='Mindray BC-5380';document.getElementById('mapUsed').textContent='1 analyzer';}else{document.getElementById('mapAn').textContent='GeneXpert MTB/RIF #1';document.getElementById('mapProf').textContent='Cepheid GeneXpert — MTB/RIF';document.getElementById('mapUsed').textContent='3 analyzers';}}
+  function showScope(){document.getElementById('scope').classList.remove('hide');document.getElementById('scope').scrollIntoView({behavior:'smooth'});}
+  function selOpt(el,which){document.querySelectorAll('.opt').forEach(o=>{o.classList.remove('sel');o.querySelector('input').checked=false;});el.classList.add('sel');el.querySelector('input').checked=true;}
+  function toggleNew(){document.getElementById('newprof').classList.toggle('hide');}
+  function simulateResult(){
+    document.getElementById('recvPanel').classList.remove('hide');
+    document.getElementById('lv-mtb').innerHTML='<span class="tag t-green">✓ seen · verified</span>';
+    document.getElementById('lv-rif').innerHTML='<span class="tag t-amber">⚠ new result</span>';
+    // HIV-VL was not in this transmission — stays "not seen yet"
+    document.getElementById('recvHint').textContent='Reconciled 3 results: 1 verified, 2 need mapping (1 was not transmitted)';
+    document.getElementById('recvPanel').scrollIntoView({behavior:'smooth',block:'center'});
+  }
+  function applyRecv(which){
+    const row=document.getElementById('recv-'+which);
+    if(which==='rif'){row.style.background='';row.cells[2].innerHTML='<span class="tag t-green">mapped</span>';row.cells[3].innerHTML='<span class="meta">→ Indeterminate · verified ✓</span>';document.getElementById('lv-rif').innerHTML='<span class="tag t-green">✓ verified</span>';}
+    if(which==='xdr'){row.style.background='';row.cells[2].innerHTML='<span class="tag t-green">mapped</span>';row.cells[3].innerHTML='<span class="meta">→ MTB/XDR Resistance · added to profile ✓</span>';}
+  }
+</script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -535,6 +535,31 @@ export const MOCKUP_REGISTRY = [
 
   // ─── Analyzer Integration ───
   {
+    name: 'Analyzer Types & Mapping',
+    category: 'analyzer-integration',
+    component: null,
+    description: 'Completes the Generic ASTM/HL7/Flat-file module with reusable, forkable Analyzer Types and a lab-facing GUI to map an instrument\'s tests, result values, and QC codes to the catalog. Replaces the developer-facing "Analyzer Types" plugin-registry page; guided instrument-first setup whose normal path is verify. HTML prototype + version-agnostic FRS.',
+    specPath: 'designs/analyzer-integration/analyzer-profile-mapping.md',
+    htmlUrl: 'designs/analyzer-integration/analyzer-profile-mapping.html',
+    added: '2026-06-18',
+    status: 'draft',
+    jira: ['OGC-1054'],
+    relatedTo: ['Analyzer Types & Mapping — Gap Analysis'],
+    tags: ['analyzer', 'mapping', 'profiles', 'analyzer-types', 'ASTM', 'HL7', 'flat-file', 'Madagascar'],
+  },
+  {
+    name: 'Analyzer Types & Mapping — Gap Analysis',
+    category: 'analyzer-integration',
+    component: null,
+    description: 'Functional gap analysis grounding the Analyzer Types & Mapping FRS: reviews ~20 shipped Madagascar profiles and the ASTM/HL7/flat-file addenda, surfacing the inconsistent value-handling that the feature normalizes.',
+    specPath: 'designs/analyzer-integration/analyzer-profile-mapping-gap-analysis.md',
+    added: '2026-06-18',
+    status: 'draft',
+    jira: ['OGC-1054'],
+    relatedTo: ['Analyzer Types & Mapping'],
+    tags: ['analyzer', 'mapping', 'gap-analysis', 'profiles', 'Madagascar'],
+  },
+  {
     name: 'Sysmex XP Field Mapping',
     category: 'analyzer-integration',
     component: null,


### PR DESCRIPTION
Auto-opened for branch `design/analyzer-profile-mapping`.

S/OGC-1054 — completes the Generic ASTM/HL7/Flat-file module with reusable
forkable Analyzer Types + a lab-facing GUI to map instrument tests, result
values, and QC codes to the catalog. HTML prototype + version-agnostic FRS,
plus the functional gap-analysis companion. Status: draft. Tests 230/230.

Co-Authored-By: Claude <noreply@anthropic.com>