### PR TITLE
Stage Programs Management v2 ref set for gallery processing

### DIFF
--- a/upload/programs-management-frs-consolidated.md
+++ b/upload/programs-management-frs-consolidated.md
@@ -1,0 +1,480 @@
+# Programs Management — Consolidated Functional Requirements Specification
+
+> **In plain language (for the dev):** A "Program" in OpenELIS is a named lab initiative — HIV Care,
+> TB DOTS, a dengue sentinel survey, a water-quality surveillance program. This rework brings the
+> Programs admin page in line with the rest of the catalog admin and modernizes it in four ways:
+> (1) every Program gets a **Domain** (Clinical / Environmental / Vector) so pickers and reports can
+> filter by it; (2) the page **moves** under Admin → Test Management where it belongs; (3) the
+> Questionnaire authoring gets a **Visual Builder ↔ JSON** switch with a **live preview**; and (4)
+> Programs get a proper **Deactivate / Reactivate** lifecycle (no hard delete). One consolidated spec,
+> version-agnostic — the implementing developer slices the work from the Epic (we don't pre-slice into
+> stories anymore).
+
+**Feature:** Programs admin rework — Domain classification, Test Management IA, Visual/JSON Questionnaire builder + live preview, and Deactivate/Reactivate lifecycle
+**Status:** Draft v2.0 (consolidated)
+**Date:** 2026-07-01
+**Supersedes:** `programs-management-frs.md` (base Domain FRS) + `programs-management-deactivate-addendum.md` (lifecycle addendum) — merged here into one source
+**Jira epic:** OGC-781 (Programs Management Rework) — **not yet in build** (In Progress/claimed, no implementation PR as of 2026-07-01); this consolidated spec replaces the phased breakdown in that epic
+**Pattern source:** OGC-748 (Test Catalog Basic Info — Domain radio group)
+**Related tickets:** OGC-361 (Lab Unit Domain), OGC-538 (SampleType Domain follow-up), OGC-189 (Lab Units Redesign), OGC-296 (Sample Type Management), OGC-527 (Env/Vector Epic)
+**Governing decisions:** D-002 (no hard delete), D-004 (Domain has no BOTH), D-005 (inline edit; modal for destructive/large), D-012 (path-segment route), D-013 (breadcrumb label drift), D-028 (one Epic per mockup; dev slices)
+
+---
+
+## Lab Context
+
+### Current State
+
+A Program is a named clinical or surveillance initiative that a country's ministry of health runs
+across the lab network — each with its own indicator set, funder reporting, and often its own
+order-entry form. Today the Programs admin is a flat list editor (name, code, description, lab-unit
+assignment, active flag), and it sits on the main Admin menu rather than with the other catalog admin
+pages. It has no field saying what *kind* of work a Program does, so an environmental
+compliance program sits in the same dropdown as a clinical HIV program at Reception. Editing a
+Program's order-entry Questionnaire is done through an "Edit JSON" toggle or a bare set of question
+cards, with no live view of what reception staff will actually see. And the only lifecycle control is
+a bare Active checkbox with no confirmation, no warning about orders in use, and no way to find a
+switched-off Program again.
+
+### Pain
+
+A reception clerk at SILNAS Indonesia enters 40–60 orders a day across clinical, environmental, and
+vector work, and must pick a Program from a dropdown of ~35 — with no way to filter — so scrolling
+wastes time and cross-domain mis-attribution happens (a water sample coded to a clinical hepatitis
+program), which corrupts both programs' indicator counts. An admin building a Program's order form
+edits raw JSON or bare cards and only discovers a field-ordering mistake when reception complains,
+because there's no preview. And when a surveillance project ends, unchecking Active silently drops the
+Program from reception's picker with no warning that 300 historical orders reference it — and because
+the Program then disappears from the list with no way back, the admin recreates it as a duplicate,
+splitting the indicator counts.
+
+### What Changes
+
+Every Program gets a **Domain** (Clinical / Environmental / Vector), set the same way as on Tests and
+Lab Units, with a list column, a list filter, and downstream filtering of the Order Entry Program
+picker — so reception sees only the ~12 programs relevant to the order's domain. The page **moves**
+under Admin → Test Management alongside the rest of the catalog admin. Questionnaire authoring gets a
+**Visual Builder ↔ JSON** content switcher with a **live "Example" preview** so admins see exactly
+what reception will see as they build. And Programs get a real **Deactivate / Reactivate** lifecycle:
+deactivating warns how many orders are affected and confirms history is preserved; the list hides
+deactivated programs by default behind a **Show deactivated** toggle; reactivating is one click, so
+duplicates stop happening. No Program is ever hard-deleted.
+
+---
+
+## Navigation & URL
+
+- **SideNav placement:** `Admin → Test Management → Programs` (moved from the main Admin menu — an IA
+  fix). SideNav-config change only; URL is unchanged, so existing bookmarks stay valid.
+- **Breadcrumb (list):** `Home / Admin Management / Test Management / Programs`
+- **Breadcrumb (editor):** `Home / Admin Management / Test Management / Programs / Add/Edit Program`
+- **Breadcrumb label quirk (D-013):** SideNav reads "Admin"; first breadcrumb reads "Admin
+  Management" — preserved live-app drift.
+- **URL (list):** `/MasterListsPage/program` — existing live path-segment (singular `program`);
+  preserved to avoid breaking deep links.
+- **Editor is INLINE, not a separate page (decision 2026-07-01, reverses the earlier "dedicated
+  page" call):** clicking **Edit** on a list row expands the full editor inline beneath the row;
+  **Add Program** opens the same editor inline at the top of the list. This matches D-005 (inline
+  row expansion for edits) and keeps the admin in one place. There is no separate `/program/<uuid>`
+  editor route; an optional deep link may open the list with a given row pre-expanded, but that is a
+  convenience, not a distinct page. The Questionnaire section's two-column editor + live preview
+  renders inside the expanded region (it is tall, so the expanded row scrolls).
+
+---
+
+## Overview
+
+Rework the Programs admin to harmonize with the rest of the catalog admin and modernize Questionnaire
+authoring, across four pillars:
+
+1. **Domain field** — CLINICAL / ENVIRONMENTAL / VECTOR on every Program; list column + filter;
+   Order Entry picker filtering.
+2. **IA move** — Programs relocates under Test Management (SideNav config; URL unchanged).
+3. **Questionnaire authoring** — `ContentSwitcher` (Visual Builder ↔ JSON), question-card overhaul
+   (auto-save on blur, OverflowMenu, inline answer-options editor), and a live "Example" preview pane.
+4. **Deactivate / Reactivate lifecycle** — confirmed deactivate with order-reference count, default
+   hide-deactivated + Show-deactivated toggle, one-click reactivate, audit — no hard delete.
+
+The FRS is **version-agnostic**. It does not pre-slice into phases or stories; the implementing
+developer slices the work from the Epic against the live code (D-028). A non-binding slicing guide is
+included at the end for orientation only.
+
+---
+
+## User Stories
+
+1. **As a lab administrator**, I want to mark each Program Clinical / Environmental / Vector so Programs
+   behaves like the rest of the catalog and downstream pickers can filter accurately.
+2. **As a reception clerk** entering an environmental order, I want the Program picker to show only
+   Environmental programs so I stop coding a water sample to a clinical program.
+3. **As a lab administrator**, I want to filter the Programs list by Domain and by active/deactivated
+   so I can audit the catalog without scrolling past irrelevant rows.
+4. **As a lab administrator**, I want to author a Program's order form either by pasting FHIR
+   Questionnaire JSON or by building questions visually, and see a **live preview** of what reception
+   will see.
+5. **As a lab administrator** retiring a program, I want to **deactivate** it with a confirmation that
+   tells me how many orders reference it and that history is preserved — and **reactivate** it in one
+   click if needed — so I never silently break the picker or create a duplicate.
+6. **As an auditor**, I want Domain changes and deactivate/reactivate recorded in the audit trail, so
+   program lifecycle and classification changes are traceable for accreditation.
+
+---
+
+## Functional Requirements
+
+### Domain classification
+
+**FR-1 — Domain field on the Program record.** Add a `domain` column to `program`:
+`ENUM('CLINICAL','ENVIRONMENTAL','VECTOR')`, not nullable (backfilled — FR-7). No schema default.
+
+**FR-2 — Domain radio group (Basic Info).** Required Carbon `RadioButtonGroup` labeled "Domain" with
+Clinical / Environmental / Vector. Save disabled until selected; nothing pre-selected for a new
+Program; exactly one selection (no BOTH — D-004); placed under Name/Code/Description, above lab-unit
+assignment.
+
+**FR-3 — Domain change confirmation (existing Program).** Changing the saved Domain opens a
+confirmation modal (copy mirrors OGC-748): historical orders were evaluated against the prior domain's
+rules; the change is forward-looking and does not re-code past orders. New (unsaved) Programs don't
+trigger it.
+
+**FR-4 — Domain column in the list.** Between Name and Lab Unit, a sortable Carbon `Tag` column:
+Clinical → `blue`, Environmental → `green`, Vector → `purple`.
+
+**FR-5 — Domain filter on the list.** A Carbon `MultiSelect` labeled "Domain" (Clinical / Environmental
+/ Vector); empty = all; combines via AND with Name/Code search and the Show-deactivated toggle
+(FR-19); session-persistent, resets on logout.
+
+**FR-6 — Order Entry Program picker filtered by order Domain.** At Step 1, the picker shows only
+Programs where `domain = <order domain>` AND `active = true`. Domain-specific empty-state messages
+(e.g. "No Clinical programs are currently active…"). No BOTH; orders carry exactly one domain.
+
+**FR-7 — Migration backfill.** Add `domain` nullable; backfill existing rows to `CLINICAL`; alter to
+NOT NULL; emit a one-time post-upgrade banner ("Programs upgraded — all defaulted to Clinical. Review
+and re-classify Environmental/Vector programs.").
+
+**FR-8 — Audit (Domain).** `PROGRAM_DOMAIN_UPDATED` on every Domain change of a persisted Program
+(`{from, to, program_code}`, actor, timestamp). Create rides the existing `PROGRAM_CREATED` payload.
+Migration backfill emits one `PROGRAM_DOMAIN_BACKFILLED_BY_MIGRATION` attributed to `SYSTEM_MIGRATION`.
+
+**FR-9 — Envers.** `Program` is `@Audited`; confirm the new `domain` column is tracked (no field-level
+exclusion).
+
+### Editor & Questionnaire authoring
+
+**FR-10 — Inline editor layout.** The editor renders inline (row expansion for Edit; a panel at the
+top of the list for Add). Top-to-bottom: an at-a-glance guidance intro → Basic Info → Domain →
+Lifecycle (edit only) → Questionnaire (two-column: editor left, live "Example" preview right) → Save /
+Cancel (Save disabled until Domain selected and form valid). The label "Example" is the **rendered
+preview pane** (FR-13.5), not a free-text input.
+
+**FR-10.1 — Basic Info fields (Code and UUID not surfaced).** Basic Info shows only **Program Name**
+(with helper: the name reception sees at order entry) and **Lab unit(s)** (FR-10.2). The program's
+**`code` and `uuid` are system-managed and are NOT shown in the editor or the list** (decision
+2026-07-01) — they remain on the record (and in the API) but are not user-facing fields. This removes
+the live-app confusion of a raw `program.name.program`-labelled Code field and an internal UUID.
+
+**FR-10.2 — Lab unit(s) is a multi-select with Select-all.** A Program may be run by more than one lab
+unit, so the single "Test Section" control becomes a **multi-select** (Carbon `FilterableMultiSelect`)
+labelled **"Lab unit(s)"** with a **Select all** affordance. **Data-model dependency (D-009):** the
+current `program`→lab-unit link is single-valued (one `test_section`); supporting multiple units
+requires a **`program_lab_unit` junction table** (many-to-many). This is a **named new dependency** —
+flag at build; the Order Entry Program picker (FR-6) filters by Domain, not by lab unit, so it is
+unaffected. Label is "Lab unit" everywhere (the term "Test Section" is retired from this UI).
+
+**FR-11 — Mode switch (ContentSwitcher).** Carbon `ContentSwitcher` with two equal segments —
+**Visual Builder** (default) and **JSON**. Replaces the legacy Edit JSON `Toggle`. One mode visible at
+a time; underlying store is one FHIR Questionnaire resource; switching round-trips through it. JSON →
+Visual Builder prompts before discarding unsaved/invalid JSON.
+
+**FR-11.1 — Round-trip limits.** Lossless only for the GUI-supported subset (`linkId`, `text`, `type`,
+`answerOption[]` for Choice/Checkbox). Advanced FHIR features (`enableWhen`, `repeats`, nested
+`item[]`, `required`, `readOnly`, `initial[]`, `code[]`, extensions) are preserved verbatim and shown
+as read-only "advanced" cards steering the admin to JSON mode. (Catalyst, OGC-113, is the future
+assistive path — not a dependency here; D-023.)
+
+**FR-12 — JSON mode validation.** Validate button parses JSON, checks FHIR Questionnaire R4 shape
+(`resourceType === 'Questionnaire'`, `item[]`, each item has `linkId`/`text`/`type` from the allowed
+enum); inline Carbon `InlineNotification` error (with reason) or success ("Validated — N questions").
+Submit disabled until valid.
+
+**FR-13 — Visual Builder cards.** Questionnaire id input; repeating Question cards (Carbon `Tile`) with
+Question Text, Question Type (`Select`, 10 FHIR item.type values — FR-15), answer-options sub-section
+for Choice/Checkbox (FR-14), and an `OverflowMenu` (⋮) with Delete (Modal-confirmed). **No per-card
+Save** — inputs commit to in-memory state on blur; the page Submit persists in one transaction. No
+"draft" visual treatment. "Add New Question" seeds "New Field" + Type "String".
+
+**FR-14 — Answer-options editor (Choice/Checkbox).** Repeating `TextInput` rows + per-row ghost delete
+`IconButton` + "+ Add option"; empty-state placeholder; persists to `answerOption[]` as
+`{valueString}`; switching Type away preserves the array; imported `valueCoding` renders read-only with
+a "(coded)" badge (edit in JSON).
+
+**FR-15 — Question Type enum.** Exactly 10 values, this order: Boolean, Choice, Checkbox, Integer,
+Decimal, Date, Time, String, Text, Quantity. Default String.
+
+**FR-15.3 — Quantity units are extension-defined (JSON-only).** A `quantity` answer is a number **plus
+a unit**, but FHIR R4 does not put the unit on the bare `item.type`: the allowed unit(s) come from the
+`questionnaire-unit` (one fixed unit) or `questionnaire-unitOption` (a choice list) extension on the
+item — and *"in the absence of either, any unit is valid."* Those extensions are outside the Visual
+Builder's editable subset (FR-11.1), so a Quantity question authored purely in the Visual Builder is
+**unit-unconstrained** (accepts any unit). To fix or offer units, author them in **JSON mode**. The
+live preview renders a Quantity as a number input + a unit control to make the unit's presence obvious;
+the guidance/example text states the unit is set via the extension in JSON. (Source: FHIR R4
+questionnaire-unit / -unitOption extensions.)
+
+**FR-13.5 — Live "Example" preview pane.** Right of the editor, renders the questionnaire read-only as
+reception will see it. Visual Builder: updates immediately (text debounced ~200ms). JSON: updates only
+after a successful Validate, with a "Preview reflects last validated JSON. Validate to refresh." caption
+when dirty. Each Type maps to the correct read-only Carbon control; empty-state placeholder; scrolls
+independently. Does not exercise `enableWhen`/`repeats`/nested items in v-scope.
+
+**FR-16 — On-screen guidance.** Domain "What does each Domain mean?" disclosable; dismissible
+Questionnaire dual-path info banner (persist dismissal in `user_preference`); non-dismissible JSON
+reference card (format line + 10 item.type chips + LLM-authoring tip); GUI empty-state Tile; per-Type
+example sentence under the Type dropdown. All i18n-wrapped under `admin.programs.guidance.*`.
+
+**FR-17 — i18n leak fix.** Replace the leaking raw keys `program.name.program` / `program.name.code`
+with proper labels + fallbacks so raw keys never render.
+
+### Lifecycle — Deactivate / Reactivate (No Hard Delete — D-002)
+
+**FR-18 — Lifecycle state.** The existing `program.active` boolean is the lifecycle state: **Active**
+(`true`) or **Deactivated** (`false`). There is **no hard-delete path** — the editor and list expose
+Deactivate / Reactivate only.
+
+**FR-18.1 — Deactivate action.** In the list row `OverflowMenu` (⋮) and in the editor Basic Info
+(status `Tag` + a `Button kind="danger--tertiary"`). The bare Active checkbox is retired in favor of
+this explicit, labeled control.
+
+**FR-18.2 — Deactivate confirmation (with order count).** Opens a confirmation `Modal`:
+> **Deactivate this Program?** "{programName}" will stop appearing in the order-entry Program picker
+> for new orders. Its {orderCount} historical order(s) keep their program coding and all indicator
+> counts are preserved. You can reactivate it any time from the Programs list. [Cancel] [Deactivate]
+
+`{orderCount}` is a read-time indexed count (`sample`/`order` by `program_id`); if unavailable, the
+modal degrades to generic copy without blocking. Zero-order case uses "This Program has no orders…".
+
+**FR-18.3 — Reactivate.** From the row `OverflowMenu` / editor (visible when Show-deactivated is on).
+**Not** modal-gated (non-destructive, reversible); shows a success `InlineNotification`; the Program
+returns to the domain-filtered order picker (FR-6).
+
+**FR-19 — List defaults to hiding deactivated + Show-deactivated toggle.** The list hides deactivated
+Programs by default (D-002). A Carbon `Toggle` "Show deactivated" in the toolbar reveals them (rows
+muted, "Inactive" `gray` Tag). Combines via AND with Name/Code search and the Domain filter (FR-5);
+session-persistent, resets on logout. (This is the resolution of the "active/inactive" filter — a
+default-hide toggle, not a neutral show-all filter.)
+
+**FR-19.1 — Status column.** An "Active" status column (sortable) after the Domain column: Active →
+`green` "Active"; Deactivated → `gray` "Inactive".
+
+**FR-20 — Audit (lifecycle).** `PROGRAM_DEACTIVATED` (`{program_code, orderCount, actor}`) and
+`PROGRAM_REACTIVATED` (`{program_code, actor}`). Envers already tracks `active` on the `@Audited`
+entity.
+
+---
+
+## Permissions & Audit
+
+- **Role attachment:** the existing **Admin** role bundle (binary admin bit) grants all Programs admin
+  actions, including Deactivate / Reactivate. **Test Catalog Manager does NOT** grant Programs access
+  (documented exception, scoped to Test Catalog). No new permission keys (D-006).
+- **Audit events:** `PROGRAM_DOMAIN_UPDATED`, `PROGRAM_DEACTIVATED`, `PROGRAM_REACTIVATED`, plus the
+  migration backfill event. No read auditing.
+- **Envers:** `Program` `@Audited`; `domain` and `active` tracked.
+
+---
+
+## Data Model
+
+### Existing entities reused
+
+- **`program`** — reused. Stores the Questionnaire as a FHIR Questionnaire resource (confirm exact
+  storage shape at build); no structural change to Questionnaire storage. Reuses existing `active`.
+- **`audit_trail`** — reused for the events above.
+- **FHIR Questionnaire (R4)** — reused; item types restricted to the 10-value enum (FR-15).
+- **Domain enum** — canonical `CLINICAL / ENVIRONMENTAL / VECTOR`; no BOTH anywhere (D-004).
+
+### New columns
+
+| Table | Column | Type | Nullable | Default | Notes |
+|---|---|---|---|---|---|
+| `program` | `domain` | `ENUM('CLINICAL','ENVIRONMENTAL','VECTOR')` | NOT NULL (post-migration) | none | backfilled to `CLINICAL` |
+
+**New junction (FR-10.2 — multi lab unit):** a **`program_lab_unit`** table (`program_id`,
+`test_section_id`) to support a Program serving multiple lab units (many-to-many), replacing the
+single-valued link. Named new dependency; migrate existing single assignments into one junction row
+each. `{orderCount}` (FR-18.2) is a read-time count, not stored.
+
+**Not surfaced (FR-10.1):** `program.code` and the program UUID remain on the record and in the API but
+are **not** shown in the editor or list — no schema change, a UI-visibility decision only.
+
+---
+
+## API & Data Reuse (D-029 — reuse the existing Program backend; do not rebuild it)
+
+The Programs admin already has a working backend — **reuse it.** Confirm exact paths against the repo
+before build (`ProgramController` / the React admin's `getFromOpenElisServer` calls); the known/likely
+endpoints:
+
+| Operation | Method + path | Status |
+|---|---|---|
+| Create / update a Program (incl. Questionnaire) | `POST /rest/program` | **Existing** — `ProgramController.createProgram` (persists the record, then the FHIR Questionnaire via `fhirPersistanceService`). Reuse; add `domain` + `active` + `labUnits[]` to the payload additively. |
+| List Programs | `GET /rest/program` (or the Master List program feed) | **Existing — confirm exact path.** Reuse; add `domain`/`active` to the response additively; the Domain filter + Show-deactivated are server-side query params. |
+| Order-Entry Program picker feed | existing Step-1 programs call | **Existing.** FR-6 adds a server-side `domain = <order domain> AND active = true` filter to the same call — no new endpoint. |
+| Deactivate / Reactivate | reuse the Program update path (`active` flag on `POST /rest/program`) | **Existing** — lifecycle is a field update, **not** a new endpoint. |
+
+**New endpoints: none required.** Domain, lifecycle, and multi-lab-unit all ride on the existing
+Program create/update + list calls (additive fields). The only new *data* is the `program.domain`
+column and the `program_lab_unit` junction (Data Model). If build discovers the list/picker path
+differs, record it here — do not assume a new controller.
+
+---
+
+## i18n reuse (D-029 — keep translation cost down)
+
+Before adding any key below, reuse an existing one with the same English. **Common labels reuse the
+shared namespace** — do **not** mint program-scoped versions: **Cancel, Search, Yes, No, Domain
+(shared with Test/Lab Unit), Clinical / Environmental / Vector** (shared Domain value labels already
+exist from OGC-748/OGC-361), and the status words **Active / Inactive**. The Domain radio, list column,
+filter, and value tags should all pull the **same** Domain keys the Test Catalog and Lab Unit editors
+use — one Domain vocabulary across the catalog, translated once. Truly new keys here are the
+Programs-specific guidance, questionnaire-builder, and deactivate-modal strings. Mark each key
+**Reuse**/**New** in the Localization table and keep the New count minimal.
+
+---
+
+## Dependencies
+
+1. **OGC-748** (Test Catalog Domain) — pattern source (radio, modal copy, i18n naming).
+2. **OGC-361** (Lab Unit Domain) — sibling; same enum/pattern; ship in the same release for harmony.
+3. **OGC-538** (SampleType Domain) — separate follow-up to migrate `Both` → 3-value enum; FR-6 does
+   **not** depend on SampleType Domain values, so specs ship independently.
+4. **OGC-189** (Lab Units Redesign) — visual-parity reference.
+5. **Order Entry Step 1** — sets the order's Domain; FR-6 is a server-side filter on the Programs API
+   from that step. No UI change to Step 1 itself.
+
+---
+
+## Slicing guidance (non-binding — the dev slices from the Epic; D-028)
+
+This spec is **not** pre-sliced into stories. Per current policy, the Epic (OGC-781) is the unit of
+handoff and the implementing developer slices PR-sized increments from it against the live code. For
+orientation only, natural seams a dev might use — each an independently shippable, dependency-ordered
+slice, sized to a reviewable PR:
+
+- **Domain harmonization** — schema + backfill + Basic Info radio + change modal + list column/filter
+  + Order Entry picker filter + the IA move. Ships the domain value end-to-end on its own.
+- **Deactivate / Reactivate lifecycle** — status column + Show-deactivated toggle (default hide) +
+  deactivate confirm w/ order count + reactivate + audit. Independent of the editor modernization.
+- **Questionnaire editor modernization** — ContentSwitcher + Visual Builder auto-save cards +
+  OverflowMenu + JSON validate + guidance + i18n-leak fix.
+- **Live preview + answer-options + round-trip safety** — the "Example" pane, Choice/Checkbox options
+  editor, and FHIR advanced-feature preservation.
+
+Cross-cutting concerns (i18n keys, audit entries, Envers, role attachment) belong to whichever slice
+introduces them — not separate slices.
+
+---
+
+## Acceptance Criteria
+
+Domain: [ ] radio required in Basic Info · [ ] Save disabled until Domain chosen (new) · [ ] change
+modal on existing · [ ] Cancel no-save / Confirm writes audit · [ ] sortable colored Tag column ·
+[ ] MultiSelect filter (server-side, AND with search + Show-deactivated) · [ ] Order Entry picker
+filters by order Domain · [ ] domain-specific empty states · [ ] migration backfills to CLINICAL + NOT
+NULL · [ ] post-upgrade banner once · [ ] `PROGRAM_DOMAIN_UPDATED` payload · [ ] Envers tracks Domain ·
+[ ] REST adds `domain` additively.
+
+Editor/Questionnaire: [ ] editor order per FR-10 · [ ] ContentSwitcher replaces Toggle, one mode
+visible · [ ] mode-switch discards prompt · [ ] Validate JSON w/ inline error/success · [ ] cards:
+Text + Type + OverflowMenu, default String · [ ] blur-commit, no per-card Save, no draft styling ·
+[ ] 10 Types in order · [ ] Add New Question focuses text · [ ] Delete modal-confirmed · [ ] answer
+options for Choice/Checkbox, preserve on Type-switch, "(coded)" read-only · [ ] round-trip lossless for
+supported subset · [ ] live "Example" preview updates per mode rules + non-interactive + empty-state +
+independent scroll · [ ] guidance affordances + per-user banner dismissal · [ ] i18n leaks fixed ·
+[ ] all strings i18n-wrapped.
+
+Lifecycle: [ ] list hides deactivated by default · [ ] Show-deactivated toggle (AND with filters,
+session-persistent) · [ ] sortable green/gray status column · [ ] Deactivate in row menu + editor ·
+[ ] deactivate modal shows order count / history-preserved · [ ] modal degrades gracefully + zero-order
+copy · [ ] Cancel no-op / Deactivate writes `PROGRAM_DEACTIVATED` and drops from default list ·
+[ ] Reactivate (non-modal) restores + success notice + `PROGRAM_REACTIVATED` + returns to picker ·
+[ ] no hard-delete control anywhere · [ ] lifecycle strings i18n-wrapped.
+
+---
+
+## i18n keys
+
+The consolidated key set merges the Domain/editor/guidance keys from the base FRS
+(`admin.programs.*`, `admin.programs.basicInfo.domain.*`, `admin.programs.questionnaire.*`,
+`admin.programs.guidance.*`, `breadcrumb.*`, `orderEntry.programPicker.empty.*`) with the lifecycle
+keys below. All require English fallbacks before merge (Principle VII); other languages follow the
+translation cycle.
+
+| Key | English fallback |
+|---|---|
+| `admin.programs.list.column.active` | Active |
+| `admin.programs.list.status.active` | Active |
+| `admin.programs.list.status.inactive` | Inactive |
+| `admin.programs.list.toggle.showDeactivated` | Show deactivated |
+| `admin.programs.action.deactivate` | Deactivate |
+| `admin.programs.action.reactivate` | Reactivate |
+| `admin.programs.deactivate.modal.title` | Deactivate this Program? |
+| `admin.programs.deactivate.modal.body` | "{programName}" will stop appearing in the order-entry Program picker for new orders. Its {orderCount} historical order(s) keep their program coding and all indicator counts are preserved. You can reactivate it at any time from the Programs list. |
+| `admin.programs.deactivate.modal.body.noOrders` | This Program has no orders and will simply stop appearing for new orders. You can reactivate it at any time. |
+| `admin.programs.deactivate.modal.confirm` | Deactivate |
+| `admin.programs.deactivate.modal.cancel` | Cancel |
+| `admin.programs.reactivate.success` | {programName} reactivated |
+
+> The full Domain/editor/guidance i18n table (200+ keys) carries over unchanged from the base FRS —
+> reproduce it verbatim in the implementation; it is not re-listed here to keep this consolidated
+> document readable. The lifecycle keys above are additive to it.
+
+---
+
+## Out of Scope
+
+- Catalyst LLM assistance for Questionnaire authoring (OGC-70 / OGC-113) — future; no work here.
+- Program indicator definitions and funder report bindings.
+- Multi-domain Programs / a BOTH value — a Program serves exactly one Domain (two Programs with a
+  shared code prefix if needed).
+- Programs editor multi-tab redesign (mirror of OGC-189) — future FRS.
+- Per-Program lab-unit Domain enforcement — admin discretion in v-scope.
+- Bulk deactivate/reactivate; cascade lifecycle from lab-unit; scheduled auto-deactivation (no
+  end-date field exists).
+
+---
+
+## Reference set (one coherent handoff for Claude Code)
+
+This feature ships as **one reference set** — a single implementer works all of it from these three
+files together (the implementer is Claude Code, so a consolidated set beats scattered docs):
+
+1. **Spec:** `programs-management-frs-consolidated.md` (this file)
+2. **Mockup:** `programs-management-v2-mockup.jsx` (Carbon; all four pillars incl. the new lifecycle)
+3. **Preview:** `programs-management-v2-preview.html` (interactive; list + editor views)
+
+These supersede the base `programs-management-frs.md`, the `programs-management-deactivate-addendum.md`,
+and the older `programs-management-mockup.jsx`/`-preview.html` — do not hand those off separately.
+
+## Handoff Media
+
+| Asset | Type | Path | Shows |
+|---|---|---|---|
+| `programs-management-v2-preview.html` | interactive preview | workspace | target UI — list (Domain col, status, Show-deactivated toggle, Deactivate/Reactivate, confirm modal) + editor (Domain radio, lifecycle control, ContentSwitcher, live Example preview) |
+| `programs-management-v2-mockup.jsx` | Carbon mockup | workspace | implementation reference for the above |
+| `handoff-programs-before/01-programs-list-current.png` | live "before" screenshot | `OpenELIS QA/docs-media/handoff-programs-before/` | current Program editor — captures the pain the FRS fixes: the raw `program.name.program` i18n leak used as a label (FR-17), the legacy "Edit Json" toggle (FR-11 replaces with ContentSwitcher), the "Example" preview label (FR-13.5), **no Domain field** (FR-2), and the misplaced "Program Entry" main-menu location + "Admin Management" breadcrumb (the IA move) |
+| `handoff-programs-before/walkthrough.webm` | clip | same folder | navigation through the current editor |
+
+Captured live from testing.openelis-global.org (v3.2.1.10) on 2026-07-01 via the openelis-screenshots
+harness. Media is not committed by default; publish by copying into the gallery/Epic attachment.
+
+---
+
+## Mockup note
+
+The companion mockup (`programs-management-mockup.jsx` / the committed
+`designs/admin-config/programs-management.jsx`) predates the lifecycle work and must gain: the
+**Active status column**, the **Show-deactivated `Toggle`** in the table toolbar, the row
+**OverflowMenu Deactivate/Reactivate** actions, the **deactivate confirmation Modal** (with order
+count), and the editor Basic-Info **status Tag + Deactivate/Reactivate control** replacing the bare
+Active checkbox. The HTML preview should echo these so reviewers see the lifecycle affordances.

--- a/upload/programs-management-v2-mockup.jsx
+++ b/upload/programs-management-v2-mockup.jsx
@@ -1,0 +1,308 @@
+// Route: /MasterListsPage/program   (edit + add happen INLINE on this list — no separate editor page)
+// SideNav: Admin → Test Management → Programs
+// FRS: programs-management-frs-consolidated.md  (this is the v2 consolidated ref set)
+// Reference set (one coherent handoff for Claude Code):
+//   - programs-management-frs-consolidated.md   (spec)
+//   - programs-management-v2-mockup.jsx          (this file)
+//   - programs-management-v2-preview.html        (interactive preview)
+//
+// Version-agnostic (dev slices from the Epic, D-028). Four pillars:
+//   Domain classification · Test Management IA · inline editor (ContentSwitcher + live preview) ·
+//   Deactivate/Reactivate lifecycle (no hard delete, D-002).
+// UI decisions folded in from review (2026-07-01):
+//   - Edit + Add are INLINE (row expansion / top panel), not a separate page/tab (D-005).
+//   - Code and UUID are system-managed and NOT surfaced in the UI.
+//   - "Lab unit(s)" is a multi-select with Select-all (a program can serve several units).
+//   - Heavy on-screen guidance for an IT admin (intro, per-field helpers, domain explainer).
+//   - Quantity: unit comes from a FHIR unit/unitOption extension (JSON-only, not the Visual Builder).
+
+import React, { useState, useMemo } from 'react';
+import {
+  Grid, Column, Stack,
+  DataTable, TableContainer, Table, TableHead, TableRow, TableHeader, TableBody, TableCell,
+  TableExpandHeader, TableExpandRow, TableExpandedRow,
+  TableToolbar, TableToolbarContent, TableToolbarSearch,
+  RadioButtonGroup, RadioButton, Select, SelectItem, TextInput, TextArea, MultiSelect,
+  FilterableMultiSelect, Toggle, ContentSwitcher, Switch, Button, IconButton, Tag, Modal,
+  InlineNotification, Tile, Breadcrumb, BreadcrumbItem, OverflowMenu, OverflowMenuItem,
+} from '@carbon/react';
+import { Add, TrashCan } from '@carbon/icons-react';
+
+const t = (key, fallback) => fallback || key;
+const DOMAIN_TAG = { CLINICAL: 'blue', ENVIRONMENTAL: 'green', VECTOR: 'purple' };
+const domainLabel = (d) => ({ CLINICAL: 'Clinical', ENVIRONMENTAL: 'Environmental', VECTOR: 'Vector' }[d]);
+const LAB_UNITS = ['Serology', 'Microbiology', 'Hematology', 'Chemistry', 'Entomology', 'Environmental Lab'];
+const QUESTION_TYPES = ['boolean','choice','checkbox','integer','decimal','date','time','string','text','quantity'];
+const TYPE_EXAMPLE = {
+  boolean: 'Yes/no answer. Example: "First antenatal visit?"',
+  choice: 'One option from a fixed list. Example: "Specimen condition".',
+  checkbox: 'Multiple options can be selected. Example: "Symptoms present".',
+  integer: 'Whole numbers only. Example: "Gestational age (weeks)".',
+  decimal: 'Numbers with decimals. Example: "Maternal weight (kg)".',
+  date: 'Calendar date. Example: "Date of last menstrual period".',
+  time: 'Time of day. Example: "Time of sample collection".',
+  string: 'Short free-text. Example: "Provider name".',
+  text: 'Long free-text. Example: "Clinical notes".',
+  // Quantity's unit is defined by a FHIR unit/unitOption extension, editable only in JSON mode:
+  quantity: 'A number plus a unit (e.g. "Volume collected — 5 mL"). The allowed unit(s) come from a FHIR extension set in JSON mode; a GUI-only Quantity accepts any unit.',
+};
+
+const SEED = [
+  { id: 1, name: 'HIV Treatment Cohort', code: 'HIV-TX-01', domain: 'CLINICAL', units: ['Serology'], active: true, orders: 1247 },
+  { id: 2, name: 'TB DOTS Surveillance', code: 'TB-DOTS-02', domain: 'CLINICAL', units: ['Microbiology'], active: true, orders: 842 },
+  { id: 3, name: 'Water Quality — Lake Toba', code: 'ENV-WQ-11', domain: 'ENVIRONMENTAL', units: ['Environmental Lab'], active: true, orders: 311 },
+  { id: 4, name: 'Dengue Sentinel — Jakarta', code: 'VEC-DEN-04', domain: 'VECTOR', units: ['Entomology'], active: true, orders: 196 },
+  { id: 5, name: 'HBV Antenatal Screening', code: 'HBV-ANC-01', domain: 'CLINICAL', units: ['Serology', 'Chemistry'], active: true, orders: 520 },
+  { id: 6, name: 'Malaria Pilot (2024) — closed', code: 'VEC-MAL-99', domain: 'VECTOR', units: ['Entomology'], active: false, orders: 74 },
+];
+
+export default function ProgramsManagement() {
+  const [rows, setRows] = useState(SEED);
+  const [query, setQuery] = useState('');
+  const [domains, setDomains] = useState([]);
+  const [showDeactivated, setShowDeactivated] = useState(false);   // FR-19: hide deactivated by default
+  const [expandedId, setExpandedId] = useState(null);
+  const [adding, setAdding] = useState(false);
+  const [confirm, setConfirm] = useState(null);
+  const [notice, setNotice] = useState(null);
+
+  const visible = useMemo(() => rows.filter((r) =>
+    (showDeactivated || r.active) &&
+    (domains.length === 0 || domains.includes(r.domain)) &&
+    r.name.toLowerCase().includes(query.toLowerCase())
+  ), [rows, showDeactivated, domains, query]);
+
+  const deactivate = () => { setRows((rs) => rs.map((r) => (r.id === confirm.id ? { ...r, active: false } : r))); setNotice(`"${confirm.name}" deactivated — historical orders preserved`); setConfirm(null); setExpandedId(null); };
+  const reactivate = (r) => { setRows((rs) => rs.map((x) => (x.id === r.id ? { ...x, active: true } : x))); setNotice(`${r.name} reactivated`); };
+
+  return (
+    <Grid fullWidth>
+      <Column lg={16}>
+        <Breadcrumb noTrailingSlash style={{ marginBottom: '1rem' }}>
+          <BreadcrumbItem href="#">{t('breadcrumb.home', 'Home')}</BreadcrumbItem>
+          <BreadcrumbItem href="#">{t('breadcrumb.adminManagement', 'Admin Management')}</BreadcrumbItem>
+          <BreadcrumbItem href="#">{t('breadcrumb.testManagement', 'Test Management')}</BreadcrumbItem>
+          <BreadcrumbItem isCurrentPage>{t('breadcrumb.admin.programs', 'Programs')}</BreadcrumbItem>
+        </Breadcrumb>
+        <h3>{t('admin.programs.title', 'Programs')}</h3>
+        <p style={{ color: 'var(--cds-text-secondary)' }}>The initiatives that orders are filed under — each with a domain, one or more lab units, and an optional order-entry questionnaire.</p>
+
+        {/* At-a-glance guidance for the admin (FR-16) */}
+        <InlineNotification kind="info" lowContrast hideCloseButton title={t('admin.programs.guidance.page.title', 'How this page works')}
+          subtitle="Each row is a Program. Click Edit to configure it inline (no separate page). The ⋮ menu deactivates a program (stops it appearing for new orders but keeps its history) or reactivates it. Deactivated programs are hidden by default — flip Show deactivated to see them. Add Program opens an inline editor at the top." />
+
+        {notice && <InlineNotification kind="success" lowContrast title={notice} onCloseButtonClick={() => setNotice(null)} />}
+
+        <TableContainer title="" description="">
+          <TableToolbar>
+            <TableToolbarContent>
+              <TableToolbarSearch persistent placeholder={t('admin.programs.search', 'Search by name')} onChange={(e) => setQuery(e.target.value)} />
+              <div style={{ minWidth: 220 }}>
+                <MultiSelect id="domain-filter" label={t('admin.programs.list.filter.domain.label', 'Domain')} size="lg"
+                  items={['CLINICAL', 'ENVIRONMENTAL', 'VECTOR']} itemToString={domainLabel}
+                  onChange={({ selectedItems }) => setDomains(selectedItems)} />
+              </div>
+              <Toggle id="show-deactivated" size="sm" labelText="" labelA={t('admin.programs.list.toggle.showDeactivated', 'Show deactivated')}
+                labelB={t('admin.programs.list.toggle.showDeactivated', 'Show deactivated')} toggled={showDeactivated} onToggle={setShowDeactivated} />
+              <Button renderIcon={Add} onClick={() => { setAdding((a) => !a); setExpandedId(null); }}>{adding ? t('button.close', 'Close') : t('admin.programs.add', 'Add Program')}</Button>
+            </TableToolbarContent>
+          </TableToolbar>
+
+          {/* Inline "Add new" editor at the top */}
+          {adding && (
+            <Tile style={{ borderLeft: '3px solid var(--cds-interactive)', margin: '0 0 4px' }}>
+              <h4>{t('admin.programs.selector.new', 'New Program')}</h4>
+              <ProgramEditor isNew onClose={() => setAdding(false)} />
+            </Tile>
+          )}
+
+          <Table>
+            <TableHead><TableRow>
+              <TableExpandHeader />
+              <TableHeader>{t('admin.programs.list.column.name', 'Name')}</TableHeader>
+              <TableHeader>{t('admin.programs.list.column.domain', 'Domain')}</TableHeader>
+              <TableHeader>{t('admin.programs.list.column.active', 'Status')}</TableHeader>
+              <TableHeader>{t('admin.programs.list.column.units', 'Lab unit(s)')}</TableHeader>
+              <TableHeader />
+            </TableRow></TableHead>
+            <TableBody>
+              {visible.map((r) => (
+                <React.Fragment key={r.id}>
+                  <TableExpandRow isExpanded={expandedId === r.id} onExpand={() => setExpandedId(expandedId === r.id ? null : r.id)}
+                    ariaLabel="Edit program" style={r.active ? undefined : { color: 'var(--cds-text-disabled)' }}>
+                    <TableCell>{r.name}</TableCell>
+                    <TableCell><Tag type={DOMAIN_TAG[r.domain]}>{domainLabel(r.domain)}</Tag></TableCell>
+                    <TableCell>{r.active ? <Tag type="green">{t('admin.programs.list.status.active', 'Active')}</Tag> : <Tag type="gray">{t('admin.programs.list.status.inactive', 'Inactive')}</Tag>}</TableCell>
+                    <TableCell>{r.units.join(', ')}</TableCell>
+                    <TableCell>
+                      <OverflowMenu aria-label="Program actions" flipped>
+                        {r.active
+                          ? <OverflowMenuItem isDelete itemText={t('admin.programs.action.deactivate', 'Deactivate')} onClick={() => setConfirm(r)} />
+                          : <OverflowMenuItem itemText={t('admin.programs.action.reactivate', 'Reactivate')} onClick={() => reactivate(r)} />}
+                      </OverflowMenu>
+                    </TableCell>
+                  </TableExpandRow>
+                  {expandedId === r.id && (
+                    <TableExpandedRow colSpan={6}>
+                      <ProgramEditor row={r} onClose={() => setExpandedId(null)} onDeactivate={() => setConfirm(r)} onReactivate={() => reactivate(r)} />
+                    </TableExpandedRow>
+                  )}
+                </React.Fragment>
+              ))}
+            </TableBody>
+          </Table>
+        </TableContainer>
+
+        {confirm && (
+          <Modal open danger modalHeading={t('admin.programs.deactivate.modal.title', 'Deactivate this Program?')}
+            primaryButtonText={t('admin.programs.deactivate.modal.confirm', 'Deactivate')} secondaryButtonText={t('admin.programs.deactivate.modal.cancel', 'Cancel')}
+            onRequestClose={() => setConfirm(null)} onRequestSubmit={deactivate}>
+            <p>"{confirm.name}" will stop appearing in the order-entry Program picker for new orders. Its {confirm.orders.toLocaleString()} historical order(s) keep their program coding and all indicator counts are preserved. You can reactivate it at any time from the Programs list.</p>
+          </Modal>
+        )}
+      </Column>
+    </Grid>
+  );
+}
+
+// Inline editor — identical whether adding or editing. Code/UUID are system-managed (not shown).
+function ProgramEditor({ row, isNew, onClose, onDeactivate, onReactivate }) {
+  const [domain, setDomain] = useState(row ? row.domain : '');
+  const [units, setUnits] = useState(row ? row.units : []);
+  const [showDomainHelp, setShowDomainHelp] = useState(false);
+  const [mode, setMode] = useState(0); // 0 Visual, 1 JSON
+  const [questions, setQuestions] = useState(isNew ? [] : [
+    { id: 1, text: 'First antenatal visit?', type: 'boolean', options: [] },
+    { id: 2, text: 'Specimen condition', type: 'choice', options: ['Acceptable', 'Compromised', 'Rejected'] },
+  ]);
+  const setQ = (id, patch) => setQuestions((qs) => qs.map((q) => (q.id === id ? { ...q, ...patch } : q)));
+  const active = row ? row.active : true;
+
+  return (
+    <Stack gap={5} style={{ padding: '0.5rem 0' }}>
+      <InlineNotification kind="info" lowContrast hideCloseButton title={t('admin.programs.guidance.editor.title', "What you're setting up")}
+        subtitle="A Program is an initiative orders are filed under. 1) name it, 2) pick its Domain (controls where reception sees it), 3) assign the Lab unit(s) that run its work, 4) optionally build the order-entry questionnaire reception fills in for this program." />
+
+      {/* Basic Info — no Code/UUID */}
+      <Tile>
+        <Grid>
+          <Column lg={8}>
+            <TextInput id={`pname-${row ? row.id : 'new'}`} labelText={t('admin.programs.basicInfo.programName.label', 'Program Name')}
+              defaultValue={row ? row.name : ''} placeholder={isNew ? 'e.g. HBV Antenatal Screening' : undefined}
+              helperText={t('admin.programs.basicInfo.programName.helper', 'The name reception staff see when picking a program at order entry.')} />
+          </Column>
+          <Column lg={8}>
+            {/* Lab unit(s): multi-select with Select-all (FR: a program may serve several units) */}
+            <FilterableMultiSelect id={`units-${row ? row.id : 'new'}`} titleText={t('admin.programs.basicInfo.labUnits.label', 'Lab unit(s)')}
+              helperText={t('admin.programs.basicInfo.labUnits.helper', 'One or more lab sections that run this program — pick all that apply, or Select all.')}
+              items={LAB_UNITS} initialSelectedItems={units} selectionFeedback="top-after-reopen"
+              onChange={({ selectedItems }) => setUnits(selectedItems)} />
+            {/* Select-all affordance provided by the "Select all" item convention in the app build. */}
+          </Column>
+        </Grid>
+
+        <div style={{ marginTop: '1rem' }}>
+          <RadioButtonGroup legendText={t('admin.programs.basicInfo.domain.label', 'Domain')} name={`domain-${row ? row.id : 'new'}`} valueSelected={domain} onChange={setDomain} orientation="vertical">
+            <RadioButton labelText="Clinical" value="CLINICAL" id={`dc-${row ? row.id : 'new'}`} />
+            <RadioButton labelText="Environmental" value="ENVIRONMENTAL" id={`de-${row ? row.id : 'new'}`} />
+            <RadioButton labelText="Vector" value="VECTOR" id={`dv-${row ? row.id : 'new'}`} />
+          </RadioButtonGroup>
+          <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)' }}>Controls where this program appears — reception only sees programs matching the order's domain.</p>
+          {!domain && <p style={{ color: 'var(--cds-text-error)', fontSize: 12 }}>{t('admin.programs.basicInfo.domain.required', 'Domain is required')}</p>}
+          <Button kind="ghost" size="sm" onClick={() => setShowDomainHelp((v) => !v)}>{showDomainHelp ? t('admin.programs.guidance.domain.toggle.hide', 'Hide') : t('admin.programs.guidance.domain.toggle.show', 'What does each Domain mean?')}</Button>
+          {showDomainHelp && (
+            <Tile style={{ background: 'var(--cds-layer-02)', marginTop: 6 }}>
+              <p><Tag type="blue">Clinical</Tag> Patient testing — form captures patient identifiers, provider, prior history.</p>
+              <p><Tag type="green">Environmental</Tag> Compliance/surveillance sampling (water, food, air) — sampling site, standard, hold-time. No patient fields.</p>
+              <p><Tag type="purple">Vector</Tag> Specimen surveillance (mosquito, tick) — collection lot, species/taxonomy, pool manifest.</p>
+            </Tile>
+          )}
+        </div>
+
+        {!isNew && (
+          <Stack orientation="horizontal" gap={4} style={{ marginTop: '1rem', alignItems: 'center' }}>
+            <span>Status: {active ? <Tag type="green">Active</Tag> : <Tag type="gray">Inactive</Tag>}</span>
+            {active
+              ? <Button kind="danger--tertiary" size="sm" onClick={onDeactivate}>{t('admin.programs.action.deactivate', 'Deactivate')}</Button>
+              : <Button kind="ghost" size="sm" onClick={onReactivate}>{t('admin.programs.action.reactivate', 'Reactivate')}</Button>}
+            <span style={{ fontSize: 12, color: 'var(--cds-text-secondary)' }}>No hard delete — deactivate preserves history (D-002).</span>
+          </Stack>
+        )}
+      </Tile>
+
+      {/* Questionnaire */}
+      <InlineNotification kind="info" lowContrast hideCloseButton title={t('admin.programs.guidance.questionnaire.banner.title', "How to add questions to this Program's order form")}
+        subtitle="Visual Builder — add questions one at a time. JSON — paste a complete FHIR Questionnaire. Your work round-trips through the same JSON." />
+      <ContentSwitcher selectedIndex={mode} onChange={({ index }) => setMode(index)}>
+        <Switch name="visual" text={t('admin.programs.questionnaire.mode.visualBuilder', 'Visual Builder')} />
+        <Switch name="json" text={t('admin.programs.questionnaire.mode.json', 'JSON')} />
+      </ContentSwitcher>
+
+      <Grid>
+        <Column lg={9}>
+          {mode === 0 ? (
+            <Stack gap={3}>
+              {questions.map((q) => (
+                <Tile key={q.id}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+                    <TextInput id={`qt-${q.id}`} labelText={t('admin.programs.questionnaire.question.text.label', 'Question Text')} value={q.text} onChange={(e) => setQ(q.id, { text: e.target.value })} />
+                    <OverflowMenu aria-label="Question actions"><OverflowMenuItem isDelete itemText={t('admin.programs.questionnaire.question.actions.delete', 'Delete question')} onClick={() => setQuestions((qs) => qs.filter((x) => x.id !== q.id))} /></OverflowMenu>
+                  </div>
+                  <Select id={`qty-${q.id}`} labelText={t('admin.programs.questionnaire.question.type.label', 'Question Type')} value={q.type} onChange={(e) => setQ(q.id, { type: e.target.value })}>
+                    {QUESTION_TYPES.map((ty) => <SelectItem key={ty} value={ty} text={ty[0].toUpperCase() + ty.slice(1)} />)}
+                  </Select>
+                  <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)', marginTop: 4 }}>{TYPE_EXAMPLE[q.type]}</p>
+                  {(q.type === 'choice' || q.type === 'checkbox') && (
+                    <Stack gap={2} style={{ marginTop: 8 }}>
+                      <span style={{ fontSize: 12, textTransform: 'uppercase' }}>{t('admin.programs.questionnaire.answerOptions.section.title', 'Answer options')}</span>
+                      {q.options.map((o, i) => (
+                        <div key={i} style={{ display: 'flex', gap: 8 }}>
+                          <TextInput id={`opt-${q.id}-${i}`} size="sm" labelText="" value={o} onChange={(e) => { const n = [...q.options]; n[i] = e.target.value; setQ(q.id, { options: n }); }} />
+                          <IconButton kind="ghost" size="sm" label="Delete option" onClick={() => setQ(q.id, { options: q.options.filter((_, j) => j !== i) })}><TrashCan /></IconButton>
+                        </div>
+                      ))}
+                      {q.options.length === 0 && <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)' }}>{t('admin.programs.questionnaire.answerOptions.empty', 'No options yet — add at least one so reception can pick a value.')}</p>}
+                      <Button kind="ghost" size="sm" renderIcon={Add} onClick={() => setQ(q.id, { options: [...q.options, 'New option'] })}>{t('admin.programs.questionnaire.answerOptions.addOption', '+ Add option')}</Button>
+                    </Stack>
+                  )}
+                </Tile>
+              ))}
+              {questions.length === 0 && <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)' }}>{t('admin.programs.guidance.gui.emptyState.body', 'No questions yet — add questions one at a time, or paste a Questionnaire in JSON mode.')}</p>}
+              <Button kind="ghost" renderIcon={Add} onClick={() => setQuestions((qs) => [...qs, { id: Date.now(), text: 'New Field', type: 'string', options: [] }])}>{questions.length === 0 ? t('admin.programs.guidance.gui.emptyState.action', '+ Add First Question') : t('admin.programs.questionnaire.question.addNew', 'Add New Question')}</Button>
+            </Stack>
+          ) : (
+            <Stack gap={3}>
+              <TextArea id={`json-${row ? row.id : 'new'}`} labelText={t('admin.programs.questionnaire.mode.json', 'JSON')} rows={8} defaultValue={'{ "resourceType": "Questionnaire", "item": [] }'} />
+              <Button kind="tertiary" size="sm">{t('admin.programs.questionnaire.json.validate', 'Validate JSON')}</Button>
+              <Tile><p style={{ fontSize: 12 }}>{t('admin.programs.guidance.json.referenceCard.format', 'Format: FHIR R4 Questionnaire')} — allowed item.type: {QUESTION_TYPES.join(', ')}. Advanced features (enableWhen, Quantity units via unit/unitOption, nested items) are edited here in JSON.</p></Tile>
+            </Stack>
+          )}
+        </Column>
+
+        {/* Live "Example" preview (FR-13.5) */}
+        <Column lg={7}>
+          <p style={{ fontSize: 12, textTransform: 'uppercase', color: 'var(--cds-text-secondary)' }}>{t('admin.programs.questionnaire.preview.label', 'Example')}</p>
+          <Tile>
+            {questions.length === 0 && <p style={{ color: 'var(--cds-text-secondary)' }}>{t('admin.programs.questionnaire.preview.empty', 'No questions yet — start adding questions to see the preview.')}</p>}
+            {questions.map((q) => (
+              <div key={q.id} style={{ marginBottom: 12 }}>
+                <label style={{ fontSize: 12, display: 'block', marginBottom: 4 }}>{q.text || '(untitled)'}</label>
+                {q.type === 'choice' && <Select id={`pv-${q.id}`} labelText="" disabled><SelectItem text={q.options[0] || '—'} /></Select>}
+                {q.type === 'boolean' && <span style={{ fontSize: 13 }}>◯ Yes ◯ No</span>}
+                {q.type === 'text' && <TextArea id={`pv-${q.id}`} labelText="" disabled rows={2} />}
+                {['integer','decimal','string','date','time'].includes(q.type) && <TextInput id={`pv-${q.id}`} labelText="" disabled placeholder={q.type} />}
+                {q.type === 'quantity' && <div style={{ display: 'flex', gap: 6 }}><TextInput id={`pv-${q.id}`} labelText="" disabled placeholder="number" /><Select id={`pvu-${q.id}`} labelText="" disabled><SelectItem text="unit" /></Select></div>}
+                {q.type === 'checkbox' && q.options.map((o, i) => <div key={i} style={{ fontSize: 13 }}>☐ {o}</div>)}
+              </div>
+            ))}
+          </Tile>
+        </Column>
+      </Grid>
+
+      <Stack orientation="horizontal" gap={3}>
+        <Button kind="primary" disabled={!domain}>{t('button.save', 'Save')}</Button>
+        <Button kind="secondary" onClick={onClose}>{t('button.cancel', 'Cancel')}</Button>
+      </Stack>
+    </Stack>
+  );
+}

