### PR TITLE
Wire shared HTML preview to Test Catalog Completion v2

### DIFF
--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -2139,6 +2139,7 @@
   type: jsx
   path: designs/admin-config/test-catalog-completion-v2.jsx
   spec: designs/admin-config/test-catalog-completion-v2.md
+  preview: designs/admin-config/test-catalog-panels-sampletypes.html
   category: admin-config
   description: >
     Consolidated Test Catalog FRS v2 (FR-46–86) — the single implementing-agent

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -101,6 +101,7 @@ export const MOCKUP_REGISTRY = [
     component: React.lazy(() => import('@designs/admin-config/test-catalog-completion-v2.jsx')),
     description: 'Consolidated Test Catalog FRS (v2) — the single implementing-agent handoff. Part A corrects delivered gaps in the shipped unified editor (custom label presets filtered out of the picker, terminology mappings missing display names, LOINC integrity warnings siloed in one section, half the combined shared-settings editor shipped, activation allowed on tests that cannot capture a result). Part B adds Manageability: grouped catalog view treating specimen variants of an assay as one family (link/unlink, issues toggle), create-in-place, add-specimen-variant with completeness rail + activation gate. FR-46–86. Supersedes the test-catalog-editor-completion and test-catalog-manageability work lists.',
     specPath: 'designs/admin-config/test-catalog-completion-v2.md',
+    htmlUrl: 'designs/admin-config/test-catalog-panels-sampletypes.html',
     added: '2026-07-15',
     updated: '2026-07-15',
     status: 'draft',


### PR DESCRIPTION
Registers the Tests·Panels·Sample Types interactive walkthrough (test-catalog-panels-sampletypes.html) as the htmlUrl/preview for the Test Catalog Completion v2 entry. It already backs the panel and sample-type entries, so all four Test Catalog shell surfaces now share one live preview. App.jsx + MANIFEST.yaml only; 256 tests pass.