### PR TITLE
docs(microbiology): Sync 7 — retire M-10 / rescope M-12 / Hub→Catalog Subscription refs

### DIFF
--- a/designs/microbiology/m-00-micro-module-parent.md
+++ b/designs/microbiology/m-00-micro-module-parent.md
@@ -30,7 +30,7 @@ Bacterial micro workflow end-to-end: order entry hook, culture setup, incubation
 
 **In scope for Phase 1B (3-4 months after 1A):**
 
-Expert Rules Engine with built-in rules (MRSA inference, D-test required, ESBL screen and confirm, cascade reporting, intrinsic resistance verification); WHONET Export Generator with code mapping admin (now **including TB**, M-09 §4.5); Hub Subscription for breakpoint and reference-data updates; additional analyzer profiles (BD Phoenix, Sensititre, BACTEC, MALDI-TOF); FHIR push for micro reports; AST Run QC integration.
+Expert Rules Engine with built-in rules (MRSA inference, D-test required, ESBL screen and confirm, cascade reporting, intrinsic resistance verification); WHONET Export Generator with code mapping admin (now **including TB**, M-09 §4.5); reference-data + breakpoint updates via the existing Catalog Subscription feature (M-10 hub retired); additional analyzer profiles (BD Phoenix, Sensititre, BACTEC, MALDI-TOF); FHIR push for micro reports; AST Run QC integration.
 
 **Planned scope (post-1B; now in scope as planned modules):**
 
@@ -80,7 +80,7 @@ Admin
 │   └── Culture Protocols (as Methods — A-REUSE-1)
 ├── Breakpoint Catalog            (M-02)
 ├── Macro Library                 (M-08)
-├── Hub Subscription              (M-10, Phase 1B)
+├── Hub Subscription              (M-10 — RETIRED; folded into Catalog Subscription)
 ├── WHONET Mapping                (M-09, Phase 1B)
 └── Test → Reagent Linkage        (M-12; cross-cutting, lives in Test Catalog admin actually — see M-12 spec)
 ```
@@ -433,7 +433,7 @@ Per `feedback_openelis_admin_permissions`: admin menu is binary in OE today (all
 | `micro.breakpoint.manage` | Manage Breakpoint Catalog (versions, imports, active selection) |
 | `micro.macro.view` | View Macro Library |
 | `micro.macro.manage` | Manage Macro Library |
-| `micro.hub.manage` | Manage Hub Subscription (Phase 1B) |
+| `catalog.subscription.manage` | Manage catalog subscriptions (existing Catalog Subscription feature; M-10 retired) |
 | `micro.surveillance.export` | Generate WHONET exports (Phase 1B) |
 | `micro.surveillance.mapping` | Manage WHONET code mappings (Phase 1B) |
 | `critical.notify.create` | Log a critical-result notification (used by Micro; also by other modules) |
@@ -545,7 +545,7 @@ Eleven modules ship as a coordinated release. Pre-track: M-12 Test→Reagent Lin
 |--------|-------|
 | M-06 Expert Rules Engine | Built-in rules: MRSA inference, D-test, ESBL screen/confirm, cascade, intrinsic resistance. Emits orders through the existing reflex/test-rules action API (§8.2). |
 | M-09 WHONET Export | Per `whonet-export-design-review-v1.md` |
-| M-10 Hub Subscription | Unified admin: breakpoints + WHONET codes + organism/antibiotic updates |
+| ~~M-10 Hub Subscription~~ | **RETIRED** — duplicated the existing Catalog Subscription & Metadata Sync feature; AMR reference-data updates fold into it (+ M-02 CSV import offline). See m-10 v3.0. |
 | Additional analyzer profiles | BD Phoenix, Sensititre, BACTEC, MALDI-TOF |
 | FHIR push for micro reports | Reuse `FRS_FHIR_Outbound_Push` infrastructure |
 | AST Run QC integration | Run-QC organism results gating release |
@@ -592,7 +592,7 @@ The module deliberately does NOT include:
 - **Real-time outbreak detection** — pattern-based alerts across recent isolates. Phase 4+.
 - **Image attachments** — plate photos, Gram stain photos. UI surface design deferred. Phase 3+.
 - **Mobile bottle barcode scanning** — requires mobile companion app. Phase 3+.
-- **Multi-site config sharing** — Hub Subscription is read-only updates from a central repository, not multi-write.
+- **Multi-site config sharing** — Catalog Subscription is read-only updates from a central catalog, not multi-write.
 - **AI-assisted organism ID** — suggest organism from colony morphology. Phase 4+.
 - **AI-assisted rule creation** — suggest expert rules from data. Phase 4+.
 - **User-specific personal macros** — sites use site-wide macros in Phase 1; per-user is an amplifier.

--- a/designs/microbiology/m-01-amr-reference-data.md
+++ b/designs/microbiology/m-01-amr-reference-data.md
@@ -126,7 +126,7 @@ The list surfaces the **Default panel** column so a manager can see, without ope
 | `default_ast_panel_id` | FK | No | FK to `ast_panel` | **Pre-selected at AST set-up** in M-04 when this organism is the isolate's organism |
 | `intrinsic_resistances` | M:N to antibiotic_master | No | — | Junction table; antibiotics this organism is always resistant to. **Auto-set R in AST regardless of MIC/zone** (review edit H1) |
 | `active` | bool | Yes | Default true | Soft delete |
-| `seeded` | bool | Yes | Default false | True if seeded from WHONET / Hub (M-10) |
+| `seeded` | bool | Yes | Default false | True if seeded from WHONET / Catalog Subscription |
 | `notes` | text | No | ≤ 1000 chars | Clinical or procedural notes |
 | `created_at`, `created_by`, `last_updated_at`, `last_updated_by` | audit | — | — | Standard audit columns |
 
@@ -188,11 +188,11 @@ A small fixed-set vocabulary that drives Expert Rule application. Stored in `org
 - **Deactivate** is the default. Removes the organism from selection dropdowns in workflow surfaces but preserves all historical Isolate references. Deactivated records visible in admin list with `Status: Inactive` filter. The deactivate confirmation states the **downstream impact** plainly: *"This organism will no longer appear in Isolate-ID pickers or as an AST default. Historical cases keep it. Reactivate any time."*
 - **Delete** is only allowed if no Isolate, Breakpoint, or AST Panel references the record. Confirmation dialog warns the user. Deletion is hard; no undo.
 
