### PR TITLE
Add Additional Information Builder (contexts) to gallery (OGC-781)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -14,6 +14,7 @@ Master index of all designs. Each feature has a co-located `.jsx` mockup and `.m
 | Lab Units Management | [lab-units.jsx](designs/admin-config/lab-units.jsx) | [lab-units.md](designs/admin-config/lab-units.md) |
 | Methods | [methods.jsx](designs/admin-config/methods.jsx) | [methods.md](designs/admin-config/methods.md) |
 | Organizations Management | [organizations-management.jsx](designs/admin-config/organizations-management.jsx) | [organizations-management.md](designs/admin-config/organizations-management.md) |
+| Additional Information Builder (contexts) | [additional-info-builder.jsx](designs/admin-config/additional-info-builder.jsx) · [preview](designs/admin-config/additional-info-builder.html) | [programs-management.md](designs/admin-config/programs-management.md) |
 | Require Requesting Provider (Order Entry) | [order-entry-require-provider.jsx](designs/admin-config/order-entry-require-provider.jsx) · [preview](designs/admin-config/order-entry-require-provider.html) | [order-entry-require-provider.md](designs/admin-config/order-entry-require-provider.md) |
 | Panel Management | [panel.jsx](designs/admin-config/panel.jsx) | [panel.md](designs/admin-config/panel.md) |
 | Range Editor | [range-editor.jsx](designs/admin-config/range-editor.jsx) | [range-editor.md](designs/admin-config/range-editor.md) |

--- a/MANIFEST.yaml
+++ b/MANIFEST.yaml
@@ -3775,3 +3775,18 @@
     gallery: https://digi-uw.github.io/openelis-work/#/admin-config/require-requesting-provider-order-entry
     preview: https://digi-uw.github.io/openelis-work/designs/admin-config/order-entry-require-provider.html
   added: "2026-07-17"
+
+- id: additional-info-builder
+  type: jsx
+  path: designs/admin-config/additional-info-builder.jsx
+  spec: designs/admin-config/programs-management.md
+  preview: designs/admin-config/additional-info-builder.html
+  category: admin-config
+  description: >
+    Additional Information questionnaire builder — one builder, per-context via a SideNav
+    submenu (Programs / per-domain Order form fields / Patient form fields). Shipped fields
+    hide-not-delete + collapse + JSON-exclusion. Part of OGC-781 (baked-in Additional Info).
+  links:
+    jira: ["OGC-781"]
+    preview: https://digi-uw.github.io/openelis-work/designs/admin-config/additional-info-builder.html
+  added: "2026-07-17"

--- a/designs/admin-config/additional-info-builder.html
+++ b/designs/admin-config/additional-info-builder.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Additional Information Builder — Contexts — OpenELIS Preview</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+<style>
+  body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+  .banner{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+  .crumbs{font-size:12px;color:#525252;padding:10px 1.5rem 0;}
+  .crumbs a{color:#0f62fe;text-decoration:none;}
+  .shell{display:grid;grid-template-columns:250px 1fr;min-height:660px;}
+  .side{background:#fff;border-right:1px solid #e0e0e0;padding:10px 0;}
+  .side .grp{font-size:11px;text-transform:uppercase;letter-spacing:.03em;color:#6f6f6f;padding:12px 16px 4px;}
+  .side a{display:block;padding:8px 16px 8px 24px;font-size:13px;color:#393939;text-decoration:none;cursor:pointer;border-left:3px solid transparent;}
+  .side a:hover{background:#f4f4f4;}
+  .side a.on{background:#e8f0fe;border-left-color:#0f62fe;color:#0f62fe;font-weight:600;}
+  .side a.sub{padding-left:38px;font-size:12px;}
+  .side a.sub2{padding-left:52px;font-size:12px;}
+  .main{padding:18px 26px 60px;max-width:1160px;}
+  h1{font-weight:400;font-size:24px;margin:2px 0 2px;}
+  .ctxbar{display:flex;align-items:center;gap:10px;background:#edf5ff;border:1px solid #d0e2ff;border-radius:3px;padding:10px 14px;margin:10px 0 14px;font-size:13px;}
+  .ctxbar .pill{font-size:11px;font-weight:600;padding:2px 8px;border-radius:10px;background:#0f62fe;color:#fff;white-space:nowrap;}
+  .tile{background:#fff;border:1px solid #e0e0e0;padding:16px;margin-bottom:16px;}
+  .tile h3{margin:0 0 12px;font-size:15px;}
+  .lbl{display:block;font-size:12px;color:#525252;margin:0 0 4px;}
+  .in{width:100%;height:34px;border:none;border-bottom:1px solid #8d8d8d;background:#f4f4f4;padding:0 10px;font-size:14px;box-sizing:border-box;}
+  textarea.in{height:auto;padding:8px 10px;font-family:monospace;font-size:12px;}
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+  .radiog{display:flex;gap:16px;font-size:13px;margin-top:4px;}
+  .radiog label{display:flex;gap:5px;align-items:center;cursor:pointer;}
+  .switcher{display:inline-flex;border:1px solid #0f62fe;border-radius:2px;overflow:hidden;margin-bottom:14px;}
+  .switcher button{border:none;background:#fff;color:#0f62fe;padding:6px 16px;font-size:13px;cursor:pointer;}
+  .switcher button.on{background:#0f62fe;color:#fff;}
+  .build{display:grid;grid-template-columns:1fr 320px;gap:18px;}
+  .qcard{border:1px solid #e0e0e0;padding:10px 12px;margin-bottom:9px;background:#fff;}
+  .qcard.shipped{background:#f7f8fa;}
+  .qcard.hidden{opacity:.5;}
+  .qtop{display:flex;gap:8px;align-items:center;}
+  .qtop .in{flex:1;background:#fff;height:32px;}
+  .sel{height:32px;border:1px solid #c6c6c6;border-radius:2px;background:#fff;font-size:12px;padding:0 6px;}
+  .sw{width:30px;height:16px;border-radius:9px;position:relative;cursor:pointer;flex:0 0 auto;}
+  .sw .k{position:absolute;top:2px;width:12px;height:12px;border-radius:50%;background:#fff;}
+  .sw.on{background:#0f62fe;}.sw.on .k{left:16px;}.sw.off{background:#8d8d8d;}.sw.off .k{left:2px;}
+  .badge{font-size:9px;padding:1px 6px;border-radius:8px;white-space:nowrap;}
+  .badge.ship{background:#dde1e6;color:#4d5358;}
+  .badge.lock{background:#e0e0ff;color:#0043ce;}
+  .badge.new{background:#d0e2ff;color:#0043ce;}
+  .kebab{border:none;background:none;cursor:pointer;font-size:15px;color:#525252;padding:0 4px;}
+  .kebab.del{color:#da1e28;}
+  .kebab.dis{color:#c6c6c6;cursor:not-allowed;}
+  .opts{margin:8px 0 0 4px;}
+  .optrow{display:flex;gap:6px;align-items:center;margin-bottom:5px;}
+  .optrow .in{height:28px;background:#fff;max-width:230px;}
+  .ghost{border:none;background:none;color:#0f62fe;font-size:12px;cursor:pointer;padding:2px 4px;}
+  .del{color:#da1e28;}
+  .addq{border:1px dashed #8d8d8d;background:#fff;color:#0f62fe;width:100%;padding:8px;font-size:13px;cursor:pointer;border-radius:2px;}
+  .pane{border:1px solid #e0e0e0;background:#fff;padding:14px;}
+  .pane .h{font-size:12px;text-transform:uppercase;letter-spacing:.02em;color:#6f6f6f;margin-bottom:10px;}
+  .pv label{display:block;font-size:12px;color:#161616;margin:0 0 3px;}
+  .pv .c{width:100%;height:30px;border:1px solid #c6c6c6;background:#fff;margin-bottom:11px;}
+  .note{font-size:12px;color:#6f6f6f;line-height:1.5;margin-top:6px;}
+  .btnrow{margin-top:12px;display:flex;gap:10px;}
+  .btn{border:none;padding:8px 16px;font-size:13px;cursor:pointer;}
+  .btn.p{background:#0f62fe;color:#fff;} .btn.s{background:#fff;border:1px solid #0f62fe;color:#0f62fe;}
+  .info{background:#edf5ff;border-left:3px solid #0f62fe;padding:8px 12px;font-size:12px;margin-bottom:12px;line-height:1.5;}
+</style>
+</head>
+<body class="cds--white">
+<div class="banner">⚡ Preview — Additional Information Builder · one builder, per-context (submenu) | shipped fields hide-not-delete | Admin reference | Not a live app</div>
+<div class="crumbs" id="crumb"></div>
+<div id="root"></div>
+<script type="text/babel">
+const {useState}=React;
+const TYPES=["Boolean","Choice","Checkbox","Integer","Decimal","Date","Time","String","Text","Quantity"];
+let UID=1000;
+
+// q: {id,text,type,options,shipped,locked,vis}
+const mk=(text,type,opts,f)=>({id:++UID,text,type,options:opts||[],shipped:!!(f&&f.shipped),locked:!!(f&&f.locked),vis:f&&f.vis===false?false:true});
+
+const CONTEXTS={
+  program:{label:"Program (selected per order)",attach:"Attaches to an order when a user picks this Program at order entry.",basicInfo:true,
+    seed:()=>[ mk("ARV during pregnancy?","Boolean"), mk("Recent maternal viral load (copies/ml)","Decimal"),
+      mk("Reason for request","Choice",["1st PCR (6 wk)","2nd PCR (9 mo)","Confirmatory"]), mk("Breastfeeding?","Boolean") ]},
+  order_clinical:{label:"Clinical order — every clinical order",attach:"Always on every CLINICAL order (Step-1 “Clinical Information” section).",domainNote:"Clinical",
+    seed:()=>[ mk("Provisional Diagnosis","String",[],{shipped:true}), mk("Payment Status","Choice",["Cash","Insurance","Waived"],{shipped:true}) ]},
+  order_environmental:{label:"Environmental order — every env order",attach:"Always on every ENVIRONMENTAL order (Step-1 env details).",domainNote:"Environmental",
+    seed:()=>[ mk("Collection Method","Choice",["Grab","Composite"],{shipped:true}), mk("Water Temp (°C)","Decimal",[],{shipped:true}),
+      mk("Ambient Temp (°C)","Decimal",[],{shipped:true}), mk("Weather","String",[],{shipped:true}),
+      mk("Preservation Method","Choice",["Ice","Acid","None"],{shipped:true}), mk("Field Notes","Text",[],{shipped:true}),
+      mk("Compliance Standards","Choice",["ISO 17025","National"],{shipped:true}) ]},
+  order_vector:{label:"Vector order — every vector order",attach:"Always on every VECTOR order (Step-1 Sample section).",domainNote:"Vector",
+    seed:()=>[ mk("Lifecycle Stage","Choice",["Adult","Larva","Pupa"],{shipped:true}), mk("Trap Type","Choice",["Light","BG","Ovitrap"],{shipped:true}),
+      mk("Quantity in Pool","Integer",[],{shipped:true}), mk("Traps Deployed","Integer",[],{shipped:true}), mk("Nights Deployed","Integer",[],{shipped:true}) ]},
+  patient:{label:"Patient form — every patient",attach:"Always on the patient form (Additional Information). Cross-domain.",
+    seed:()=>[ mk("Education","Choice",["None","Primary","Secondary","Upper"],{shipped:true}),
+      mk("Marital Status","Choice",["Single","Married","Divorced","Widowed"],{shipped:true}),
+      mk("Nationality","Choice",["Malagasy","French","Other"],{shipped:true}),
+      mk("Occupation","String",[],{shipped:true}), mk("Custom Notes","Text",[],{shipped:true}),
+      mk("Health Region","String",[],{shipped:true,locked:true}), mk("Health District","String",[],{shipped:true,locked:true}) ]},
+};
+
+function PreviewCtl({q}){
+  const t=q.type;
+  if(t==="Boolean")return <div><label style={{display:"inline",marginRight:12,fontWeight:400}}><input type="radio" disabled/> Yes</label><label style={{display:"inline",fontWeight:400}}><input type="radio" disabled/> No</label></div>;
+  if(t==="Choice")return <select className="c" disabled><option>{q.options[0]||"—"}</option></select>;
+  if(t==="Checkbox")return <div>{(q.options.length?q.options:["option"]).map((o,i)=><label key={i} style={{display:"block",fontWeight:400}}><input type="checkbox" disabled/> {o}</label>)}</div>;
+  if(t==="Text")return <textarea className="c" style={{height:44}} disabled/>;
+  return <div className="c"/>;
+}
+
+function App(){
+  const [ctx,setCtx]=useState("program");
+  const [mode,setMode]=useState("visual");
+  const [store,setStore]=useState(()=>{const o={};Object.keys(CONTEXTS).forEach(k=>o[k]=CONTEXTS[k].seed());return o;});
+  const [name,setName]=useState("HIV / PMTCT–EID");
+  const [domain,setDomain]=useState("CLINICAL");
+  const C=CONTEXTS[ctx];
+  const qs=store[ctx];
+  const setQs=(fn)=>setStore(m=>({...m,[ctx]:fn(m[ctx])}));
+  const setQ=(id,patch)=>setQs(l=>l.map(q=>q.id===id?{...q,...patch}:q));
+  const addQ=()=>setQs(l=>[...l,mk("New question","String")]);
+  const delQ=(id)=>setQs(l=>l.filter(q=>q.id!==id));
+  const addOpt=(id)=>{const q=qs.find(x=>x.id===id);setQ(id,{options:[...q.options,""]});};
+  const setOpt=(id,i,v)=>{const q=qs.find(x=>x.id===id);const o=[...q.options];o[i]=v;setQ(id,{options:o});};
+  const delOpt=(id,i)=>{const q=qs.find(x=>x.id===id);setQ(id,{options:q.options.filter((_,j)=>j!==i)});};
+
+  const visQ=qs.filter(q=>q.vis);
+  const authQ=qs.filter(q=>!q.shipped&&!q.locked); // admin-authored only — shipped/perma fields excluded from JSON
+  const json=JSON.stringify({resourceType:"Questionnaire",status:"active",item:authQ.map(q=>({linkId:String(q.id),text:q.text,type:q.type.toLowerCase(),...(q.options.length?{answerOption:q.options.map(o=>({valueString:o}))}:{})}))},null,2);
+
+  const navItem=(key,txt,cls)=> <a className={(cls||"sub")+" "+(ctx===key?"on":"")} onClick={()=>{setCtx(key);setMode("visual");}}>{txt}</a>;
+
+  return (
+   <div>
+    <SetCrumb ctx={ctx}/>
+    <div className="shell">
+      <div className="side">
+        <div className="grp">Admin · Test Management</div>
+        <a>Test Catalog</a><a>Lab Units</a>
+        <div className="grp">Additional Information</div>
+        {navItem("program","Programs (per order)")}
+        <div style={{fontSize:11,color:"#6f6f6f",padding:"6px 16px 2px 24px"}}>Order form fields</div>
+        {navItem("order_clinical","Clinical","sub2")}
+        {navItem("order_environmental","Environmental","sub2")}
+        {navItem("order_vector","Vector","sub2")}
+        {navItem("patient","Patient form fields")}
+      </div>
+
+      <div className="main">
+        <h1>{ctx==="program"?"Programs":ctx==="patient"?"Patient form fields":C.domainNote+" order fields"}</h1>
+        <div className="ctxbar"><span className="pill">{C.label}</span><span>{C.attach}</span></div>
+        <div className="info"><b>One builder, per-context.</b> The submenu switches which context you author — each <b>order domain</b> has its own always-on set (so shared vs unique-per-domain is handled), plus the cross-domain <b>Patient</b> set and selectable <b>Programs</b>. New fields you add export as a FHIR <b>QuestionnaireResponse</b>.</div>
+
+        {C.basicInfo && (
+          <div className="tile"><h3>Basic Info</h3>
+            <div className="row">
+              <div><span className="lbl">Program Name</span><input className="in" value={name} onChange={e=>setName(e.target.value)}/></div>
+              <div><span className="lbl">Lab unit(s)</span><input className="in" defaultValue="Serology" readOnly/></div>
+            </div>
+            <div style={{marginTop:12}}><span className="lbl">Domain</span>
+              <div className="radiog">{["CLINICAL","ENVIRONMENTAL","VECTOR"].map(d=><label key={d}><input type="radio" checked={domain===d} onChange={()=>setDomain(d)}/> {d[0]+d.slice(1).toLowerCase()}</label>)}</div>
+            </div>
+          </div>
+        )}
+
+        <div className="tile">
+          <h3>Fields</h3>
+          <div className="info" style={{background:"#f7f8fa",borderLeftColor:"#8d8d8d"}}><span className="badge ship">shipped</span> fields come with OpenELIS — toggle <b>Visible</b> off to hide them, but they’re <b>kept, not deleted</b> (future use). <span className="badge lock">Site Information</span> fields (Region/District) are managed there — configure, don’t re-author. Only <span className="badge new">new</span> admin-added fields can be deleted.</div>
+          <div className="switcher">
+            <button className={mode==="visual"?"on":""} onClick={()=>setMode("visual")}>Visual Builder</button>
+            <button className={mode==="json"?"on":""} onClick={()=>setMode("json")}>JSON</button>
+          </div>
+
+          {mode==="visual" ? (
+            <div className="build">
+              <div>
+                {qs.map(q=> q.vis ? (
+                  <div className={"qcard"+(q.shipped?" shipped":"")} key={q.id}>
+                    <div className="qtop">
+                      <div className="sw on" title="Visible — hide" onClick={()=>setQ(q.id,{vis:false})}><div className="k"/></div>
+                      <input className="in" value={q.text} readOnly={q.locked} onChange={e=>setQ(q.id,{text:e.target.value})}/>
+                      <select className="sel" value={q.type} disabled={q.locked} onChange={e=>setQ(q.id,{type:e.target.value})}>{TYPES.map(t=><option key={t}>{t}</option>)}</select>
+                      {q.locked?<span className="badge lock">Site Information</span>:q.shipped?<span className="badge ship">shipped</span>:<span className="badge new">new</span>}
+                      {q.shipped||q.locked
+                        ? <span className="kebab dis" title="Shipped/managed — hide instead of delete">🔒</span>
+                        : <button className="kebab del" title="Delete" onClick={()=>delQ(q.id)}>🗑</button>}
+                    </div>
+                    {(q.type==="Choice"||q.type==="Checkbox")&&!q.locked && (
+                      <div className="opts">
+                        {q.options.map((o,i)=><div className="optrow" key={i}><input className="in" value={o} placeholder="Answer option" onChange={e=>setOpt(q.id,i,e.target.value)}/><button className="ghost del" onClick={()=>delOpt(q.id,i)}>Remove</button></div>)}
+                        <button className="ghost" onClick={()=>addOpt(q.id)}>+ Add option</button>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="qcard hidden" key={q.id} style={{padding:"5px 12px",background:"#f4f4f4"}}>
+                    <div className="qtop">
+                      <div className="sw off" title="Hidden — show" onClick={()=>setQ(q.id,{vis:true})}><div className="k"/></div>
+                      <span style={{flex:1,fontSize:12,color:"#8d8d8d"}}>{q.text}</span>
+                      <span className="badge ship">hidden</span>
+                      {q.locked?<span className="badge lock">Site Information</span>:q.shipped?<span className="badge ship">shipped</span>:<span className="badge new">new</span>}
+                    </div>
+                  </div>
+                ))}
+                <button className="addq" onClick={addQ}>+ Add question</button>
+              </div>
+              <div className="pane">
+                <div className="h">Example — what staff sees ({visQ.length} visible)</div>
+                <div className="pv">
+                  {visQ.length===0&&<div className="note">All fields hidden.</div>}
+                  {visQ.map(q=><div key={q.id}><label>{q.text}</label><PreviewCtl q={q}/></div>)}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="build">
+              <div>
+                <span className="lbl">FHIR Questionnaire — admin-authored questions only</span>
+                <textarea className="in" style={{minHeight:280}} value={json} readOnly/>
+                <div className="btnrow"><button className="btn s">Validate</button></div>
+                <div className="note">Only the questions you can add/remove are shown here. <b>Shipped / permanent</b> fields aren’t editable and aren’t included in the JSON — manage them with the Visible toggle in the Visual Builder. Paste an LLM-authored or hand-written Questionnaire (no upload needed); round-trips to the Visual Builder for the supported subset.</div>
+              </div>
+              <div className="pane"><div className="h">Example</div><div className="pv">{visQ.map(q=><div key={q.id}><label>{q.text}</label><PreviewCtl q={q}/></div>)}</div></div>
+            </div>
+          )}
+          <div className="btnrow"><button className="btn p">Save</button><button className="btn s">Cancel</button></div>
+        </div>
+
+        <div className="note">Where these questions render on the order/patient forms already exists — not designed here. This screen is only the authoring/config UI.</div>
+      </div>
+    </div>
+   </div>
+  );
+}
+function SetCrumb({ctx}){
+  const leaf=ctx==="program"?"Programs":ctx==="patient"?"Patient form fields":CONTEXTS[ctx].domainNote+" order fields";
+  document.getElementById("crumb").innerHTML='<a>Home</a> / <a>Admin Management</a> / <a>Test Management</a> / '+leaf;
+  return null;
+}
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>

--- a/designs/admin-config/additional-info-builder.jsx
+++ b/designs/admin-config/additional-info-builder.jsx
@@ -1,0 +1,191 @@
+// Additional Information Builder — one builder, per-context (submenu switch)  [OGC-781 baked-in FR-28/FR-29]
+// SideNav: Admin → Test Management → Additional Information → { Programs | Order form fields (Clinical/
+//   Environmental/Vector) | Patient form fields }.  Breadcrumb: Home / Admin Management / Test Management / <leaf>.
+//
+// ONE questionnaire builder, reused across contexts (the submenu is the context switch):
+//   • Programs — selectable per-order form (Basic Info: Name + Domain + Lab unit).
+//   • Order form fields — ONE always-attached set PER order domain (Clinical/Env/Vector) — not a single
+//     "every order" bucket, so shared-vs-unique-per-domain is expressible.
+//   • Patient form fields — one cross-domain always-attached set.
+// Shipped fields (seeded per context) are hide-not-delete (Visible toggle; retained — D-002); only
+//   admin-added fields are deletable. Site-Information-managed fields (Region/District) are locked
+//   (configure, not re-authored). Authored fields export as FHIR QuestionnaireResponse. JSON = paste/edit.
+// This is the AUTHORING/config UI only — where the questions render on the order/patient forms already exists.
+
+import React, { useState } from 'react';
+import {
+  SideNav, SideNavItems, SideNavLink, Grid, Column, Tile, TextInput, TextArea,
+  Select, SelectItem, RadioButtonGroup, RadioButton, ContentSwitcher, Switch,
+  Toggle, Tag, Button, InlineNotification, Checkbox,
+} from '@carbon/react';
+import { Add, TrashCan, Locked } from '@carbon/icons-react';
+
+const TYPES = ['Boolean','Choice','Checkbox','Integer','Decimal','Date','Time','String','Text','Quantity'];
+let UID = 1000;
+const mk = (text, type, options = [], f = {}) => ({ id: ++UID, text, type, options, shipped: !!f.shipped, locked: !!f.locked, vis: f.vis !== false });
+
+const CONTEXTS = {
+  program: { label: 'Program (selected per order)', attach: 'Attaches to an order when a user picks this Program at order entry.', basicInfo: true,
+    seed: () => [ mk('ARV during pregnancy?','Boolean'), mk('Recent maternal viral load (copies/ml)','Decimal'),
+      mk('Reason for request','Choice',['1st PCR (6 wk)','2nd PCR (9 mo)','Confirmatory']), mk('Breastfeeding?','Boolean') ] },
+  order_clinical: { label: 'Clinical order — every clinical order', attach: 'Always on every CLINICAL order (Step-1 “Clinical Information”).', leaf: 'Clinical order fields',
+    seed: () => [ mk('Provisional Diagnosis','String',[],{shipped:true}), mk('Payment Status','Choice',['Cash','Insurance','Waived'],{shipped:true}) ] },
+  order_environmental: { label: 'Environmental order — every env order', attach: 'Always on every ENVIRONMENTAL order (Step-1 env details).', leaf: 'Environmental order fields',
+    seed: () => [ mk('Collection Method','Choice',['Grab','Composite'],{shipped:true}), mk('Water Temp (°C)','Decimal',[],{shipped:true}),
+      mk('Ambient Temp (°C)','Decimal',[],{shipped:true}), mk('Weather','String',[],{shipped:true}),
+      mk('Preservation Method','Choice',['Ice','Acid','None'],{shipped:true}), mk('Field Notes','Text',[],{shipped:true}),
+      mk('Compliance Standards','Choice',['ISO 17025','National'],{shipped:true}) ] },
+  order_vector: { label: 'Vector order — every vector order', attach: 'Always on every VECTOR order (Step-1 Sample section).', leaf: 'Vector order fields',
+    seed: () => [ mk('Lifecycle Stage','Choice',['Adult','Larva','Pupa'],{shipped:true}), mk('Trap Type','Choice',['Light','BG','Ovitrap'],{shipped:true}),
+      mk('Quantity in Pool','Integer',[],{shipped:true}), mk('Traps Deployed','Integer',[],{shipped:true}), mk('Nights Deployed','Integer',[],{shipped:true}) ] },
+  patient: { label: 'Patient form — every patient', attach: 'Always on the patient form (Additional Information). Cross-domain.', leaf: 'Patient form fields',
+    seed: () => [ mk('Education','Choice',['None','Primary','Secondary','Upper'],{shipped:true}),
+      mk('Marital Status','Choice',['Single','Married','Divorced','Widowed'],{shipped:true}),
+      mk('Nationality','Choice',['Malagasy','French','Other'],{shipped:true}),
+      mk('Occupation','String',[],{shipped:true}), mk('Custom Notes','Text',[],{shipped:true}),
+      mk('Health Region','String',[],{shipped:true,locked:true}), mk('Health District','String',[],{shipped:true,locked:true}) ] },
+};
+
+function PreviewCtl({ q }) {
+  if (q.type === 'Boolean') return <RadioButtonGroup name={`pv-${q.id}`}><RadioButton labelText="Yes" value="y" id={`y${q.id}`} /><RadioButton labelText="No" value="n" id={`n${q.id}`} /></RadioButtonGroup>;
+  if (q.type === 'Choice') return <Select id={`pv-${q.id}`} labelText="" size="sm"><SelectItem value="" text={q.options[0] || '—'} /></Select>;
+  if (q.type === 'Checkbox') return <>{(q.options.length ? q.options : ['option']).map((o,i) => <Checkbox key={i} id={`c${q.id}-${i}`} labelText={o} />)}</>;
+  if (q.type === 'Text') return <TextArea labelText="" rows={2} id={`pv-${q.id}`} />;
+  return <TextInput labelText="" id={`pv-${q.id}`} size="sm" />;
+}
+
+function QuestionCard({ q, onChange, onDelete }) {
+  const coded = q.type === 'Choice' || q.type === 'Checkbox';
+  // Hidden fields COLLAPSE to a compact row (toggle + label + badges) — not a greyed full card.
+  if (!q.vis) {
+    return (
+      <Tile style={{ marginBottom: 6, padding: '4px 12px', background: 'var(--cds-layer-accent)' }}>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <Toggle id={`vis-${q.id}`} size="sm" hideLabel labelText="Show" toggled={false} onToggle={() => onChange({ vis: true })} />
+          <span style={{ flex: 1, fontSize: 12, color: 'var(--cds-text-secondary)' }}>{q.text}</span>
+          <Tag type="cool-gray" size="sm">hidden</Tag>
+          {q.locked ? <Tag type="blue" size="sm">Site Information</Tag> : q.shipped ? <Tag type="cool-gray" size="sm">shipped</Tag> : <Tag type="blue" size="sm">new</Tag>}
+        </div>
+      </Tile>
+    );
+  }
+  return (
+    <Tile style={{ marginBottom: 8, background: q.shipped ? 'var(--cds-layer-accent)' : undefined }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <Toggle id={`vis-${q.id}`} size="sm" hideLabel labelText="Visible" toggled={q.vis} onToggle={(v) => onChange({ vis: v })} />
+        <TextInput id={`t-${q.id}`} labelText="" hideLabel value={q.text} readOnly={q.locked} onChange={(e) => onChange({ text: e.target.value })} style={{ flex: 1 }} />
+        <Select id={`ty-${q.id}`} labelText="" hideLabel size="sm" value={q.type} disabled={q.locked} onChange={(e) => onChange({ type: e.target.value })} style={{ maxWidth: 120 }}>
+          {TYPES.map(t => <SelectItem key={t} value={t} text={t} />)}
+        </Select>
+        {q.locked ? <Tag type="blue" size="sm">Site Information</Tag> : q.shipped ? <Tag type="cool-gray" size="sm">shipped</Tag> : <Tag type="blue" size="sm">new</Tag>}
+        {q.shipped || q.locked
+          ? <Button hasIconOnly kind="ghost" size="sm" renderIcon={Locked} iconDescription="Shipped/managed — hide instead of delete" disabled />
+          : <Button hasIconOnly kind="danger--ghost" size="sm" renderIcon={TrashCan} iconDescription="Delete" onClick={onDelete} />}
+      </div>
+      {coded && !q.locked && (
+        <div style={{ marginTop: 8, marginLeft: 40 }}>
+          {q.options.map((o, i) => (
+            <div key={i} style={{ display: 'flex', gap: 6, alignItems: 'center', marginBottom: 4 }}>
+              <TextInput id={`o-${q.id}-${i}`} labelText="" hideLabel size="sm" value={o} placeholder="Answer option"
+                onChange={(e) => { const opts = [...q.options]; opts[i] = e.target.value; onChange({ options: opts }); }} style={{ maxWidth: 240 }} />
+              <Button kind="ghost" size="sm" onClick={() => onChange({ options: q.options.filter((_, j) => j !== i) })}>Remove</Button>
+            </div>
+          ))}
+          <Button kind="ghost" size="sm" renderIcon={Add} onClick={() => onChange({ options: [...q.options, ''] })}>Add option</Button>
+        </div>
+      )}
+    </Tile>
+  );
+}
+
+export default function AdditionalInfoBuilder() {
+  const [ctx, setCtx] = useState('program');
+  const [mode, setMode] = useState('visual');
+  const [store, setStore] = useState(() => { const o = {}; Object.keys(CONTEXTS).forEach(k => (o[k] = CONTEXTS[k].seed())); return o; });
+  const [name, setName] = useState('HIV / PMTCT–EID');
+  const [domain, setDomain] = useState('CLINICAL');
+  const C = CONTEXTS[ctx];
+  const qs = store[ctx];
+  const setQs = (fn) => setStore(m => ({ ...m, [ctx]: fn(m[ctx]) }));
+  const setQ = (id, patch) => setQs(l => l.map(q => q.id === id ? { ...q, ...patch } : q));
+  const visQ = qs.filter(q => q.vis);
+  const authQ = qs.filter(q => !q.shipped && !q.locked); // admin-authored only — shipped/perma excluded from JSON
+  const json = JSON.stringify({ resourceType: 'Questionnaire', status: 'active', item: authQ.map(q => ({ linkId: String(q.id), text: q.text, type: q.type.toLowerCase(), ...(q.options.length ? { answerOption: q.options.map(o => ({ valueString: o })) } : {}) })) }, null, 2);
+
+  const NavLink = ({ id, label }) => <SideNavLink href="#" isActive={ctx === id} onClick={(e) => { e.preventDefault(); setCtx(id); setMode('visual'); }}>{label}</SideNavLink>;
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '256px 1fr', minHeight: 640 }}>
+      <SideNav isFixedNav expanded isChildOfHeader={false} aria-label="Additional Information">
+        <SideNavItems>
+          <NavLink id="program" label="Programs (per order)" />
+          <div style={{ fontSize: 11, color: 'var(--cds-text-secondary)', padding: '8px 16px 2px' }}>Order form fields</div>
+          <NavLink id="order_clinical" label="Clinical" />
+          <NavLink id="order_environmental" label="Environmental" />
+          <NavLink id="order_vector" label="Vector" />
+          <NavLink id="patient" label="Patient form fields" />
+        </SideNavItems>
+      </SideNav>
+
+      <div style={{ padding: '18px 26px', maxWidth: 1160 }}>
+        <h3 style={{ fontWeight: 400 }}>{ctx === 'program' ? 'Programs' : C.leaf}</h3>
+        <InlineNotification kind="info" lowContrast hideCloseButton title={C.label} subtitle={C.attach} style={{ maxWidth: '100%' }} />
+        <InlineNotification kind="info" lowContrast hideCloseButton style={{ maxWidth: '100%', marginTop: 8 }}
+          title="One builder, per-context"
+          subtitle="The submenu switches context. Each order domain has its own always-on set (shared vs unique per domain is expressible); Patient is cross-domain; Programs are selectable per order. Authored fields → QuestionnaireResponse." />
+
+        {C.basicInfo && (
+          <Tile style={{ marginTop: 12 }}>
+            <h5>Basic Info</h5>
+            <Grid narrow style={{ marginTop: 8 }}>
+              <Column lg={8}><TextInput id="pname" labelText="Program Name" value={name} onChange={(e) => setName(e.target.value)} /></Column>
+              <Column lg={8}><TextInput id="unit" labelText="Lab unit(s)" defaultValue="Serology" /></Column>
+            </Grid>
+            <RadioButtonGroup legendText="Domain" name="domain" valueSelected={domain} onChange={setDomain} style={{ marginTop: 12 }}>
+              <RadioButton labelText="Clinical" value="CLINICAL" id="d1" /><RadioButton labelText="Environmental" value="ENVIRONMENTAL" id="d2" /><RadioButton labelText="Vector" value="VECTOR" id="d3" />
+            </RadioButtonGroup>
+          </Tile>
+        )}
+
+        <Tile style={{ marginTop: 12 }}>
+          <h5>Fields</h5>
+          <InlineNotification kind="info" lowContrast hideCloseButton style={{ maxWidth: '100%' }}
+            title="Shipped fields: hide, don't delete"
+            subtitle="'shipped' fields ship with OpenELIS — toggle Visible off to hide (retained, D-002 — future use), not deletable. 'Site Information' fields (Region/District) are managed there. Only 'new' admin-added fields can be deleted. The preview shows visible fields only." />
+          <ContentSwitcher selectedIndex={mode === 'visual' ? 0 : 1} onChange={({ index }) => setMode(index === 0 ? 'visual' : 'json')} style={{ maxWidth: 320, margin: '12px 0' }}>
+            <Switch name="visual" text="Visual Builder" />
+            <Switch name="json" text="JSON" />
+          </ContentSwitcher>
+
+          <Grid narrow>
+            <Column lg={10} md={5} sm={4}>
+              {mode === 'visual' ? (
+                <>
+                  {qs.map(q => <QuestionCard key={q.id} q={q} onChange={(p) => setQ(q.id, p)} onDelete={() => setQs(l => l.filter(x => x.id !== q.id))} />)}
+                  <Button kind="tertiary" size="sm" renderIcon={Add} onClick={() => setQs(l => [...l, mk('New question', 'String')])}>Add question</Button>
+                </>
+              ) : (
+                <>
+                  <TextArea labelText="FHIR Questionnaire — admin-authored questions only" rows={14} value={json} readOnly />
+                  <Button kind="secondary" size="sm" style={{ marginTop: 8 }}>Validate</Button>
+                  <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)', marginTop: 6 }}>Only add/removable questions appear here. Shipped/permanent fields are not editable and are excluded from the JSON — manage them via the Visible toggle in the Visual Builder. Paste an LLM-authored or hand-written Questionnaire (no upload); round-trips for the supported subset.</p>
+                </>
+              )}
+            </Column>
+            <Column lg={6} md={3} sm={4}>
+              <Tile>
+                <div style={{ fontSize: 12, textTransform: 'uppercase', color: 'var(--cds-text-secondary)', marginBottom: 10 }}>Example — what staff sees ({visQ.length} visible)</div>
+                {visQ.map(q => <div key={q.id} style={{ marginBottom: 12 }}><label style={{ fontSize: 12 }}>{q.text}</label><PreviewCtl q={q} /></div>)}
+                {visQ.length === 0 && <p style={{ fontSize: 12, color: 'var(--cds-text-secondary)' }}>All fields hidden.</p>}
+              </Tile>
+            </Column>
+          </Grid>
+
+          <div style={{ marginTop: 12, display: 'flex', gap: 10 }}>
+            <Button kind="primary">Save</Button><Button kind="secondary">Cancel</Button>
+          </div>
+        </Tile>
+      </div>
+    </div>
+  );
+}

--- a/mockup-viewer/public/designs/admin-config/additional-info-builder.html
+++ b/mockup-viewer/public/designs/admin-config/additional-info-builder.html
@@ -1,0 +1,247 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"><meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Additional Information Builder — Contexts — OpenELIS Preview</title>
+<link rel="stylesheet" href="https://unpkg.com/@carbon/styles@1/css/styles.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js" crossorigin></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js" crossorigin></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.23.2/babel.min.js"></script>
+<style>
+  body{background:#f4f4f4;margin:0;font-family:'IBM Plex Sans',sans-serif;color:#161616;}
+  .banner{background:#0f62fe;color:#fff;padding:6px 1rem;font-size:12px;font-family:monospace;}
+  .crumbs{font-size:12px;color:#525252;padding:10px 1.5rem 0;}
+  .crumbs a{color:#0f62fe;text-decoration:none;}
+  .shell{display:grid;grid-template-columns:250px 1fr;min-height:660px;}
+  .side{background:#fff;border-right:1px solid #e0e0e0;padding:10px 0;}
+  .side .grp{font-size:11px;text-transform:uppercase;letter-spacing:.03em;color:#6f6f6f;padding:12px 16px 4px;}
+  .side a{display:block;padding:8px 16px 8px 24px;font-size:13px;color:#393939;text-decoration:none;cursor:pointer;border-left:3px solid transparent;}
+  .side a:hover{background:#f4f4f4;}
+  .side a.on{background:#e8f0fe;border-left-color:#0f62fe;color:#0f62fe;font-weight:600;}
+  .side a.sub{padding-left:38px;font-size:12px;}
+  .side a.sub2{padding-left:52px;font-size:12px;}
+  .main{padding:18px 26px 60px;max-width:1160px;}
+  h1{font-weight:400;font-size:24px;margin:2px 0 2px;}
+  .ctxbar{display:flex;align-items:center;gap:10px;background:#edf5ff;border:1px solid #d0e2ff;border-radius:3px;padding:10px 14px;margin:10px 0 14px;font-size:13px;}
+  .ctxbar .pill{font-size:11px;font-weight:600;padding:2px 8px;border-radius:10px;background:#0f62fe;color:#fff;white-space:nowrap;}
+  .tile{background:#fff;border:1px solid #e0e0e0;padding:16px;margin-bottom:16px;}
+  .tile h3{margin:0 0 12px;font-size:15px;}
+  .lbl{display:block;font-size:12px;color:#525252;margin:0 0 4px;}
+  .in{width:100%;height:34px;border:none;border-bottom:1px solid #8d8d8d;background:#f4f4f4;padding:0 10px;font-size:14px;box-sizing:border-box;}
+  textarea.in{height:auto;padding:8px 10px;font-family:monospace;font-size:12px;}
+  .row{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+  .radiog{display:flex;gap:16px;font-size:13px;margin-top:4px;}
+  .radiog label{display:flex;gap:5px;align-items:center;cursor:pointer;}
+  .switcher{display:inline-flex;border:1px solid #0f62fe;border-radius:2px;overflow:hidden;margin-bottom:14px;}
+  .switcher button{border:none;background:#fff;color:#0f62fe;padding:6px 16px;font-size:13px;cursor:pointer;}
+  .switcher button.on{background:#0f62fe;color:#fff;}
+  .build{display:grid;grid-template-columns:1fr 320px;gap:18px;}
+  .qcard{border:1px solid #e0e0e0;padding:10px 12px;margin-bottom:9px;background:#fff;}
+  .qcard.shipped{background:#f7f8fa;}
+  .qcard.hidden{opacity:.5;}
+  .qtop{display:flex;gap:8px;align-items:center;}
+  .qtop .in{flex:1;background:#fff;height:32px;}
+  .sel{height:32px;border:1px solid #c6c6c6;border-radius:2px;background:#fff;font-size:12px;padding:0 6px;}
+  .sw{width:30px;height:16px;border-radius:9px;position:relative;cursor:pointer;flex:0 0 auto;}
+  .sw .k{position:absolute;top:2px;width:12px;height:12px;border-radius:50%;background:#fff;}
+  .sw.on{background:#0f62fe;}.sw.on .k{left:16px;}.sw.off{background:#8d8d8d;}.sw.off .k{left:2px;}
+  .badge{font-size:9px;padding:1px 6px;border-radius:8px;white-space:nowrap;}
+  .badge.ship{background:#dde1e6;color:#4d5358;}
+  .badge.lock{background:#e0e0ff;color:#0043ce;}
+  .badge.new{background:#d0e2ff;color:#0043ce;}
+  .kebab{border:none;background:none;cursor:pointer;font-size:15px;color:#525252;padding:0 4px;}
+  .kebab.del{color:#da1e28;}
+  .kebab.dis{color:#c6c6c6;cursor:not-allowed;}
+  .opts{margin:8px 0 0 4px;}
+  .optrow{display:flex;gap:6px;align-items:center;margin-bottom:5px;}
+  .optrow .in{height:28px;background:#fff;max-width:230px;}
+  .ghost{border:none;background:none;color:#0f62fe;font-size:12px;cursor:pointer;padding:2px 4px;}
+  .del{color:#da1e28;}
+  .addq{border:1px dashed #8d8d8d;background:#fff;color:#0f62fe;width:100%;padding:8px;font-size:13px;cursor:pointer;border-radius:2px;}
+  .pane{border:1px solid #e0e0e0;background:#fff;padding:14px;}
+  .pane .h{font-size:12px;text-transform:uppercase;letter-spacing:.02em;color:#6f6f6f;margin-bottom:10px;}
+  .pv label{display:block;font-size:12px;color:#161616;margin:0 0 3px;}
+  .pv .c{width:100%;height:30px;border:1px solid #c6c6c6;background:#fff;margin-bottom:11px;}
+  .note{font-size:12px;color:#6f6f6f;line-height:1.5;margin-top:6px;}
+  .btnrow{margin-top:12px;display:flex;gap:10px;}
+  .btn{border:none;padding:8px 16px;font-size:13px;cursor:pointer;}
+  .btn.p{background:#0f62fe;color:#fff;} .btn.s{background:#fff;border:1px solid #0f62fe;color:#0f62fe;}
+  .info{background:#edf5ff;border-left:3px solid #0f62fe;padding:8px 12px;font-size:12px;margin-bottom:12px;line-height:1.5;}
+</style>
+</head>
+<body class="cds--white">
+<div class="banner">⚡ Preview — Additional Information Builder · one builder, per-context (submenu) | shipped fields hide-not-delete | Admin reference | Not a live app</div>
+<div class="crumbs" id="crumb"></div>
+<div id="root"></div>
+<script type="text/babel">
+const {useState}=React;
+const TYPES=["Boolean","Choice","Checkbox","Integer","Decimal","Date","Time","String","Text","Quantity"];
+let UID=1000;
+
+// q: {id,text,type,options,shipped,locked,vis}
+const mk=(text,type,opts,f)=>({id:++UID,text,type,options:opts||[],shipped:!!(f&&f.shipped),locked:!!(f&&f.locked),vis:f&&f.vis===false?false:true});
+
+const CONTEXTS={
+  program:{label:"Program (selected per order)",attach:"Attaches to an order when a user picks this Program at order entry.",basicInfo:true,
+    seed:()=>[ mk("ARV during pregnancy?","Boolean"), mk("Recent maternal viral load (copies/ml)","Decimal"),
+      mk("Reason for request","Choice",["1st PCR (6 wk)","2nd PCR (9 mo)","Confirmatory"]), mk("Breastfeeding?","Boolean") ]},
+  order_clinical:{label:"Clinical order — every clinical order",attach:"Always on every CLINICAL order (Step-1 “Clinical Information” section).",domainNote:"Clinical",
+    seed:()=>[ mk("Provisional Diagnosis","String",[],{shipped:true}), mk("Payment Status","Choice",["Cash","Insurance","Waived"],{shipped:true}) ]},
+  order_environmental:{label:"Environmental order — every env order",attach:"Always on every ENVIRONMENTAL order (Step-1 env details).",domainNote:"Environmental",
+    seed:()=>[ mk("Collection Method","Choice",["Grab","Composite"],{shipped:true}), mk("Water Temp (°C)","Decimal",[],{shipped:true}),
+      mk("Ambient Temp (°C)","Decimal",[],{shipped:true}), mk("Weather","String",[],{shipped:true}),
+      mk("Preservation Method","Choice",["Ice","Acid","None"],{shipped:true}), mk("Field Notes","Text",[],{shipped:true}),
+      mk("Compliance Standards","Choice",["ISO 17025","National"],{shipped:true}) ]},
+  order_vector:{label:"Vector order — every vector order",attach:"Always on every VECTOR order (Step-1 Sample section).",domainNote:"Vector",
+    seed:()=>[ mk("Lifecycle Stage","Choice",["Adult","Larva","Pupa"],{shipped:true}), mk("Trap Type","Choice",["Light","BG","Ovitrap"],{shipped:true}),
+      mk("Quantity in Pool","Integer",[],{shipped:true}), mk("Traps Deployed","Integer",[],{shipped:true}), mk("Nights Deployed","Integer",[],{shipped:true}) ]},
+  patient:{label:"Patient form — every patient",attach:"Always on the patient form (Additional Information). Cross-domain.",
+    seed:()=>[ mk("Education","Choice",["None","Primary","Secondary","Upper"],{shipped:true}),
+      mk("Marital Status","Choice",["Single","Married","Divorced","Widowed"],{shipped:true}),
+      mk("Nationality","Choice",["Malagasy","French","Other"],{shipped:true}),
+      mk("Occupation","String",[],{shipped:true}), mk("Custom Notes","Text",[],{shipped:true}),
+      mk("Health Region","String",[],{shipped:true,locked:true}), mk("Health District","String",[],{shipped:true,locked:true}) ]},
+};
+
+function PreviewCtl({q}){
+  const t=q.type;
+  if(t==="Boolean")return <div><label style={{display:"inline",marginRight:12,fontWeight:400}}><input type="radio" disabled/> Yes</label><label style={{display:"inline",fontWeight:400}}><input type="radio" disabled/> No</label></div>;
+  if(t==="Choice")return <select className="c" disabled><option>{q.options[0]||"—"}</option></select>;
+  if(t==="Checkbox")return <div>{(q.options.length?q.options:["option"]).map((o,i)=><label key={i} style={{display:"block",fontWeight:400}}><input type="checkbox" disabled/> {o}</label>)}</div>;
+  if(t==="Text")return <textarea className="c" style={{height:44}} disabled/>;
+  return <div className="c"/>;
+}
+
+function App(){
+  const [ctx,setCtx]=useState("program");
+  const [mode,setMode]=useState("visual");
+  const [store,setStore]=useState(()=>{const o={};Object.keys(CONTEXTS).forEach(k=>o[k]=CONTEXTS[k].seed());return o;});
+  const [name,setName]=useState("HIV / PMTCT–EID");
+  const [domain,setDomain]=useState("CLINICAL");
+  const C=CONTEXTS[ctx];
+  const qs=store[ctx];
+  const setQs=(fn)=>setStore(m=>({...m,[ctx]:fn(m[ctx])}));
+  const setQ=(id,patch)=>setQs(l=>l.map(q=>q.id===id?{...q,...patch}:q));
+  const addQ=()=>setQs(l=>[...l,mk("New question","String")]);
+  const delQ=(id)=>setQs(l=>l.filter(q=>q.id!==id));
+  const addOpt=(id)=>{const q=qs.find(x=>x.id===id);setQ(id,{options:[...q.options,""]});};
+  const setOpt=(id,i,v)=>{const q=qs.find(x=>x.id===id);const o=[...q.options];o[i]=v;setQ(id,{options:o});};
+  const delOpt=(id,i)=>{const q=qs.find(x=>x.id===id);setQ(id,{options:q.options.filter((_,j)=>j!==i)});};
+
+  const visQ=qs.filter(q=>q.vis);
+  const authQ=qs.filter(q=>!q.shipped&&!q.locked); // admin-authored only — shipped/perma fields excluded from JSON
+  const json=JSON.stringify({resourceType:"Questionnaire",status:"active",item:authQ.map(q=>({linkId:String(q.id),text:q.text,type:q.type.toLowerCase(),...(q.options.length?{answerOption:q.options.map(o=>({valueString:o}))}:{})}))},null,2);
+
+  const navItem=(key,txt,cls)=> <a className={(cls||"sub")+" "+(ctx===key?"on":"")} onClick={()=>{setCtx(key);setMode("visual");}}>{txt}</a>;
+
+  return (
+   <div>
+    <SetCrumb ctx={ctx}/>
+    <div className="shell">
+      <div className="side">
+        <div className="grp">Admin · Test Management</div>
+        <a>Test Catalog</a><a>Lab Units</a>
+        <div className="grp">Additional Information</div>
+        {navItem("program","Programs (per order)")}
+        <div style={{fontSize:11,color:"#6f6f6f",padding:"6px 16px 2px 24px"}}>Order form fields</div>
+        {navItem("order_clinical","Clinical","sub2")}
+        {navItem("order_environmental","Environmental","sub2")}
+        {navItem("order_vector","Vector","sub2")}
+        {navItem("patient","Patient form fields")}
+      </div>
+
+      <div className="main">
+        <h1>{ctx==="program"?"Programs":ctx==="patient"?"Patient form fields":C.domainNote+" order fields"}</h1>
+        <div className="ctxbar"><span className="pill">{C.label}</span><span>{C.attach}</span></div>
+        <div className="info"><b>One builder, per-context.</b> The submenu switches which context you author — each <b>order domain</b> has its own always-on set (so shared vs unique-per-domain is handled), plus the cross-domain <b>Patient</b> set and selectable <b>Programs</b>. New fields you add export as a FHIR <b>QuestionnaireResponse</b>.</div>
+
+        {C.basicInfo && (
+          <div className="tile"><h3>Basic Info</h3>
+            <div className="row">
+              <div><span className="lbl">Program Name</span><input className="in" value={name} onChange={e=>setName(e.target.value)}/></div>
+              <div><span className="lbl">Lab unit(s)</span><input className="in" defaultValue="Serology" readOnly/></div>
+            </div>
+            <div style={{marginTop:12}}><span className="lbl">Domain</span>
+              <div className="radiog">{["CLINICAL","ENVIRONMENTAL","VECTOR"].map(d=><label key={d}><input type="radio" checked={domain===d} onChange={()=>setDomain(d)}/> {d[0]+d.slice(1).toLowerCase()}</label>)}</div>
+            </div>
+          </div>
+        )}
+
+        <div className="tile">
+          <h3>Fields</h3>
+          <div className="info" style={{background:"#f7f8fa",borderLeftColor:"#8d8d8d"}}><span className="badge ship">shipped</span> fields come with OpenELIS — toggle <b>Visible</b> off to hide them, but they’re <b>kept, not deleted</b> (future use). <span className="badge lock">Site Information</span> fields (Region/District) are managed there — configure, don’t re-author. Only <span className="badge new">new</span> admin-added fields can be deleted.</div>
+          <div className="switcher">
+            <button className={mode==="visual"?"on":""} onClick={()=>setMode("visual")}>Visual Builder</button>
+            <button className={mode==="json"?"on":""} onClick={()=>setMode("json")}>JSON</button>
+          </div>
+
+          {mode==="visual" ? (
+            <div className="build">
+              <div>
+                {qs.map(q=> q.vis ? (
+                  <div className={"qcard"+(q.shipped?" shipped":"")} key={q.id}>
+                    <div className="qtop">
+                      <div className="sw on" title="Visible — hide" onClick={()=>setQ(q.id,{vis:false})}><div className="k"/></div>
+                      <input className="in" value={q.text} readOnly={q.locked} onChange={e=>setQ(q.id,{text:e.target.value})}/>
+                      <select className="sel" value={q.type} disabled={q.locked} onChange={e=>setQ(q.id,{type:e.target.value})}>{TYPES.map(t=><option key={t}>{t}</option>)}</select>
+                      {q.locked?<span className="badge lock">Site Information</span>:q.shipped?<span className="badge ship">shipped</span>:<span className="badge new">new</span>}
+                      {q.shipped||q.locked
+                        ? <span className="kebab dis" title="Shipped/managed — hide instead of delete">🔒</span>
+                        : <button className="kebab del" title="Delete" onClick={()=>delQ(q.id)}>🗑</button>}
+                    </div>
+                    {(q.type==="Choice"||q.type==="Checkbox")&&!q.locked && (
+                      <div className="opts">
+                        {q.options.map((o,i)=><div className="optrow" key={i}><input className="in" value={o} placeholder="Answer option" onChange={e=>setOpt(q.id,i,e.target.value)}/><button className="ghost del" onClick={()=>delOpt(q.id,i)}>Remove</button></div>)}
+                        <button className="ghost" onClick={()=>addOpt(q.id)}>+ Add option</button>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="qcard hidden" key={q.id} style={{padding:"5px 12px",background:"#f4f4f4"}}>
+                    <div className="qtop">
+                      <div className="sw off" title="Hidden — show" onClick={()=>setQ(q.id,{vis:true})}><div className="k"/></div>
+                      <span style={{flex:1,fontSize:12,color:"#8d8d8d"}}>{q.text}</span>
+                      <span className="badge ship">hidden</span>
+                      {q.locked?<span className="badge lock">Site Information</span>:q.shipped?<span className="badge ship">shipped</span>:<span className="badge new">new</span>}
+                    </div>
+                  </div>
+                ))}
+                <button className="addq" onClick={addQ}>+ Add question</button>
+              </div>
+              <div className="pane">
+                <div className="h">Example — what staff sees ({visQ.length} visible)</div>
+                <div className="pv">
+                  {visQ.length===0&&<div className="note">All fields hidden.</div>}
+                  {visQ.map(q=><div key={q.id}><label>{q.text}</label><PreviewCtl q={q}/></div>)}
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="build">
+              <div>
+                <span className="lbl">FHIR Questionnaire — admin-authored questions only</span>
+                <textarea className="in" style={{minHeight:280}} value={json} readOnly/>
+                <div className="btnrow"><button className="btn s">Validate</button></div>
+                <div className="note">Only the questions you can add/remove are shown here. <b>Shipped / permanent</b> fields aren’t editable and aren’t included in the JSON — manage them with the Visible toggle in the Visual Builder. Paste an LLM-authored or hand-written Questionnaire (no upload needed); round-trips to the Visual Builder for the supported subset.</div>
+              </div>
+              <div className="pane"><div className="h">Example</div><div className="pv">{visQ.map(q=><div key={q.id}><label>{q.text}</label><PreviewCtl q={q}/></div>)}</div></div>
+            </div>
+          )}
+          <div className="btnrow"><button className="btn p">Save</button><button className="btn s">Cancel</button></div>
+        </div>
+
+        <div className="note">Where these questions render on the order/patient forms already exists — not designed here. This screen is only the authoring/config UI.</div>
+      </div>
+    </div>
+   </div>
+  );
+}
+function SetCrumb({ctx}){
+  const leaf=ctx==="program"?"Programs":ctx==="patient"?"Patient form fields":CONTEXTS[ctx].domainNote+" order fields";
+  document.getElementById("crumb").innerHTML='<a>Home</a> / <a>Admin Management</a> / <a>Test Management</a> / '+leaf;
+  return null;
+}
+ReactDOM.createRoot(document.getElementById("root")).render(<App/>);
+</script>
+</body>
+</html>

--- a/mockup-viewer/src/App.jsx
+++ b/mockup-viewer/src/App.jsx
@@ -646,6 +646,18 @@ export const MOCKUP_REGISTRY = [
     tags: ['admin', 'programs', 'test-management', 'domain', 'fhir-questionnaire', 'visual-builder', 'json', 'live-preview', 'order-entry', 'global'],
   },
   {
+    name: 'Additional Information Builder (contexts)',
+    category: 'admin-config',
+    component: React.lazy(() => import('@designs/admin-config/additional-info-builder.jsx')),
+    description: 'One questionnaire builder, per-context via a SideNav submenu (Programs / per-domain Order form fields / Patient form fields); shipped fields hide-not-delete + collapse + JSON-exclusion. Part of OGC-781 (baked-in Additional Information).',
+    specPath: 'designs/admin-config/programs-management.md',
+    htmlUrl: 'designs/admin-config/additional-info-builder.html',
+    added: '2026-07-17',
+    status: 'draft',
+    jira: ['OGC-781'],
+    tags: ['programs','additional-information','fhir-questionnaire','builder','admin','madagascar'],
+  },
+  {
     name: 'Result & Validation Configuration v4',
     project: ['png'],
     category: 'admin-config',


### PR DESCRIPTION
New gallery entry: the Additional Information questionnaire builder — one builder, per-context via a SideNav submenu (Programs / per-domain Order form fields / Patient form fields), with shipped-field hide-not-delete + collapse + JSON-exclusion. Part of OGC-781 (baked-in Additional Information, FR-21..FR-29). Spec shared with the Programs entry (programs-management.md).