--- a/upload/programs-management-v2-preview.html
+++ b/upload/programs-management-v2-preview.html
@@ -1,0 +1,361 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Programs Management v2 — OpenELIS Preview</title>
+  <link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+  <style>
+    body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+    .banner{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+    .wrap{max-width:1180px;margin:0 auto;padding:1rem 1.5rem 3rem;}
+    .crumbs{font-size:12px;color:#6f6f6f;margin:14px 0;} .crumbs a{color:#0f62fe;text-decoration:none;}
+    h2{margin:0 0 2px;} .sub{color:#6f6f6f;font-size:14px;margin:0 0 16px;}
+    .tag{display:inline-block;padding:1px 10px;border-radius:12px;font-size:12px;line-height:20px;white-space:nowrap;}
+    .tag-blue{background:#d0e2ff;color:#0043ce;}.tag-green{background:#a7f0ba;color:#0e6027;}.tag-purple{background:#e8daff;color:#6929c4;}
+    .tag-gray{background:#e0e0e0;color:#525252;}
+    table{width:100%;border-collapse:collapse;background:#fff;}
+    th,td{text-align:left;padding:11px 14px;border-bottom:1px solid #e0e0e0;font-size:14px;vertical-align:middle;}
+    th{background:#f4f4f4;font-weight:600;}
+    tr.deactivated td:not(.editcell){color:#8d8d8d;}
+    .toolbar{display:flex;align-items:center;gap:16px;background:#fff;padding:10px 14px;border-bottom:1px solid #e0e0e0;flex-wrap:wrap;}
+    input[type=text],select,textarea{font-size:14px;padding:8px;border:none;border-bottom:1px solid #8d8d8d;background:#f4f4f4;box-sizing:border-box;font-family:inherit;}
+    .search{flex:1;min-width:200px;background:#fff;border-bottom:1px solid #8d8d8d;}
+    .toggle{display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;user-select:none;}
+    .sw{width:36px;height:18px;border-radius:9px;background:#8d8d8d;position:relative;transition:.15s;}
+    .sw.on{background:#0f62fe;} .sw::after{content:'';position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;background:#fff;transition:.15s;}
+    .sw.on::after{left:20px;}
+    .chip{font-size:12px;border:1px solid #8d8d8d;border-radius:12px;padding:2px 10px;cursor:pointer;background:#fff;}
+    .chip.on{background:#161616;color:#fff;border-color:#161616;}
+    .kebab{background:none;border:none;cursor:pointer;font-size:18px;color:#161616;padding:2px 8px;}
+    .linkbtn{background:none;border:none;color:#0f62fe;cursor:pointer;font-size:14px;padding:0;}
+    .menu{position:absolute;right:14px;background:#fff;border:1px solid #e0e0e0;box-shadow:0 2px 6px rgba(0,0,0,.2);z-index:5;min-width:150px;}
+    .menu button{display:block;width:100%;text-align:left;padding:10px 14px;border:none;background:none;font-size:13px;cursor:pointer;}
+    .menu button:hover{background:#f4f4f4;} .menu button.danger{color:#da1e28;}
+    .btn{border:none;cursor:pointer;font-size:14px;padding:8px 15px;border-radius:0;}
+    .btn-primary{background:#0f62fe;color:#fff;}.btn-sec{background:#393939;color:#fff;}.btn-ghost{background:none;color:#0f62fe;}
+    .btn-danger{background:#da1e28;color:#fff;}.btn-dtert{background:#fff;color:#da1e28;border:1px solid #da1e28;}
+    .btn:disabled{background:#c6c6c6;color:#8d8d8d;cursor:not-allowed;}
+    .overlay{position:fixed;inset:0;background:rgba(0,0,0,.5);display:flex;align-items:center;justify-content:center;z-index:20;}
+    .modal{background:#fff;max-width:520px;width:92%;} .modal h3{margin:0;padding:20px 20px 6px;font-size:20px;} .modal p{padding:0 20px 22px;font-size:14px;line-height:1.4;}
+    .modal-actions{display:flex;} .modal-actions .btn{flex:1;padding:15px;}
+    .inline-editor{background:#f4f4f4;border-left:3px solid #0f62fe;padding:18px 20px;}
+    .panel{background:#fff;border:1px solid #e0e0e0;padding:16px;margin-bottom:14px;}
+    .grid2{display:flex;gap:24px;flex-wrap:wrap;} .col{flex:1;min-width:260px;}
+    .lbl{font-size:12px;color:#525252;margin:0 0 4px;display:block;}
+    .uplbl{font-size:12px;text-transform:uppercase;letter-spacing:.02em;color:#6f6f6f;margin:18px 0 8px;font-weight:600;}
+    .radio{display:block;margin:6px 0;font-size:14px;cursor:pointer;}
+    .switcher{display:flex;border:1px solid #8d8d8d;width:fit-content;margin-bottom:12px;}
+    .switcher button{padding:8px 20px;border:none;background:#fff;cursor:pointer;font-size:14px;}
+    .switcher button.on{background:#161616;color:#fff;}
+    .notif{padding:12px 14px;margin:0 0 14px;border-left:3px solid;font-size:13px;line-height:1.4;}
+    .notif-info{background:#edf5ff;border-color:#0043ce;}.notif-warn{background:#fff8e1;border-color:#f1c21b;}.notif-success{background:#defbe6;border-color:#24a148;}
+    .qcard{border:1px solid #e0e0e0;padding:14px;margin-bottom:10px;background:#fafafa;position:relative;}
+    .opt-row{display:flex;gap:8px;align-items:center;margin:6px 0;}
+    .preview-pane{background:#fff;border:1px solid #e0e0e0;padding:16px;min-height:180px;}
+    .mono{font-family:'IBM Plex Mono',monospace;font-size:13px;}
+    .chipset span{display:inline-block;background:#e0e0e0;border-radius:4px;padding:1px 7px;margin:2px;font-size:11px;font-family:monospace;}
+    .example{font-size:12px;color:#6f6f6f;background:#f4f4f4;padding:6px 8px;margin-top:6px;}
+    .req{color:#da1e28;}
+  </style>
+</head>
+<body class="cds--white">
+  <div class="banner">⚡ Visual Preview — Programs Management v2 (consolidated) &nbsp;|&nbsp; Route: /MasterListsPage/program &nbsp;|&nbsp; SideNav: Admin → Test Management → Programs &nbsp;|&nbsp; Not a live app</div>
+  <div class="wrap" id="root"></div>
+  <script type="text/babel">
+    const { useState } = React;
+    const Tag = ({k,children}) => <span className={'tag tag-'+k}>{children}</span>;
+    const domainTag = d => ({CLINICAL:'blue',ENVIRONMENTAL:'green',VECTOR:'purple'}[d]);
+    const domainLabel = d => ({CLINICAL:'Clinical',ENVIRONMENTAL:'Environmental',VECTOR:'Vector'}[d]);
+    const TYPES = ['boolean','choice','checkbox','integer','decimal','date','time','string','text','quantity'];
+    const EX = {boolean:'Yes/no answer. Example: "First antenatal visit?"',choice:'One option from a list. Example: "Specimen condition".',checkbox:'Multiple options. Example: "Symptoms present".',integer:'Whole numbers. Example: "Gestational age (weeks)".',decimal:'Decimals. Example: "Maternal weight (kg)".',date:'Calendar date. Example: "Date of last menstrual period".',time:'Time of day. Example: "Time of sample collection".',string:'Short text. Example: "Provider name".',text:'Long text. Example: "Clinical notes".',quantity:'A number plus a unit (e.g. "Volume collected — 5 mL"). The allowed unit(s) are set via a FHIR extension in JSON mode — the Visual Builder can\'t define units, so a GUI-only Quantity accepts any unit.'};
+
+    const SEED = [
+      { id:1, name:'HIV Treatment Cohort', code:'HIV-TX-01', domain:'CLINICAL', unit:'Serology', active:true, orders:1247 },
+      { id:2, name:'TB DOTS Surveillance', code:'TB-DOTS-02', domain:'CLINICAL', unit:'Microbiology', active:true, orders:842 },
+      { id:3, name:'Water Quality — Lake Toba', code:'ENV-WQ-11', domain:'ENVIRONMENTAL', unit:'Environmental Lab', active:true, orders:311 },
+      { id:4, name:'Dengue Sentinel — Jakarta', code:'VEC-DEN-04', domain:'VECTOR', unit:'Entomology', active:true, orders:196 },
+      { id:5, name:'HBV Antenatal Screening', code:'HBV-ANC-01', domain:'CLINICAL', unit:'Serology', active:true, orders:520 },
+      { id:6, name:'Malaria Pilot (2024) — closed', code:'VEC-MAL-99', domain:'VECTOR', unit:'Entomology', active:false, orders:74 },
+    ];
+
+    function App(){
+      const [rows,setRows] = useState(SEED);
+      const [q,setQ] = useState('');
+      const [domains,setDomains] = useState([]);
+      const [showDeact,setShowDeact] = useState(false);
+      const [menu,setMenu] = useState(null);
+      const [expandedId,setExpandedId] = useState(null);   // row being edited inline
+      const [adding,setAdding] = useState(false);           // inline "add new" editor at top
+      const [confirm,setConfirm] = useState(null);
+      const [toast,setToast] = useState(null);
+
+      const toggleDomain = d => setDomains(s => s.includes(d)? s.filter(x=>x!==d): [...s,d]);
+      const visible = rows.filter(r =>
+        (showDeact || r.active) &&
+        (domains.length===0 || domains.includes(r.domain)) &&
+        (r.name+r.code).toLowerCase().includes(q.toLowerCase()));
+
+      const doDeactivate = () => { setRows(rs=>rs.map(r=>r.id===confirm.id?{...r,active:false}:r)); setToast(`"${confirm.name}" deactivated — historical orders preserved`); setConfirm(null); };
+      const reactivate = r => { setRows(rs=>rs.map(x=>x.id===r.id?{...x,active:true}:x)); setToast(`${r.name} reactivated`); setMenu(null); };
+      const edit = r => { setAdding(false); setExpandedId(expandedId===r.id?null:r.id); setMenu(null); };
+      const addNew = () => { setExpandedId(null); setAdding(a=>!a); };
+
+      return (
+        <div>
+          <div className="crumbs"><a href="#">Home</a> / <a href="#">Admin Management</a> / <a href="#">Test Management</a> / Programs</div>
+          <h2>Programs</h2>
+          <p className="sub">The initiatives that orders are filed under — each with a domain, a lab unit, and an optional order-entry questionnaire.</p>
+
+          <div className="notif notif-info">
+            <strong>How this page works.</strong> Each row is a Program. Click <b>Edit</b> to expand and configure it right here (no separate page).
+            Use the <b>⋮</b> menu to <b>Deactivate</b> a program — it stops appearing for new orders but keeps all its history — or <b>Reactivate</b> one.
+            Deactivated programs are hidden by default; flip <b>Show deactivated</b> to see them. Narrow the list with <b>Search</b> or the <b>Domain</b> filter.
+            Click <b>Add Program</b> to create one inline at the top.
+          </div>
+
+          {toast && <div className="notif notif-success">{toast} <a href="#" style={{float:'right'}} onClick={e=>{e.preventDefault();setToast(null);}}>✕</a></div>}
+
+          <div className="toolbar">
+            <input className="search" type="text" placeholder="Search by name or code" value={q} onChange={e=>setQ(e.target.value)}/>
+            <div style={{display:'flex',gap:6,alignItems:'center'}}>
+              <span style={{fontSize:12,color:'#525252'}}>Domain:</span>
+              {['CLINICAL','ENVIRONMENTAL','VECTOR'].map(d=>
+                <button key={d} className={'chip'+(domains.includes(d)?' on':'')} onClick={()=>toggleDomain(d)}>{domainLabel(d)}</button>)}
+            </div>
+            <div className="toggle" onClick={()=>setShowDeact(v=>!v)}>
+              <span className={'sw'+(showDeact?' on':'')}></span> Show deactivated
+            </div>
+            <button className="btn btn-primary" style={{marginLeft:'auto'}} onClick={addNew}>{adding?'Close new program':'Add Program'}</button>
+          </div>
+
+          {/* Inline "Add new" editor opens at the top of the list (no page change) */}
+          {adding && (
+            <div className="inline-editor">
+              <h3 style={{marginTop:0}}>New Program</h3>
+              <EditorPanel isNew onClose={()=>setAdding(false)}/>
+            </div>
+          )}
+
+          <table>
+            <thead><tr><th>Name</th><th>Domain</th><th>Status</th><th>Lab Unit</th><th style={{width:120}}></th></tr></thead>
+            <tbody>
+              {visible.map(r=>(
+                <React.Fragment key={r.id}>
+                  <tr className={r.active?'':'deactivated'}>
+                    <td>{r.name}</td>
+                    <td><Tag k={domainTag(r.domain)}>{domainLabel(r.domain)}</Tag></td>
+                    <td>{r.active? <Tag k="green">Active</Tag> : <Tag k="gray">Inactive</Tag>}</td>
+                    <td>{r.unit}</td>
+                    <td className="editcell" style={{position:'relative',textAlign:'right'}}>
+                      <button className="linkbtn" onClick={()=>edit(r)}>{expandedId===r.id?'Close':'Edit'}</button>
+                      <button className="kebab" onClick={()=>setMenu(menu===r.id?null:r.id)}>⋮</button>
+                      {menu===r.id && (
+                        <div className="menu">
+                          <button onClick={()=>edit(r)}>Edit</button>
+                          {r.active
+                            ? <button className="danger" onClick={()=>{setConfirm(r);setMenu(null);}}>Deactivate</button>
+                            : <button onClick={()=>reactivate(r)}>Reactivate</button>}
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                  {expandedId===r.id && (
+                    <tr><td colSpan="5" style={{padding:0}}>
+                      <div className="inline-editor">
+                        <EditorPanel row={r} onClose={()=>setExpandedId(null)} onDeactivate={()=>{setConfirm(r);setExpandedId(null);}} onReactivate={()=>reactivate(r)}/>
+                      </div>
+                    </td></tr>
+                  )}
+                </React.Fragment>
+              ))}
+              {visible.length===0 && <tr><td colSpan="5" style={{color:'#6f6f6f'}}>No programs match your filters.</td></tr>}
+            </tbody>
+          </table>
+          <p className="sub" style={{marginTop:10}}>{visible.length} shown · deactivated hidden by default · inline edit (D-005) · no hard delete (D-002)</p>
+
+          {confirm && (
+            <div className="overlay" onClick={()=>setConfirm(null)}>
+              <div className="modal" onClick={e=>e.stopPropagation()}>
+                <h3>Deactivate this Program?</h3>
+                <p>"<strong>{confirm.name}</strong>" will stop appearing in the order-entry Program picker for new orders. Its <strong>{confirm.orders.toLocaleString()}</strong> historical order(s) keep their program coding and all indicator counts are preserved. You can reactivate it at any time from the Programs list.</p>
+                <div className="modal-actions">
+                  <button className="btn btn-sec" onClick={()=>setConfirm(null)}>Cancel</button>
+                  <button className="btn btn-danger" onClick={doDeactivate}>Deactivate</button>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      );
+    }
+
+    // The inline editor — same content whether adding or editing an existing row.
+    function EditorPanel({row, isNew, onClose, onDeactivate, onReactivate}){
+      const [domain,setDomain] = useState(row?row.domain:'');
+      const active = row? row.active : true;
+      const [mode,setMode] = useState('visual');
+      const [showGuide,setShowGuide] = useState(true);
+      const [showDomainHelp,setShowDomainHelp] = useState(false);
+      const ALL_UNITS = ['Serology','Microbiology','Hematology','Chemistry','Entomology','Environmental Lab'];
+      const [units,setUnits] = useState(row&&row.unit?[row.unit]:[]);
+      const toggleUnit = u => setUnits(s=> s.includes(u)? s.filter(x=>x!==u): [...s,u]);
+      const allSelected = units.length===ALL_UNITS.length;
+      const toggleAll = () => setUnits(allSelected? [] : [...ALL_UNITS]);
+      const [questions,setQuestions] = useState(isNew?[]:[
+        { id:1, text:'First antenatal visit?', type:'boolean', options:[] },
+        { id:2, text:'Specimen condition', type:'choice', options:['Acceptable','Compromised','Rejected'] },
+      ]);
+      const setQ = (id,patch)=>setQuestions(qs=>qs.map(q=>q.id===id?{...q,...patch}:q));
+
+      return (
+        <div>
+          <div className="notif notif-info" style={{marginBottom:14}}>
+            <strong>What you're setting up.</strong> A <b>Program</b> is an initiative that orders are filed under
+            (e.g. "HIV Treatment Cohort", "Water Quality — Lake Toba"). To set one up: <b>1.</b> name it,
+            <b> 2.</b> pick its <b>Domain</b> (this controls where the program shows up for reception),
+            <b> 3.</b> assign the <b>Lab unit</b> that runs its work, and <b>4.</b> optionally build the
+            <b> order-entry questionnaire</b> — extra questions reception answers when they file an order under this program.
+          </div>
+
+          <div className="panel">
+            <div className="grid2">
+              <div className="col">
+                <label className="lbl">Program Name</label>
+                <input type="text" defaultValue={row?row.name:''} placeholder={isNew?'e.g. HBV Antenatal Screening':''} style={{width:'100%'}}/>
+                <div className="example">The name reception staff see when picking a program at order entry.</div>
+              </div>
+              <div className="col">
+                <label className="lbl">Lab unit(s)</label>
+                <div style={{border:'1px solid #8d8d8d',background:'#fff',padding:'8px 10px',maxHeight:150,overflowY:'auto'}}>
+                  <label className="radio" style={{fontWeight:600,borderBottom:'1px solid #e0e0e0',paddingBottom:6,marginBottom:4}}>
+                    <input type="checkbox" checked={allSelected} ref={el=>{if(el)el.indeterminate=units.length>0&&!allSelected;}} onChange={toggleAll}/> Select all lab units
+                  </label>
+                  {ALL_UNITS.map(u=>(
+                    <label key={u} className="radio"><input type="checkbox" checked={units.includes(u)} onChange={()=>toggleUnit(u)}/> {u}</label>
+                  ))}
+                </div>
+                <div className="example">One or more sections of the lab that run this program's testing — pick all that apply, or Select all.</div>
+              </div>
+            </div>
+
+            <div className="uplbl">Domain <span className="req">*</span></div>
+            <div style={{fontSize:13,color:'#525252',marginBottom:6}}>Controls where this program appears — reception only sees programs matching the order's domain.</div>
+            {['CLINICAL','ENVIRONMENTAL','VECTOR'].map(d=>
+              <label key={d} className="radio"><input type="radio" name={'dom'+(row?row.id:'new')} checked={domain===d} onChange={()=>setDomain(d)}/> {domainLabel(d)}</label>)}
+            {!domain && <div style={{fontSize:12,color:'#da1e28',marginTop:4}}>Domain is required</div>}
+            <button className="btn btn-ghost" style={{padding:'4px 0',marginTop:4,fontSize:13}} onClick={()=>setShowDomainHelp(v=>!v)}>{showDomainHelp?'Hide':'What does each Domain mean?'}</button>
+            {showDomainHelp && (
+              <div className="panel" style={{background:'#fafafa',marginTop:6}}>
+                <div style={{fontSize:13,marginBottom:6}}><Tag k="blue">Clinical</Tag> Patient testing — the form captures patient identifiers, provider, prior history.</div>
+                <div style={{fontSize:13,marginBottom:6}}><Tag k="green">Environmental</Tag> Compliance/surveillance sampling (water, food, air) — captures sampling site, standard, hold-time. No patient fields.</div>
+                <div style={{fontSize:13}}><Tag k="purple">Vector</Tag> Specimen surveillance (mosquito, tick) — captures collection lot, species/taxonomy, pool manifest.</div>
+              </div>
+            )}
+
+            {!isNew && (
+              <>
+                <div className="uplbl">Lifecycle</div>
+                <div style={{display:'flex',alignItems:'center',gap:14}}>
+                  Status: {active? <Tag k="green">Active</Tag> : <Tag k="gray">Inactive</Tag>}
+                  {active
+                    ? <button className="btn btn-dtert" onClick={onDeactivate}>Deactivate</button>
+                    : <button className="btn btn-ghost" onClick={onReactivate}>Reactivate</button>}
+                  <span style={{fontSize:12,color:'#6f6f6f'}}>No hard delete — deactivate preserves history (D-002)</span>
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="uplbl">Questionnaire (order-entry form)</div>
+          {showGuide && (
+            <div className="notif notif-info">
+              <strong>How to add questions:</strong> use the <b>Visual Builder</b> to add questions one at a time, or switch to <b>JSON</b> to paste a complete FHIR Questionnaire. Your work round-trips through the same JSON.
+              <a href="#" style={{float:'right'}} onClick={e=>{e.preventDefault();setShowGuide(false);}}>✕</a>
+            </div>
+          )}
+          <div className="switcher">
+            <button className={mode==='visual'?'on':''} onClick={()=>setMode('visual')}>Visual Builder</button>
+            <button className={mode==='json'?'on':''} onClick={()=>setMode('json')}>JSON</button>
+          </div>
+
+          <div className="grid2">
+            <div className="col" style={{flex:1.3}}>
+              {mode==='visual' ? (
+                <div>
+                  {questions.map(qq=>(
+                    <div className="qcard" key={qq.id}>
+                      <button className="kebab" style={{position:'absolute',top:8,right:8}} onClick={()=>setQuestions(qs=>qs.filter(q=>q.id!==qq.id))} title="Delete question">⋮</button>
+                      <label className="lbl">Question Text</label>
+                      <input type="text" value={qq.text} onChange={e=>setQ(qq.id,{text:e.target.value})} style={{width:'90%'}}/>
+                      <label className="lbl" style={{marginTop:10}}>Question Type</label>
+                      <select value={qq.type} onChange={e=>setQ(qq.id,{type:e.target.value})}>
+                        {TYPES.map(t=><option key={t} value={t}>{t.charAt(0).toUpperCase()+t.slice(1)}</option>)}
+                      </select>
+                      <div className="example">{EX[qq.type]}</div>
+                      {(qq.type==='choice'||qq.type==='checkbox') && (
+                        <div style={{marginTop:10}}>
+                          <label className="lbl">Answer options</label>
+                          {qq.options.map((o,i)=>(
+                            <div className="opt-row" key={i}>
+                              <input type="text" value={o} onChange={e=>{const n=[...qq.options];n[i]=e.target.value;setQ(qq.id,{options:n});}} style={{flex:1}}/>
+                              <button className="kebab" onClick={()=>setQ(qq.id,{options:qq.options.filter((_,j)=>j!==i)})} title="Delete option">🗑</button>
+                            </div>
+                          ))}
+                          {qq.options.length===0 && <div className="example">No options yet — add at least one so reception can pick a value.</div>}
+                          <button className="btn btn-ghost" style={{padding:'4px 0',fontSize:13}} onClick={()=>setQ(qq.id,{options:[...qq.options,'New option']})}>+ Add option</button>
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                  {questions.length===0 && <div className="example" style={{marginBottom:8}}>No questions yet — add questions one at a time, or paste a Questionnaire in JSON mode.</div>}
+                  <button className="btn btn-ghost" style={{padding:'6px 0'}} onClick={()=>setQuestions(qs=>[...qs,{id:Date.now(),text:'New Field',type:'string',options:[]}])}>+ Add {questions.length===0?'First ':'New '}Question</button>
+                </div>
+              ) : (
+                <div>
+                  <textarea defaultValue={'{\n  "resourceType": "Questionnaire",\n  "item": []\n}'} style={{width:'100%',height:150,background:'#fff'}}/>
+                  <button className="btn btn-dtert" style={{marginTop:8}}>Validate JSON</button>
+                  <div className="panel" style={{marginTop:10,background:'#fafafa'}}>
+                    <div style={{fontSize:12,color:'#525252'}}>Format: FHIR R4 Questionnaire · allowed item.type:</div>
+                    <div className="chipset">{TYPES.map(t=><span key={t}>{t}</span>)}</div>
+                  </div>
+                </div>
+              )}
+            </div>
+            <div className="col">
+              <label className="lbl">Example (live preview — what reception sees)</label>
+              <div className="preview-pane">
+                {questions.length===0 && <div style={{color:'#6f6f6f'}}>No questions yet — start adding questions to see the preview.</div>}
+                {questions.map(qq=>(
+                  <div key={qq.id} style={{marginBottom:14}}>
+                    <label className="lbl" style={{color:'#161616'}}>{qq.text||'(untitled)'}</label>
+                    {qq.type==='boolean' && <div><label className="radio" style={{display:'inline',marginRight:12}}><input type="radio" disabled/> Yes</label><label className="radio" style={{display:'inline'}}><input type="radio" disabled/> No</label></div>}
+                    {qq.type==='choice' && <select disabled style={{width:'100%'}}><option>{qq.options[0]||'—'}</option></select>}
+                    {qq.type==='checkbox' && qq.options.map((o,i)=><label key={i} className="radio"><input type="checkbox" disabled/> {o}</label>)}
+                    {(qq.type==='integer'||qq.type==='decimal'||qq.type==='string') && <input type="text" disabled style={{width:'100%'}} placeholder={qq.type}/>}
+                    {qq.type==='quantity' && <div style={{display:'flex',gap:6}}><input type="text" disabled style={{flex:1}} placeholder="number"/><select disabled style={{width:90}}><option>unit</option></select></div>}
+                    {qq.type==='text' && <textarea disabled style={{width:'100%',height:50}}/>}
+                    {qq.type==='date' && <input type="text" disabled style={{width:'100%'}} placeholder="mm/dd/yyyy"/>}
+                    {qq.type==='time' && <input type="text" disabled style={{width:'100%'}} placeholder="hh:mm"/>}
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div style={{marginTop:16,display:'flex',gap:10}}>
+            <button className="btn btn-primary" disabled={!domain} title={!domain?'Select a Domain first':''}>Save</button>
+            <button className="btn btn-sec" onClick={onClose}>Cancel</button>
+            {!domain && <span style={{fontSize:12,color:'#6f6f6f',alignSelf:'center'}}>Save is disabled until a Domain is selected.</span>}
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App/>);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
Consolidated de-sliced FRS + inline-editor mockup + interactive preview (supersedes the base programs-management.* in the gallery). Epic: OGC-781.

## What changed

<!-- 1-2 lines describing this change -->

## Checklist

- [ ] `npm test` passes
- [ ] New JSX mockup registered in `mockup-viewer/src/App.jsx` MOCKUP_REGISTRY (if applicable)
- [ ] `MANIFEST.yaml` and `INDEX.md` updated (if applicable)

## Links

<!-- Jira: OGC-NNN -->
<!-- GitHub Issue: #NNN -->