-### 3.7 Import from Hub
+### 3.7 Import reference-data updates (via Catalog Subscription)
 
-When M-10 Hub Subscription ships (Phase 1B), a "Import from Hub" action appears in the toolbar. It pulls the latest organism master list from the configured central repository and merges. Local additions are preserved; remote updates apply to records where `seeded = true` only.
+Reference-data updates arrive through the existing **Catalog Subscription & Metadata Sync** feature (M-10's bespoke hub is retired — see m-10 v3.0). When a subscribed catalog has organism/antibiotic updates, the admin reviews a field-level diff and applies it: local additions are preserved; remote updates apply to records where `seeded = true` only. *(Open: organism/antibiotic master may need a dedicated catalog resource type — flagged for the Catalog Subscription owner in m-10 §2.)*
 
-In Phase 1A, the toolbar has a placeholder "Import from Hub" button that is disabled with tooltip "Available in Phase 1B." The Phase-1A standard list is **seeded from WHONET** at deployment (`seeded = true`).
+In Phase 1A the list is **seeded from WHONET** at deployment (`seeded = true`); reference-data updates later flow through the existing Catalog Subscription feature (no separate Hub button — M-10 retired).
 
 ### 3.8 Acceptance criteria
 
@@ -528,7 +528,7 @@ Most OE deployments already have a department vocabulary (referenced from Order)
 |--------|---------------------|
 | View any master list | `micro.ref.view` |
 | Add / edit / delete records | `micro.ref.manage` |
-| Import from Hub (Phase 1B) | `micro.hub.manage` (per M-10) |
+| Import / review catalog updates | `catalog.update.review` (Catalog Subscription) |
 
 Per `feedback_openelis_admin_permissions`, the admin menu in OE is binary; access to `Admin → Microbiology Reference Data` is governed by the same top-level admin permission. The codes above gate specific actions within those pages.
 
@@ -595,7 +595,7 @@ All AC-M01-* items above, totaling roughly 30 criteria across the four masters p
 - M-07 Worklist (incubating-stage day count from `max_incubation_days`)
 - M-08 Macro Library (provides `organisms` category macros that reference Organism Master)
 - M-09 WHONET Export (reads WHONET codes from Organism Master + Antibiotic Master)
-- M-10 Hub Subscription (Phase 1B; provides Import from Hub action)
+- Catalog Subscription & Metadata Sync (provides reference-data update import; M-10 retired)
 - Test Catalog v2.5 (`test-catalog-requirements-v2.5.md`)
 - Sample Type Management FRS (`Sample-Type-Management-FRS.md`)
 - WHONET design review (`whonet-export-design-review-v1.md`)

--- a/designs/microbiology/m-02-breakpoint-catalog.md
+++ b/designs/microbiology/m-02-breakpoint-catalog.md
@@ -54,7 +54,7 @@ Hold the lab's set of breakpoint reference standards. Multiple versions of each 
 - **M-05 AST Entry & Interpretation** — calls `BreakpointLookupService(organism_id, antibiotic_id, method, breakpoint_standard_id)`. Returns S, I, R thresholds. **M-05 surfaces which precedence level matched** (organism-specific / group / none) so the tech can trust the interpretation — see §6.2.
 - **M-04 Case Workbench** — AST Run header records `breakpoint_standard_id` + `breakpoint_version` at setup time. Snapshots survive subsequent catalog changes.
 - **M-09 WHONET Export** — writes `breakpoint_standard` value (e.g., `CLSI_M100_2024`) into each exported AST result column.
-- **M-10 Hub Subscription** (Phase 1B) — provides automated import of new standard versions from a central repository.
+- **Catalog Subscription & Metadata Sync** (existing) — automated import of new breakpoint-standard versions (FHIR PlanDefinition) from a central catalog; lands them `Loaded`, activated here. *(M-10's bespoke hub retired.)*
 
 ---
 
@@ -367,11 +367,11 @@ The R/S call is binary: the measured/tested concentration **≥ critical concent
 
 ## 8. Import paths
 
-### 8.1 Hub import (Phase 1B via M-10)
+### 8.1 Automated import (via the existing Catalog Subscription feature)
 
-The dominant case. M-10 Hub Subscription pulls structured breakpoint tables from the central repository. New `breakpoint_standard` rows are added; new `breakpoint` rows populate; existing standards' `seeded = true` rows refresh from the source.
+For connected sites, the existing **Catalog Subscription & Metadata Sync** feature pulls breakpoint sets (as FHIR `PlanDefinition`) from a EUCAST/WHO/national-ref-lab catalog or the OpenELIS Community Hub. New `breakpoint_standard` rows are added; new `breakpoint` rows populate; existing standards' `seeded = true` rows refresh from the source. **New standards land `status = Loaded`, never auto-active** — a lab manager activates them here in §8 (the "Activate in Breakpoint Catalog" hand-off). *(M-10's bespoke hub is retired — see m-10 v3.0; this path is Catalog Subscription + the offline §8.2 CSV import.)*
 
-In Phase 1A, breakpoint catalogs are seeded by the **initial deployment process** (data migration), not by an in-app Hub call. The Hub UI is built in Phase 1B per M-10.
+In Phase 1A — and at any offline site — breakpoint catalogs are seeded by the **initial deployment process** (data migration) and updated via the §8.2 file import, not an in-app pull.
 
 ### 8.2 Manual CSV import (Phase 1A)
 
@@ -552,7 +552,7 @@ admin.micro.breakpoint.matchedBy.none          "No standard breakpoint — inter
 - M-01 AMR Reference Data (for organism / antibiotic FK targets)
 - M-05 AST Entry & Interpretation (primary consumer; displays `matched_by` precedence and the per-run standard picker)
 - M-04 Case Workbench Core (records breakpoint_standard_id + version on AST Run)
-- M-10 Hub Subscription (Phase 1B; provides automated import)
+- Catalog Subscription & Metadata Sync (automated breakpoint import; M-10 retired)
 - `amr-crosswalk-working.md` Q4 (versioning rules)
 - `amr-pre-frs-planning-v1.md` §4 (versioning + time edge cases)
 - CLSI M100 reference standard (current version)

--- a/designs/microbiology/m-09-whonet-export.md
+++ b/designs/microbiology/m-09-whonet-export.md
@@ -30,7 +30,7 @@ Mapping vocabularies by hand is the single biggest pain and the usual reason exp
 - **Ship WHONET organism/specimen/origin codes in the M-01 seed data** from a bundled **WHONET dictionary** reference pack, so the common catalog is already mapped on install — the operator never maps *Escherichia coli*.
 - **Suggestions are a deterministic lookup, not a matcher we build (keep the lift small).** For the residue that isn't pre-seeded, a suggestion is produced by, in order: **(a)** exact match on **normalized name** (lowercase, trim, strip punctuation/qualifiers) between the OE entity and the bundled WHONET dictionary; **(b)** a **join on a shared terminology code** the entity already carries — SNOMED/LOINC via the existing **OCL/CIEL** link, since the WHONET dictionary crosswalks to those. Both are plain dictionary lookups against the bundled pack — **no fuzzy/ML matching in MVP**. Anything that matches neither has **no suggestion** and falls to manual mapping. Because a human **confirms every suggestion before it is applied**, a wrong-but-exact name collision is caught at confirm time — there's no correctness risk and nothing to "train."
 - Surfaced as **bulk "confirm suggested mappings"** (accept-all / per-row) rather than per-row data entry.
-- **The real lift is the bundled WHONET dictionary pack + keeping it current** (the **M-10 Hub** refreshes it and fills new entries) — not matching logic. *Optional later:* fuzzy/token-similarity suggestions for near-miss names, explicitly out of MVP scope.
+- **The real lift is the bundled WHONET dictionary pack + keeping it current** (the existing **Catalog Subscription** feature refreshes it and fills new entries; M-10 retired) — not matching logic. *Optional later:* fuzzy/token-similarity suggestions for near-miss names, explicitly out of MVP scope.
 - Net effect: the operator confirms a short list and manually maps only genuinely local/custom items in a few non-catalog vocabularies — a handful, not hundreds.
 
 > **Open reconciliation (flag, do not silently restructure).** In OpenELIS an antibiotic susceptibility *is a Test*, so its WHONET code naturally lives on `test_amr_config` (Test Catalog), which **overlaps with M-01's proposed `antibiotic_master.whonet_code`**. Source of truth should be **one** of them — recommend the Test Catalog AMR config (where the lab already configures the test), with M-01/M-09 reading it. Resolve before build; M-01's antibiotic-master mapping may collapse into a read-through. (Organisms still need the M-01 `organism_master` code, since an organism is not a Test.)
@@ -82,7 +82,7 @@ Generate WHONET-format CSV/TXT files from finalized Cases for submission to the 
 - **M-02 Breakpoint Catalog** — breakpoint standard codes for the export column.
 - **M-06 Expert Rules Engine** — phenotype flags populate phenotype columns.
 - **M-07 Worklists** — the AST Worklist "Export to WHONET" quick action invokes M-09 with filters pre-populated (Phase 1B; disabled in 1A). The route + param contract is defined in §1.5.
-- **M-10 Hub Subscription** — provides code updates.
+- **Catalog Subscription & Metadata Sync** — provides WHONET code-list updates (M-10 retired).
 - **M-14 Mycobacteriology / TB** — source of TB species ID, phenotypic DST (R/S by WHO critical concentration), and molecular resistance flags (Xpert MTB/RIF, LPA) for the WHONET TB export (§4.5).
 
 ### 1.5 AST-Worklist quick-action contract
@@ -188,9 +188,9 @@ When the export preview (§3.2) warns about an unmapped item, clicking **"Map no
 | **Breakpoint Standards** | **Test Catalog AMR config / `breakpoint_standard` (M-02)** | `whonet_label` | **Read-through** from the catalog/M-02; e.g., `CLSI24`, `EUCAST14`, `WHO_TB_2023` |
 | Phenotypes | (new) `phenotype_flag_definition` (small fixed set) | `whonet_column` field | M-09-owned. Maps OE phenotype names to WHONET column names: ESBL_SCREEN, MRSA, VRE, CRE, CARBAPENEMASE, MDR, XDR, PDR |
 
-### 2.6 Import from Hub
+### 2.6 Code-list updates (via Catalog Subscription)
 
-When M-10 Hub Subscription ships, the "Import Hub" button pulls the latest official code lists and merges with the local mapping. Local edits are preserved; new entries from Hub are added.
+WHONET code-list updates arrive through the existing **Catalog Subscription & Metadata Sync** feature (M-10's bespoke hub is retired). Applying an update merges the latest official code lists with the local mapping — local edits preserved, new entries added. *(Open: WHONET codes aren't `ActivityDefinition`/`PlanDefinition` — they may need a dedicated catalog resource type; flagged for the Catalog Subscription owner in m-10 §2.)*
 
 ---
 
@@ -582,7 +582,7 @@ Carried from design review:
 - M-05 AST Entry & Interpretation (AST results in `result` table)
 - M-06 Expert Rules Engine (phenotype flag values)
 - M-07 Worklists (AST-Worklist "Export to WHONET" quick action; Phase-1B disabled in 1A)
-- M-10 Hub Subscription (provides code updates)
+- Catalog Subscription & Metadata Sync (provides WHONET code-list updates; M-10 retired)
 - M-14 Mycobacteriology / TB (source of TB species ID, phenotypic DST, and Xpert/LPA molecular flags for the WHONET TB export, §4.5)
 - **`whonet-export-design-review-v1.md`** — comprehensive design review; this FRS formalizes it
 - `amr-pre-frs-planning-v1.md` §7 (GLASS direction; M-13 removed; M-09 stays)

--- a/designs/microbiology/m-10-hub-subscription.md
+++ b/designs/microbiology/m-10-hub-subscription.md
@@ -1,310 +1,58 @@
-# M-10 Hub Subscription — Functional Requirements Specification
+# M-10 Hub Subscription — SUPERSEDED (retired; folded into Catalog Subscription)
 
-**Version:** 2.0 (consolidated — folds review edits inline; no separate addendum)
-**Date:** 2026-06-07
-**Module:** Admin → Hub Subscription
-**Phase:** 1B
-**Owner:** Microbiology Module (M-00 parent)
-**Status:** Draft
+**Version:** 3.0 (retirement) · **Date:** 2026-06-12 · **Status:** Retired — do not build as a standalone module.
 
-This spec unifies what was previously split between AMR Configuration §9 (Hub Subscription for organism/antibiotic/AST Panel updates) and WHONET Integration §2.3 (Import Hub for WHONET codes). One admin page, one mechanism, four data domains.
-
-> This FRS is self-contained. There is no separate addendum — every decision from the design review (update-availability discovery signal/banner; conflict resolution for locally-customized rows; "Activate in Breakpoint Catalog →" hand-off to M-02; import-summary structure + history) is written inline below.
+> **This module is retired.** The bespoke "Hub Subscription" mechanism specified in v2.0 (its own `hub_subscription_config` / `hub_import_run` tables, a custom CSV/REST hub, a parallel discovery-signal + diff + audit) duplicates an existing, more capable feature already designed and on `main`: **Catalog Subscription & Metadata Sync** (`designs/admin-config/catalog-subscription.md`, v1.2). Per Casey (2026-06-12), the AMR reference-data update path is **Catalog Subscription + M-02 file import**, not a second hub. The v2.0 content is preserved in git history.
 
 ---
 
-## 1. Overview
+## 1. Why retired
 
-### 1.1 Purpose
+Catalog Subscription already provides everything M-10 v2.0 proposed, FHIR-natively:
 
-The Hub is a central repository (managed externally by an OE community / consortium) that supplies updates to reference data: breakpoint tables, organism master entries, antibiotic master entries, and WHONET code mappings. OE pulls; never pushes.
+| M-10 v2.0 proposed | Catalog Subscription already does it |
+|---|---|
+| Subscribe to a central hub (`hub.openelis-global.org`) | **OpenELIS Community Hub** registry (FR-1-009…012) — a FHIR registry server with a browseable catalog of publishers |
+| Pull breakpoint table updates | Pulls **`PlanDefinition`** resources; §4.5 explicitly diffs **EUCAST breakpoint sets** at organism × antimicrobial × S/I/R × MIC granularity |
+| Pull organism / antibiotic / test-reference updates | Pulls **`ActivityDefinition`** (tests) with canonical-URL + LOINC identity matching |
+| Preview diff; preserve locally-customized rows; explicit override | Field-level **accept/reject** diff that defaults to preserving local edits (FR-4) |
+| Auto-check + "N updates available" discovery signal | Background `CatalogSyncJob` + pending-updates nav badge (FR-2, FR-6-001) |
+| Import history + per-record audit | Audit trail per sync run + per field decision (FR-6-002) |
 
-A typical scenario: CLSI publishes M100 2026 in January 2026. The Hub maintainers convert it to OE-importable format (per M-02 §7.2 CSV schema). OE deployments pull the new standard from the Hub at their own pace, validate, switch over.
+M-10's only **genuinely new** requirements are the three deltas in §2. Everything else was duplication.
 
-### 1.2 Routes
+## 2. The AMR delta — what Catalog Subscription must add to absorb M-10
 
-| Surface | Route | Sidenav |
-|---------|-------|---------|
-| Hub Subscription admin | `/admin/hub-subscription` | Admin → Hub Subscription |
-| Available updates list | `/admin/hub-subscription/available` | (sub-page) |
-| Import history | `/admin/hub-subscription/history` | (sub-page) |
+These are the only requirements that don't already exist in Catalog Subscription v1.2. They should be added there (as extension stories under Catalog Subscription's epic), **not** built as a separate hub:
 
-### 1.3 Users
+1. **Breakpoint "loaded → not active → activate" hand-off (M-02).** When Catalog Subscription applies a `PlanDefinition` breakpoint set, the new `breakpoint_standard` lands with `status = Loaded`, **never auto-activated**. The apply-summary surfaces an **"Activate in Breakpoint Catalog →"** deep-link into M-02 §8, where a lab manager sets the effective date and activates. (Catalog Subscription today writes mapped fields directly; for breakpoints it must route through M-02's activation gate so historical AST runs keep their snapshotted version.)
+2. **WHONET code-mapping domain.** WHONET organism/antibiotic/specimen/origin code mappings (consumed by M-09) aren't `ActivityDefinition`/`PlanDefinition`. Add them as a reference-vocabulary catalog type — candidate FHIR shape: `CodeSystem` / `ConceptMap`. Open question for the Catalog Subscription owner: model as a third resource type, or sync as OE reference data.
+3. **Organism / Antibiotic master sync (M-01).** Catalog Subscription's `ActivityDefinition` mapping is test-centric. Organism Master and Antibiotic Master (M-01) entries — including intrinsic resistances and WHONET codes — need either their own resource type or a reference-data sync path. Flag for the Catalog Subscription owner.
 
-| Role | Actions |
-|------|---------|
-| Lab Manager | Configure subscription URL, check updates, import |
-| System Administrator | All actions |
+## 3. The realistic breakpoint-update model (the actual design question)
 
-### 1.4 Integration
+Breakpoints (CLSI/EUCAST/WHO-TB) are **reference data that changes ~annually** and that turns a raw MIC/zone into S/I/R. Antibiograms (M-13) are **not** updated — they recompute %S on demand from finalized results against whatever breakpoint version was active, so they need no update channel; they only depend on breakpoints being current + M-09 first-isolate dedup.
 
-- **M-01 AMR Reference Data** — organism / antibiotic / AST Panel updates land here.
-- **M-02 Breakpoint Catalog** — breakpoint table updates land here; the import summary hands off newly-loaded breakpoint versions to M-02 for activation (§3.4).
-- **M-09 WHONET Export** — WHONET code mapping updates land here.
+Two realistic update layers (no bespoke hub):
 
----
+- **Floor (offline, must-have):** ship a current EUCAST/CLSI set at install + import annual update **files** via **M-02 §7 CSV import** + activation. Works with no connectivity. Seed/update content sourced from the open-source **AMR R package** (encodes EUCAST + CLSI interpretation rules with SNOMED/LOINC) — the same source chosen for M-09.
+- **Connected sites:** **Catalog Subscription** pulls a EUCAST / WHO / national-reference-lab FHIR catalog (or the Community Hub) and a manager reviews + applies the annual diff (with the §2.1 M-02 activation gate for breakpoints).
 
-## 2. Subscription configuration
+**Reality checks:**
+- Cadence is annual, not continuous — the realistic interaction is "a manager imports a file or reviews a diff and activates, once a year." A live-polling hub is more than the problem needs.
+- The actor is a **lab manager / national reference lab**, never a bench tech.
+- **Gating dependency (owns every auto-update path):** a clean, **licensed, machine-readable** breakpoint source. CLSI content is copyrighted/not freely redistributable; EUCAST is more open; the AMR R package is the practical open source. Whether anyone publishes a maintained FHIR breakpoint catalog or operates the OE Community Hub is an **ownership/licensing** question to resolve before betting on any subscription mechanism — it does not change the UI.
 
-### 2.1 Single Hub URL
+## 4. Disposition
 
-The lab points OE at one Hub URL (e.g., `https://hub.openelis-global.org`). Authentication via API key configured per deployment.
+- **Jira:** epic **OGC-795** retired; stories **OGC-882 / OGC-884** closed as superseded by Catalog Subscription. The §2 deltas should be created as extension stories under the Catalog Subscription epic when it's set up (its spec lists Jira as `OGC-[TBD]`).
+- **M-02 (Breakpoints):** unchanged and now the offline update path of record (CSV import + activation). It also receives the activation hand-off from Catalog Subscription (§2.1).
+- **M-09 (WHONET):** consumes the WHONET-code domain (§2.2) once Catalog Subscription adds it; unaffected otherwise.
+- **M-00 module map:** M-10 marked retired.
 
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Admin / Hub Subscription                                                     │
-│                                                                              │
-│ Hub Configuration                                                            │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                              │
-│  Hub URL: *                                                                  │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ https://hub.openelis-global.org                                         │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│                                                                              │
-│  API Key: *                                                                  │
-│  ┌──────────────────────────────────────────────────────────────────────────┐ │
-│  │ ●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●                                          │ │
-│  └──────────────────────────────────────────────────────────────────────────┘ │
-│  [Test Connection]                                                           │
-│                                                                              │
-│  Subscriptions: (which data domains to pull)                                 │
-│  ☑ Breakpoint Tables (CLSI, EUCAST)                                          │
-│  ☑ Organism Master                                                           │
-│  ☑ Antibiotic Master                                                         │
-│  ☑ WHONET Code Mappings                                                     │
-│                                                                              │
-│  Auto-check for updates: ☑   Frequency: [Daily ▼]                            │
-│                                                                              │
-│  [Save Configuration]                                                        │
-│                                                                              │
-│ ──────────────────────────────────────────────────────────────────────────── │
-│                                                                              │
-│ Last update check: 2026-05-15 06:00 (Success)                               │
-│ Available updates: 2 [View]                                                  │
-│ [Check Now]                                                                  │
-│                                                                              │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
+## 5. References
 
-### 2.2 Update-availability discovery signal
-
-Operators must not have to poll the Hub page to learn that updates exist. When `auto_check` finds available updates (or a manual "Check Now" does), the system raises a passive discovery signal:
-
-- **Nav badge** — a count badge ("N") on the `Admin → Hub Subscription` sidenav item, equal to the number of pending available-update sets across subscribed domains. The badge clears when all available sets have been imported or explicitly dismissed.
-- **Admin banner** — on entering any Admin surface, a dismissible banner: *"N updates available from Hub — [View]."* "View" links to the Available Updates page (§3). Dismiss hides the banner for the session but leaves the nav badge until the updates are imported.
-- The signal is computed from the result of the last successful check (`hub_subscription_config.last_check_at` / the set of currently-available update sets reported by the Hub) — no new polling on the operator's part.
-
-### 2.3 Data model
-
-```
-hub_subscription_config
-├── config_id (PK, singleton — only one row per deployment)
-├── hub_url (text)
-├── api_key (text, encrypted)
-├── subscribed_domains (JSON array: ["BREAKPOINTS", "ORGANISMS", "ANTIBIOTICS", "WHONET_CODES"])
-├── auto_check_enabled (bool)
-├── auto_check_frequency (enum: DAILY, WEEKLY, MONTHLY)
-├── last_check_at (timestamp, nullable)
-├── last_check_status (enum: SUCCESS, FAILED, IN_PROGRESS)
-├── last_check_error (text, nullable)
-├── available_update_count (int, default 0 — drives the §2.2 nav badge/banner; refreshed each check)
-└── audit columns
-
-hub_import_run
-├── run_id (PK)
-├── domain (enum: BREAKPOINTS, ORGANISMS, ANTIBIOTICS, WHONET_CODES)
-├── triggered_by (FK to user, nullable for auto)
-├── triggered_at (timestamp)
-├── completed_at (timestamp, nullable)
-├── status (enum: IN_PROGRESS, SUCCESS, FAILED, PARTIAL)
-├── records_added (int)
-├── records_updated (int)
-├── records_unchanged (int)
-├── records_skipped_customized (int)
-├── records_with_conflicts (int)
-├── error_summary (text, nullable)
-└── audit columns
-
-hub_import_record (per-record audit)
-├── record_id (PK)
-├── run_id (FK)
-├── domain (enum)
-├── action (enum: ADDED, UPDATED, SKIPPED_LOCAL_CUSTOMIZED, SKIPPED_UNCHANGED, OVERRIDDEN_LOCAL_CUSTOMIZED, ERROR)
-├── target_table (text, e.g., "organism_master")
-├── target_id (UUID, nullable)
-├── source_data (JSON, the row from the Hub)
-├── error_message (text, nullable)
-└── audit columns
-```
-
-`available_update_count` and the `records_skipped_customized` rollup are the only additions; the `OVERRIDDEN_LOCAL_CUSTOMIZED` action value records the §3.2 explicit-override case.
-
----
-
-## 3. Available updates
-
-When the user clicks "View" or "Check Now":
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Admin / Hub Subscription / Available Updates                                 │
-├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                              │
-│ The Hub has 2 update sets available:                                         │
-│                                                                              │
-│ ┌──────────────────────────────────────────────────────────────────────────┐ │
-│ │ Breakpoint Tables                                                        │ │
-│ │ - CLSI M100 2026 (new version) — 1,312 breakpoints                      │ │
-│ │ - EUCAST v15.0 (new version) — 891 breakpoints                          │ │
-│ │ Published 2026-04-28 by Hub maintainers                                  │ │
-│ │ [Preview Changes]  [Import]                                              │ │
-│ └──────────────────────────────────────────────────────────────────────────┘ │
-│                                                                              │
-│ ┌──────────────────────────────────────────────────────────────────────────┐ │
-│ │ Organism Master                                                          │ │
-│ │ - 3 new organisms (Burkholderia mallei, Mycoplasma genitalium,           │ │
-│ │   Klebsiella variicola)                                                  │ │
-│ │ - 2 updated organisms (Klebsiella pneumoniae intrinsic resistances)     │ │
-│ │ Published 2026-05-10 by Hub maintainers                                  │ │
-│ │ [Preview Changes]  [Import]                                              │ │
-│ └──────────────────────────────────────────────────────────────────────────┘ │
-│                                                                              │
-└─────────────────────────────────────────────────────────────────────────────┘
-```
-
-Each update is per-domain. The user can preview before importing.
-
-### 3.1 Preview Changes
-
-Side panel showing the diff between current state and Hub state:
-
-- **Added** rows highlighted green
-- **Updated** rows highlighted yellow with side-by-side before/after
-- **Locally customized** rows highlighted blue with warning "this row was locally customized — by default it will not be updated" — see §3.2 for the conflict-resolution controls.
-
-### 3.2 Conflict resolution for locally-customized rows
-
-A row that the lab has edited locally (`locally_customized = true`) is, by default, **skipped** by an import so lab modifications are never silently clobbered. The operator is not, however, left with only a blue highlight — the preview gives them visibility and an explicit choice per customized row:
-
-- **View the diff anyway.** Each locally-customized row in the preview is expandable to show the full **local-current vs. Hub-incoming** comparison, so the operator can judge whether the Hub change matters even though it will be skipped by default.
-- **Explicit per-row override.** Each customized row carries a **"Use Hub version (override local edit)"** control. Choosing it marks that row to be updated by this import despite the customization; the import records it as `OVERRIDDEN_LOCAL_CUSTOMIZED` (distinct from the default `SKIPPED_LOCAL_CUSTOMIZED`) and clears the row's `locally_customized` flag so future imports treat it as seeded again. This requires `micro.hub.manage` and is captured in the per-record audit (who overrode what, with before/after).
-- **Default remains skip.** With no explicit override, customized rows are skipped and counted under `records_skipped_customized`; the summary calls them out (§3.4).
-
-### 3.3 Import
-
-Triggers `hub_import_run` for the domain. The import:
-
-1. Adds new rows (seeded = true).
-2. Updates existing seeded rows.
-3. **Does not modify** rows where `locally_customized = true` (preserves lab modifications) **unless** the operator explicitly chose "Use Hub version" for that row in the preview (§3.2).
-4. Writes per-record audit entries in `hub_import_record` (including `OVERRIDDEN_LOCAL_CUSTOMIZED` for explicit overrides).
-5. Returns the summary to the user (§3.4).
-
-After import:
-
-- For breakpoint domain: new `breakpoint_standard` rows are created with `status = Loaded`, not yet active. The import summary surfaces an **"Activate in Breakpoint Catalog →"** hand-off (§3.4); activation itself happens in M-02 §8.
-- For organism/antibiotic: new rows visible in M-01 reference data lists; existing rows updated as appropriate.
-- For WHONET codes: new mappings appear in M-09 admin pages.
-
-### 3.4 Import summary + activation hand-off
-
-On completion the import shows a structured success summary (not free prose), then links to the per-record history:
-
-```
-┌─ Import complete — Breakpoint Tables ───────────────────────────────────────┐
-│                                                                              │
-│  ✓ 3 added   ✓ 2 updated   ⤺ 1 skipped (locally customized)                 │
-│  0 errors                                                                    │
-│                                                                              │
-│  Newly loaded breakpoint versions (not yet active):                          │
-│   • CLSI M100 2026   — status: Loaded   [Activate in Breakpoint Catalog →]  │
-│   • EUCAST v15.0     — status: Loaded   [Activate in Breakpoint Catalog →]  │
-│                                                                              │
-│  [View import detail]                                  [Done]               │
-└──────────────────────────────────────────────────────────────────────────────┘
-```
-
-- **Summary structure:** a count line of the form **"{added} added, {updated} updated, {skipped} skipped (customized), {errors} errors"** drawn directly from the `hub_import_run` counters, with the skipped-customized count linking to the affected rows in the preview/diff.
-- **Activation hand-off (closes the M-10 → M-02 gap):** for each breakpoint version the import created with `status = Loaded`, the summary renders an **"Activate in Breakpoint Catalog →"** link that deep-links to that version in the M-02 Breakpoint Catalog (M-02 §8) where the lab manager sets its effective date and activates it. Import never auto-activates a breakpoint standard.
-- **Link to history:** "View import detail" opens the run's per-record audit (§4), and the summary is itself reachable later from Import History.
-
----
-
-## 4. Import history
-
-`/admin/hub-subscription/history`:
-
-```
-┌─────────────────────────────────────────────────────────────────────────────┐
-│ Admin / Hub Subscription / Import History                                    │
-├─────────────────────────────────────────────────────────────────────────────┤
-│ Date / Time      │ Domain      │ Triggered │ Status  │ Added │ Updated │Skip│ ⋮ │
-├──────────────────┼─────────────┼───────────┼─────────┼───────┼─────────┼────┼───┤
-│ 2026-05-15 06:01 │ Breakpoints │ Auto      │ Success │ 1,312 │ 0       │ 0  │ ⋮ │
-│ 2026-05-10 14:23 │ Organisms   │ Manager   │ Success │ 3     │ 2       │ 1  │ ⋮ │
-│ 2026-04-01 06:00 │ All         │ Auto      │ Success │ 0     │ 5       │ 0  │ ⋮ │
-│ 2026-03-15 09:14 │ Antibiotics │ Manager   │ Partial │ 1     │ 0       │ 3  │ ⋮ │
-│                  │             │           │         │       │         │    │   │
-│                  │             │           │ (3 conflicts skipped) │       │    │   │
-└──────────────────┴─────────────┴───────────┴─────────┴───────┴─────────┴────┴───┘
-```
-
-Click a row to drill into the per-record audit, which shows each row's action (ADDED / UPDATED / SKIPPED_LOCAL_CUSTOMIZED / SKIPPED_UNCHANGED / OVERRIDDEN_LOCAL_CUSTOMIZED / ERROR), target, and source data. The structured summary (§3.4) is regenerated from these counters when a run is reopened.
-
----
-
-## 5. Permissions
-
-| Action | Permission |
-|--------|-----------|
-| View Hub Subscription config | `micro.hub.manage` |
-| Edit Hub URL / API key / subscriptions | `micro.hub.manage` |
-| Manually trigger import | `micro.hub.manage` |
-| Override a locally-customized row on import | `micro.hub.manage` |
-| View import history | `micro.hub.manage` AND `audit.read` |
-
----
-
-## 6. Acceptance criteria
-
-- **AC-M10-01**: Configuration page accepts Hub URL + API key.
-- **AC-M10-02**: Test Connection button validates URL + API key.
-- **AC-M10-03**: Auto-check runs at configured frequency.
-- **AC-M10-04**: Available Updates page shows per-domain available updates.
-- **AC-M10-05**: Preview Changes shows diff (Added / Updated / Locally Customized).
-- **AC-M10-06**: Import adds new rows with `seeded = true`.
-- **AC-M10-07**: Import updates existing seeded rows.
-- **AC-M10-08**: Locally customized rows preserved by default; flagged in summary.
-- **AC-M10-09**: New breakpoint_standard rows imported with `status = Loaded`, not active.
-- **AC-M10-10**: Import history shows all past runs with detail drilldown.
-- **AC-M10-11**: All actions respect `micro.hub.manage`.
-- **AC-M10-12**: Hub authentication failures show clear error.
-- **AC-M10-13** *(folds F1)*: When updates are available, a nav badge ("N") appears on the Hub Subscription sidenav item and a dismissible "N updates available from Hub — View" banner appears on Admin surfaces; both derive from the last check, requiring no operator polling.
-- **AC-M10-14** *(folds F2)*: A locally-customized row's full local-vs-Hub diff is viewable in the preview, and a per-row "Use Hub version (override local edit)" control lets the operator explicitly override the skip; an override is recorded as `OVERRIDDEN_LOCAL_CUSTOMIZED` in the per-record audit and clears the row's `locally_customized` flag.
-- **AC-M10-15** *(folds F3)*: For each newly-loaded breakpoint version, the import summary renders an "Activate in Breakpoint Catalog →" link that deep-links to that version in M-02 for activation; import never auto-activates.
-- **AC-M10-16** *(folds F4)*: The import summary shows a structured "{added} added, {updated} updated, {skipped} skipped (customized), {errors} errors" line drawn from `hub_import_run` counters and links to the run's per-record import history.
-
----
-
-## 7. i18n keys
-
-Estimated 45-55 keys, including the discovery banner (`admin.hub.updatesAvailable.banner`), nav badge (`admin.hub.navBadge`), override control (`admin.hub.preview.useHubVersion`), summary line (`admin.hub.import.summary`), and activation hand-off (`admin.hub.import.activateInCatalog`).
-
----
-
-## 8. Open verification items
-
-- Confirm Hub URL endpoint format and API contract (managed externally — verify with Hub maintainer team), including the shape of the "available update sets" response that drives `available_update_count`.
-- Confirm encrypted API key storage path in OE.
-- Confirm the M-02 deep-link target for "Activate in Breakpoint Catalog →" (route + version identifier).
-
----
-
-## 9. References
-
-- M-00 Microbiology Module Parent Specification
-- M-01 AMR Reference Data (consumer of organism/antibiotic/AST Panel updates)
-- M-02 Breakpoint Catalog (consumer of breakpoint updates; activation hand-off target — §8)
-- M-09 WHONET Export (consumer of WHONET code updates)
-- v1.1 AMR Configuration FRS §9 and v1.1 WHONET Integration FRS §2.3 (superseded by unified M-10)
+- `designs/admin-config/catalog-subscription.md` (v1.2) — the surviving feature.
+- M-02 Breakpoint Catalog (CSV import §7, activation §8).
+- M-01 AMR Reference Data; M-09 WHONET Export.
+- AMR R package (open-source EUCAST/CLSI interpretation + WHONET/SNOMED/LOINC crosswalk) — candidate seed/update source.

--- a/designs/microbiology/m-12-test-reagent-linkage.md
+++ b/designs/microbiology/m-12-test-reagent-linkage.md
@@ -1,11 +1,16 @@
-# M-12 Test → Reagent Linkage — Functional Requirements Specification
+# M-12 Reagent Lot at Result Entry (micro) — Functional Requirements Specification
 
-**Version:** 2.0 (consolidated — folds review edits inline; no separate addendum)
-**Date:** 2026-06-07
-**Module:** Cross-cutting OpenELIS foundation (Test Catalog admin + Reagent inventory)
-**Phase:** Pre-1A — starts before Micro Phase 1A and runs as a parallel track
-**Owner:** Test Catalog admin team (Micro is a primary consumer; chemistry, hematology, etc., also benefit)
+**Version:** 3.0 (rescoped — picker + wiring only) · **Date:** 2026-06-12
+**Module:** Microbiology result entry (consumes Test Catalog v2.5 + Inventory)
+**Phase:** with M-04 / M-05
+**Owner:** Microbiology Module (M-00 parent)
 **Status:** Draft
+
+> **⚠ SCOPE NARROWED (2026-06-12, Casey).** M-12 was over-scoped — it overlapped Test Catalog v2.5 (which owns the test↔reagent definition), the Inventory module (which owns lots + consumption), and the existing **Reagent Usage on Result Entry** design (`designs/results-validation/results-page-reagent-usage-v1.md` / `…-v2.1`) on `main`, which already establishes the lot-picker-at-result-entry pattern. **M-12 is now just two things:**
+> 1. the **shared `ReagentLotPicker`** component (FIFO, QC status, expired/locked blocked, specific errors) — reused from / consistent with the existing Reagent-Usage design, extended for micro's media / AST-card / disc lots; and
+> 2. **wiring it into M-04 Inoculation and M-05 AST Setup**, consuming `test_reagent_link` (defined by **Test Catalog v2.5, OGC-759**) and writing an **`InventoryUsage`** (Inventory module) on selection.
+>
+> **M-12 does NOT own:** the `test_reagent_link` schema or the Test Catalog **Reagents tab** (→ Test Catalog v2.5 / OGC-759); reagent **lots / consumption / traceability** (→ Inventory module — `InventoryItem`/`InventoryLot`/`InventoryUsage`, already keyed to `analysis_id`/`test_result_id`); the **reverse Reagent→Tests view** and **seed data** (→ Test Catalog / Inventory admin). Sections §3.1, §4, §6, §7 below are retained as **context for those owners**, not as M-12 build scope.
 
 > This FRS is self-contained. The AMR design-review edits — REQUIRED/OPTIONAL/SUBSTITUTE and consumption-unit helper text, specific lot-validation errors, the FIFO tooltip, the reverse Reagent→Tests view, empty states, and the Phase-1A seed tests — are written **inline** in the relevant sections below; there is no separate edits doc or addendum.
 
@@ -73,10 +78,12 @@ Define the relationship between Tests and Reagents so that:
 
 ## 3. Data model
 
-### 3.1 New tables
+### 3.1 Tables (owned by Test Catalog v2.5 / Inventory — context, NOT M-12 build scope)
+
+> `test_reagent_link` is **created and owned by Test Catalog v2.5 (OGC-759)**; M-12 only *consumes* it. The shape below is reproduced for reference so the picker contract (§5) is clear — M-12 does not run this migration.
 
 ```
-test_reagent_link
+test_reagent_link   (← built by Test Catalog v2.5 / OGC-759; M-12 consumes)
 ├── link_id (UUID PK)
 ├── test_id (FK to test catalog — existing OE table)
 ├── inventory_item_id (FK to InventoryItem — existing Inventory module; the reagent/cartridge/kit)
@@ -221,8 +228,8 @@ ReagentLotPicker(
 
 The component:
 
-1. Looks up `test_reagent_link` rows for the test_id (and optionally filtered by method).
-2. For each linkage, queries available `qc_lot` rows: status = UNLOCKED, not expired, sorted by FIFO (**oldest expiry first**).
+1. Looks up `test_reagent_link` rows for the test_id (and optionally filtered by method) — the definition owned by Test Catalog v2.5 (OGC-759).
+2. For each linkage, queries available **`InventoryLot`** rows (Inventory module): `LotStatus` ACTIVE/IN_USE (excludes EXPIRED / QUARANTINED / CONSUMED), `QCStatus` not FAILED, sorted FIFO (**oldest expiry first**). *(Reuses the Inventory module — supersedes the old `qc_lot`.)*
 3. Renders one `ComboBox` per REQUIRED linkage, plus one per OPTIONAL the user enables, and a single ComboBox per SUBSTITUTE group from which one lot is chosen.
 4. Validates selection on form submit.
 
@@ -332,7 +339,9 @@ No existing data writes are blocked by this spec — at result entry, if a test 
 
 ## 9. Acceptance criteria
 
-- **AC-M12-01**: `test_reagent_link` table created with the schema in §3.1.
+> **Scope note (v3.0):** M-12's own acceptance is **AC-M12-06, -07, -08, -11** (the `ReagentLotPicker` component + its behavior in M-04/M-05). The rest below — AC-M12-01 (table), -02 (Reagents tab), -03/-04/-05 (linkage editor), -09 (reverse view), -10/-12 (inventory/seed) — are **owned by Test Catalog v2.5 (OGC-759) / Inventory** and listed here only as the contract M-12 depends on.
+
+- **AC-M12-01** *(Test Catalog v2.5 / OGC-759)*: `test_reagent_link` table created with the schema in §3.1.
 - **AC-M12-02**: Test Catalog editor's Reagents tab shows linkages for the selected test, with an empty state for tests with no linkages (review edit R-07).
 - **AC-M12-03**: Link New modal validates all required fields; the Linkage-type radio group and Consumption-unit dropdown show downstream helper text per selection (review edit H5).
 - **AC-M12-04**: Linkage types: REQUIRED blocks save without lot, OPTIONAL doesn't, SUBSTITUTE accepts one of N.
@@ -394,9 +403,9 @@ admin.reagentInventory.currentLots.column.quantity "Quantity"
 
 ## 11. Open verification items
 
-- Confirm existing `reagent` and `qc_lot` table schemas.
-- Confirm Test Catalog v2.5's Reagents tab placeholder is empty (vs. partially filled — if partially, M-12 builds on top).
-- Confirm existing reagent inventory admin routes.
+- Confirm the existing **Inventory module** schema (`InventoryItem` / `InventoryLot` / `InventoryUsage`) — the picker reads `InventoryLot` and writes `InventoryUsage`. (Supersedes the old `reagent`/`qc_lot` check.)
+- Confirm the existing **Reagent Usage on Result Entry** component (v1 / v2.1 on `main`) so the micro `ReagentLotPicker` reuses/extends it rather than diverging.
+- Confirm Test Catalog v2.5 (OGC-759) timeline for `test_reagent_link` + the Reagents tab — M-12's picker depends on that definition existing.
 
 ---
 


### PR DESCRIPTION
Auto-opened for branch `design/micro-sync7`.

Overwrites of existing canonical paths only (no registry/MANIFEST/INDEX/mockup
changes). m-10 rewritten as RETIRED v3.0 (bespoke hub duplicated the existing
Catalog Subscription & Metadata Sync feature); m-12 rescoped to ReagentLotPicker
+ wiring; m-00/m-01/m-02/m-09 reference cleanup (Import-from-Hub → Catalog
Subscription). Jira already applied directly (OGC-795/882/884 closed, OGC-784/866
rescoped, OGC-868 deferred).

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>